### PR TITLE
refactor(types): fix query generic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -464,10 +464,10 @@ export default class Surreal extends Emitter<
 	 * @param query - Specifies the SurrealQL statements.
 	 * @param vars - Assigns variables which can be used in the query.
 	 */
-	async query<T = Result[]>(
+	async query<T>(
 		query: string,
 		vars?: Record<string, unknown>,
-	): Promise<T> {
+	): Promise<Result<T>[]> {
 		const id = guid();
 
 		await this.#ws.ready;


### PR DESCRIPTION
This PR fixes the type so that the result is correctly returned when using a type generic.