### PR TITLE
feat: improve emitter class

### DIFF
--- a/src/classes/emitter.ts
+++ b/src/classes/emitter.ts
@@ -83,7 +83,7 @@ export default class Emitter<Events extends EventMap = EventMap> {
 	): this;
 	once(eventName: EventName, listener: Listener): this {
 		this.on(eventName, function once(...args: any[]) {
-			this.removeListener(eventName, listener);
+			this.removeListener(eventName, once);
 			listener.apply(this, args);
 		});
 		return this;

--- a/src/classes/emitter.ts
+++ b/src/classes/emitter.ts
@@ -7,16 +7,16 @@ export default interface Emitter {
 	off(eventName: EventName, listener: Listener): this;
 }
 
+export function once(emitter: Emitter, eventName: EventName): Promise<any[]> {
+	return new Promise((res) => {
+		emitter.once(eventName, (...args) => res(args));
+	});
+}
+
 export default class Emitter {
 	#events: Map<EventName, Listener[]> = new Map();
 
-	static once(emitter: Emitter, eventName: EventName): Promise<any[]> {
-		const prom = new Promise<any[]>((res) => {
-			emitter.once(eventName, (...args) => res(args));
-		});
-
-		return prom;
-	}
+	static once = once;
 
 	static {
 		this.prototype.addListener = this.prototype.on;

--- a/src/classes/emitter.ts
+++ b/src/classes/emitter.ts
@@ -10,6 +10,14 @@ export default interface Emitter {
 export default class Emitter {
 	#events: Map<EventName, Listener[]> = new Map();
 
+	static once(emitter: Emitter, eventName: EventName): Promise<any[]> {
+		const prom = new Promise<any[]>((res) => {
+			emitter.once(eventName, (...args) => res(args));
+		});
+
+		return prom;
+	}
+
 	static {
 		this.prototype.addListener = this.prototype.on;
 		this.prototype.off = this.prototype.removeListener;

--- a/src/classes/emitter.ts
+++ b/src/classes/emitter.ts
@@ -41,7 +41,7 @@ export default class Emitter<Events extends EventMap = EventMap> {
 		this.prototype.off = this.prototype.removeListener;
 	}
 
-	// @ts-ignore this is correct since we're overwriting with specific args.
+	// @ts-expect-error this is correct since we're overwriting with specific args.
 	on<T extends keyof Events>(
 		eventName: T,
 		listener: (this: this, ...args: Events[T]) => void,
@@ -56,7 +56,7 @@ export default class Emitter<Events extends EventMap = EventMap> {
 		return this;
 	}
 
-	// @ts-ignore see above.
+	// @ts-expect-error see above.
 	removeListener<T extends keyof Events>(
 		eventName: T,
 		listener: (this: this, ...args: Events[T]) => void,
@@ -76,7 +76,7 @@ export default class Emitter<Events extends EventMap = EventMap> {
 		return this;
 	}
 
-	// @ts-ignore see above.
+	// @ts-expect-error see above.
 	once<T extends keyof Events>(
 		eventName: T,
 		listener: (this: this, ...args: Events[T]) => void,

--- a/src/classes/emitter.ts
+++ b/src/classes/emitter.ts
@@ -17,10 +17,14 @@ export default interface Emitter<Events extends EventMap = EventMap> {
 	off(eventName: EventName, listener: Listener): this;
 }
 
-export function once<T extends EventMap, K extends keyof T>(
-	emitter: Emitter<T>,
+type EventsOf<T> = T extends { _emitter: Emitter<infer U> } ? U
+	: T extends Emitter<infer U> ? U
+	: never;
+
+export function once<T extends Emitter, K extends keyof EventsOf<T>>(
+	emitter: T,
 	eventName: K,
-): Promise<T[K]>;
+): Promise<EventsOf<T>[K]>;
 export function once(emitter: Emitter, eventName: EventName): Promise<any[]> {
 	return new Promise((res) => {
 		emitter.once(eventName, (...args) => res(args));

--- a/src/classes/emitter.ts
+++ b/src/classes/emitter.ts
@@ -1,49 +1,67 @@
 // deno-lint-ignore-file no-explicit-any
+export type EventName = string | symbol;
 export type Listener = (this: Emitter, ...args: any[]) => void;
 
+export default interface Emitter {
+	addListener(eventName: EventName, listener: Listener): this;
+	off(eventName: EventName, listener: Listener): this;
+}
+
 export default class Emitter {
-	#events: Record<string, Listener[]> = {};
+	#events: Map<EventName, Listener[]> = new Map();
 
-	on(e: string, func: Listener) {
-		if (typeof this.#events[e] !== "object") {
-			this.#events[e] = [];
-		}
-		this.#events[e].push(func);
+	static {
+		this.prototype.addListener = this.prototype.on;
+		this.prototype.off = this.prototype.removeListener;
 	}
 
-	off(e: string, func: Listener) {
-		if (typeof this.#events[e] === "object") {
-			const idx = this.#events[e].indexOf(func);
-			if (idx > -1) {
-				this.#events[e].splice(idx, 1);
-			}
-		}
-	}
-
-	once(e: string, func: Listener) {
-		this.on(e, function f(...args) {
-			this.off(e, f);
-			func.apply(this, args);
-		});
-	}
-
-	emit(e: string, ...args: any[]) {
-		if (typeof this.#events[e] === "object") {
-			this.#events[e].forEach((func) => {
-				func.apply(this, args);
-			});
-		}
-	}
-
-	removeAllListeners(e?: string) {
-		if (e) {
-			if (typeof this.#events[e] === "object") {
-				this.#events[e] = [];
-			}
+	on(eventName: EventName, listener: Listener): this {
+		const listeners = this.#events.get(eventName);
+		if (listeners !== undefined) {
+			listeners.push(listener);
 		} else {
-			for (const e in this.#events) {
-				this.#events[e] = [];
+			this.#events.set(eventName, [listener]);
+		}
+		return this;
+	}
+
+	removeListener(eventName: EventName, listener: Listener): this {
+		const events = this.#events.get(eventName);
+		if (events !== undefined) {
+			const idx = events.indexOf(listener);
+			if (idx > -1) {
+				if (events.length === 1) {
+					this.#events.delete(eventName);
+				} else {
+					events.splice(idx, 1);
+				}
 			}
 		}
+		return this;
+	}
+
+	once(eventName: EventName, listener: Listener): this {
+		this.on(eventName, function once(...args) {
+			this.removeListener(eventName, listener);
+			listener.apply(this, args);
+		});
+		return this;
+	}
+
+	emit(eventName: EventName, ...args: any[]): this {
+		const listeners = this.#events.get(eventName);
+		if (listeners !== undefined) {
+			listeners.forEach((listener) => listener.apply(this, args));
+		}
+		return this;
+	}
+
+	removeAllListeners(eventName?: EventName): this {
+		if (eventName !== undefined) {
+			this.#events.delete(eventName);
+		} else {
+			this.#events.clear();
+		}
+		return this;
 	}
 }


### PR DESCRIPTION
- Slightly improves node.js `EventEmitter` interop for current methods.
- Fixes memory leak by removing empty arrays.
- Added `Emitter.once()` for converting once listeners to promises.
- Added support for event maps.