### PR TITLE
Client can only signup to scope

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ export default class Surreal extends Emitter<
 	 * @param vars - Variables used in a signup query.
 	 * @return The authenication token.
 	 */
-	async signup(vars: Auth): Promise<string> {
+	async signup(vars: ScopeAuth): Promise<string> {
 		const id = guid();
 
 		await this.#ws.ready;


### PR DESCRIPTION
The typing indicates that a client can signup as an instance, namespace, database and scope user. This is not true, as a client can only signup to a scope