### PR TITLE
Add named export for "Surreal"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ interface SurrealBaseEventMap {
 	notify: [any];
 }
 
-export default class Surreal extends Emitter<
+export class Surreal extends Emitter<
 	& SurrealBaseEventMap
 	& {
 		[
@@ -659,3 +659,5 @@ export default class Surreal extends Emitter<
 		throw new error(errormessage);
 	}
 }
+
+export default Surreal;


### PR DESCRIPTION
Allows you to change the messy:
```typescript
const { default: Surreal } = require('surrealdb.js');
const Surreal = require('surrealdb.js').default;
```

To just:
```typescript
const { Surreal } = require('surrealdb.js');
```

PS; all of the above still work. It's just an added named export :)