### PR TITLE
Fix Object Creation Return Type in SurrealDB.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -507,7 +507,7 @@ export class Surreal extends Emitter<
 	async create<T extends Record<string, unknown>>(
 		thing: string,
 		data?: T,
-	): Promise<T & { id: Thing }> {
+	): Promise<[T & { id: Thing }]> {
 		const id = guid();
 
 		await this.wait();


### PR DESCRIPTION
Hello, this is my first time contributing to this project, so please forgive me if I'm not fully aware of all the details in your codebase. I'd like to suggest a change that I believe may improve the functionality of SurrealDB.js.

While working with SurrealDB.js, I noticed an issue with the return type of objects created using the .create method. Instead of returning the created object directly, it returns the object wrapped within a list. This may cause unexpected behavior and should be fixed.