### PR TITLE
Refactor - Breaking Change: update use statement to use named parameters

### DIFF
--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -1,6 +1,7 @@
 import { NoConnectionDetails } from "../errors.ts";
 import { SurrealHTTP } from "../library/SurrealHTTP.ts";
 import {
+useType,
 	type AnyAuth,
 	type Connection,
 	type HTTPAuthenticationResponse,
@@ -76,9 +77,9 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	 * @param ns - Switches to a specific namespace.
 	 * @param db - Switches to a specific database.
 	 */
-	use(ns: string, db: string) {
+	use(vars: useType) {
 		if (!this.http) throw new NoConnectionDetails();
-		return this.http.use(ns, db);
+		return this.http.use(vars.NS, vars.DB);
 	}
 
 	/**

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -2,6 +2,7 @@ import { NoActiveSocket, UnexpectedResponse } from "../errors.ts";
 import { Pinger } from "../library/Pinger.ts";
 import { SurrealSocket } from "../library/SurrealSocket.ts";
 import {
+useType,
 	type AnyAuth,
 	type Connection,
 	type ConnectionOptions,
@@ -100,8 +101,8 @@ export class WebSocketStrategy implements Connection {
 	 * @param ns - Switches to a specific namespace.
 	 * @param db - Switches to a specific database.
 	 */
-	async use(ns: string, db: string) {
-		const { error } = await this.send("use", [ns, db]);
+	async use(vars: useType) {
+		const { error } = await this.send("use", [vars.NS, vars.DB]);
 		if (error) throw new Error(error.message);
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface Connection {
 
 	connect: (url: string, options?: ConnectionOptions) => void;
 	ping: () => Promise<void>;
-	use: (ns: string, db: string) => MaybePromise<void>;
+	use: (vars: useType) => MaybePromise<void>;
 	info?: () => Promise<void>;
 
 	signup: (vars: ScopeAuth) => Promise<Token>;
@@ -65,6 +65,11 @@ export type HTTPConnectionOptions<TFetcher = typeof fetch> =
 //////////////////////////////////////////////
 //////////   AUTHENTICATION TYPES   //////////
 //////////////////////////////////////////////
+
+export type useType = {
+	NS: string;
+	DB: string;
+}
 
 export type SuperUserAuth = {
 	user: string;


### PR DESCRIPTION
currently the `db.use` statement uses positional parameters. To be more consitent with other methods such as `db.signin` and `db.signup` this PR adds a new type `useType` that changes the use method to use named parameters instead

previously:
`db.use("test", "test");`

it is unclear which is the namespace and which is the database without refering to the documentation.

now:
`db.use(NS: "test", DB: "test");`

Alternatively, with function overloading we can preserve the old usage whilsts promoting the new method