### PR TITLE
Cleanup queue after message is processed

### DIFF
--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -79,6 +79,7 @@ export class SurrealSocket {
 			) as RawSocketMessageResponse;
 			if (res.id && res.id in this.queue) {
 				this.queue[res.id](res);
+				delete this.queue[res.id];
 			}
 		});
 	}


### PR DESCRIPTION
Currently, the queue will hog up, slowly eating memory. As a message comes back only once (outside of live queries, will be separate queue), it can't hurt to clean it up when a message is processed