### PR TITLE
Remove `removeAllListeners` call before close

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -180,7 +180,6 @@ export default class Surreal extends Emitter {
 	}
 
 	close() {
-		this.#ws.removeAllListeners();
 		this.#ws.close();
 	}
 


### PR DESCRIPTION
Event listeners — including the one handling the `close` cleanup — were being removed before the ws connection was closed.

Resolves #6 