### PR TITLE
fix: e2e build step

### DIFF
--- a/test/e2e/scripts/run-e2e.sh
+++ b/test/e2e/scripts/run-e2e.sh
@@ -12,7 +12,7 @@ echo "
 build
 ####### ####### ####### #######
 " &&
-npm run build &&
+deno task build &&
 
 echo "
 ####### ####### ####### #######


### PR DESCRIPTION
run-e2e.sh is currently failing because the build step is incorrect

Before:
```sh
npm run build &&
```

After:
```sh
deno task build &&
```

I'm guessing the broken step once relied on a package.json script command that no longer exists.