### PR TITLE
feat: rework sending, connection status

### DIFF
--- a/src/classes/socket.ts
+++ b/src/classes/socket.ts
@@ -33,7 +33,7 @@ export enum ConnectionState {
 	/**
 	 * Connection open
 	 */
-	OPEN
+	OPEN,
 }
 
 export default class Socket extends Emitter<{
@@ -92,7 +92,6 @@ export default class Socket extends Emitter<{
 			this.emit("open", e);
 		});
 
-
 		this.#ws.addEventListener("close", () => {
 			if (this.status === ConnectionState.OPEN) {
 				// If the WebSocket connection with the
@@ -116,7 +115,6 @@ export default class Socket extends Emitter<{
 			}
 		});
 
-
 		this.#ws.addEventListener("open", () => {
 			this.status = ConnectionState.OPEN;
 			// When the WebSocket successfully opens
@@ -133,6 +131,6 @@ export default class Socket extends Emitter<{
 	close(code = 1000, reason = "Some reason"): void {
 		this.#closed = true;
 		this.#ws.close(code, reason);
-		this.status = ConnectionState.CLOSED
+		this.status = ConnectionState.CLOSED;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,8 +150,6 @@ export default class Surreal extends Emitter<
 
 	#ws!: Socket;
 
-	#url?: string;
-
 	#token?: string;
 
 	#pinger!: Pinger;
@@ -189,8 +187,6 @@ export default class Surreal extends Emitter<
 	 */
 	constructor(url?: string, token?: string) {
 		super();
-
-		this.#url = url;
 
 		this.#token = token;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import Pinger from "./classes/pinger.ts";
 import Emitter from "./classes/emitter.ts";
 import type { EventMap, EventName } from "./classes/emitter.ts";
 
-export { Emitter, Live, ConnectionState };
+export { ConnectionState, Emitter, Live };
 export type { EventMap, EventName };
 
 let singleton: Surreal;
@@ -171,11 +171,11 @@ export default class Surreal extends Emitter<
 	}
 
 	get status(): ConnectionState {
-		if(!this.#ws) {
-			return ConnectionState.NOT_CONNECTED
+		if (!this.#ws) {
+			return ConnectionState.NOT_CONNECTED;
 		}
 
-		return this.#ws.status
+		return this.#ws.status;
 	}
 
 	// ------------------------------
@@ -291,11 +291,13 @@ export default class Surreal extends Emitter<
 	 * Waits for the connection to the database to succeed.
 	 */
 	async wait(): Promise<void> {
-		if(!this.#ws) {
-			throw new Error("You have to call .connect before any other method!")
+		if (!this.#ws) {
+			throw new Error(
+				"You have to call .connect before any other method!",
+			);
 		}
-		await this.#ws.ready
-		await this.#attempted!
+		await this.#ws.ready;
+		await this.#attempted!;
 	}
 
 	/**
@@ -446,7 +448,7 @@ export default class Surreal extends Emitter<
 	 */
 	async select<T>(thing: string): Promise<T[]> {
 		const res = await this.#send("select", [thing]);
-		
+
 		return this.#outputHandlerB(
 			res,
 			thing,
@@ -510,8 +512,8 @@ export default class Surreal extends Emitter<
 		thing: string,
 		data?: Partial<T> & U,
 	): Promise<(T & U & { id: string }) | (T & U & { id: string })[]> {
-		const res = await this.#send( "change", [thing, data]);
-	
+		const res = await this.#send("change", [thing, data]);
+
 		return this.#outputHandlerB(
 			res,
 			thing,
@@ -529,7 +531,7 @@ export default class Surreal extends Emitter<
 	 */
 	async modify(thing: string, data?: Patch[]): Promise<Patch[]> {
 		const res = await this.#send("modify", [thing, data]);
-		
+
 		return this.#outputHandlerB(
 			res,
 			thing,
@@ -544,7 +546,7 @@ export default class Surreal extends Emitter<
 	 */
 	async delete(thing: string): Promise<void> {
 		const res = await this.#send("delete", [thing]);
-		
+
 		this.#outputHandlerError(res);
 		return;
 	}
@@ -562,15 +564,15 @@ export default class Surreal extends Emitter<
 	}
 
 	async #send(method: string, params: unknown[] = []) {
-		const id = guid()
-		await this.wait()
+		const id = guid();
+		await this.wait();
 		this.#ws.send(JSON.stringify({
 			id: id,
 			method: method,
 			params: params,
 		}));
-		const [res] = await this.nextEvent(id)
-		return res
+		const [res] = await this.nextEvent(id);
+		return res;
 	}
 
 	#outputHandlerA<T>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,7 +345,7 @@ export default class Surreal extends Emitter<
 	async signup(vars: Auth): Promise<string> {
 		const res = await this.#send("signup", [vars]);
 
-		this.#outputHandlerError(res, AuthenticationError as typeof Error)
+		this.#outputHandlerError(res, AuthenticationError as typeof Error);
 
 		this.#token = res.result;
 		return res.result;
@@ -359,7 +359,7 @@ export default class Surreal extends Emitter<
 	async signin(vars: Auth): Promise<string> {
 		const res = await this.#send("signin", [vars]);
 
-		this.#outputHandlerError(res, AuthenticationError as typeof Error)
+		this.#outputHandlerError(res, AuthenticationError as typeof Error);
 
 		this.#token = res.result;
 		return res.result;
@@ -371,7 +371,7 @@ export default class Surreal extends Emitter<
 	async invalidate(): Promise<void> {
 		const res = await this.#send("invalidate");
 
-		this.#outputHandlerError(res, AuthenticationError as typeof Error)
+		this.#outputHandlerError(res, AuthenticationError as typeof Error);
 
 		return res.result;
 	}
@@ -383,7 +383,7 @@ export default class Surreal extends Emitter<
 	async authenticate(token: string): Promise<void> {
 		const res = await this.#send("authenticate", [token]);
 
-		this.#outputHandlerError(res, AuthenticationError as typeof Error)
+		this.#outputHandlerError(res, AuthenticationError as typeof Error);
 
 		return res.result;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -554,20 +554,20 @@ export default class Surreal extends Emitter<
 
 	#init(): void {
 		this.#attempted = Promise.resolve().then(async () => {
-			if(!this.#token) {
-				return
+			if (!this.#token) {
+				return;
 			}
 			try {
-				await this.authenticate(this.#token)
+				await this.authenticate(this.#token);
 			} catch (_) {
 				// ignore Errors
 			}
-		})
+		});
 	}
 
 	async #send(method: string, params: unknown[] = [], wait = true) {
 		const id = guid();
-		if(wait) {
+		if (wait) {
 			await this.wait();
 		} else {
 			await this.#ws.ready;


### PR DESCRIPTION
This PR changes the following:
1. make index.ts more readable by creating the id etc. in the `#send` helper
2. If `.connect` is not called before any function we throw with an error message (https://github.com/mathe42/surrealdb.js/blob/168da41e2a9fe8b07da6cc49a7529a55608e612f/src/index.ts#L294)
3. Expose state of websocket. For possible states see https://github.com/mathe42/surrealdb.js/blob/168da41e2a9fe8b07da6cc49a7529a55608e612f/src/classes/socket.ts#L20
4. Combine some eventListeners into a single one in socket.ts
5. Some small refactoring of the output handler.