### PR TITLE
Fix typescript intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "types": "./dist/types/index.d.ts"
     }
   },
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/**/*.{js,cjs,d.ts}"
   ],


### PR DESCRIPTION
VS Code wasn't recognizing TypeScript.
I added "types" key to the package.json.
It shouldn't change how anything works, but it does allow VS Code to recognize types correctly.