### PR TITLE
Live Queries implementation

### DIFF
--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -137,23 +137,25 @@ export class SurrealSocket {
 
 	async kill(query: string) {
 		if (query in this.liveQueue) {
-			this.liveQueue[query].forEach(cb => cb({
-				action: "CLOSE",
-				detail: "Query killed"
-			}));
+			this.liveQueue[query].forEach((cb) =>
+				cb({
+					action: "CLOSE",
+					detail: "Query killed",
+				})
+			);
 
 			delete this.liveQueue[query];
 		}
 
 		await new Promise<void>((r) => {
-			this.send('kill', [query], (_) => {
+			this.send("kill", [query], (_) => {
 				if (query in this.unprocessedLiveResponses) {
 					delete this.unprocessedLiveResponses[query];
 				}
 
 				r();
 			});
-		})
+		});
 	}
 
 	private async handleLiveBatch(messages: UnprocessedLiveQueryResponse[]) {

--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -131,7 +131,9 @@ export class SurrealSocket {
 		this.liveQueue[queryUuid].push(callback);
 
 		// Cleanup unprocessed messages queue
-		await Promise.all(this.unprocessedLiveResponses[queryUuid]?.map(callback) ?? []);
+		await Promise.all(
+			this.unprocessedLiveResponses[queryUuid]?.map(callback) ?? [],
+		);
 		delete this.unprocessedLiveResponses[queryUuid];
 	}
 
@@ -159,18 +161,22 @@ export class SurrealSocket {
 	}
 
 	private async handleLiveBatch(messages: UnprocessedLiveQueryResponse[]) {
-		await Promise.all(messages.map(async ({ query: queryUuid, ...message }) => {
-			if (this.liveQueue[queryUuid]) {
-				await Promise.all(
-					this.liveQueue[queryUuid].map(async (cb) => await cb(message)),
-				);
-			} else {
-				if (!(queryUuid in this.unprocessedLiveResponses)) {
-					this.unprocessedLiveResponses[queryUuid] = [];
+		await Promise.all(
+			messages.map(async ({ query: queryUuid, ...message }) => {
+				if (this.liveQueue[queryUuid]) {
+					await Promise.all(
+						this.liveQueue[queryUuid].map(async (cb) =>
+							await cb(message)
+						),
+					);
+				} else {
+					if (!(queryUuid in this.unprocessedLiveResponses)) {
+						this.unprocessedLiveResponses[queryUuid] = [];
+					}
+					this.unprocessedLiveResponses[queryUuid].push(message);
 				}
-				this.unprocessedLiveResponses[queryUuid].push(message);
-			}
-		}));
+			}),
+		);
 	}
 
 	async close(reason: keyof typeof this.socketClosureReason) {

--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -135,6 +135,27 @@ export class SurrealSocket {
 		delete this.unprocessedLiveResponses[query];
 	}
 
+	async kill(query: string) {
+		if (query in this.liveQueue) {
+			this.liveQueue[query].forEach(cb => cb({
+				action: "CLOSE",
+				detail: "Query killed"
+			}));
+
+			delete this.liveQueue[query];
+		}
+
+		await new Promise<void>((r) => {
+			this.send('kill', [query], (_) => {
+				if (query in this.unprocessedLiveResponses) {
+					delete this.unprocessedLiveResponses[query];
+				}
+
+				r();
+			});
+		})
+	}
+
 	private async handleLiveBatch(messages: UnprocessedLiveQueryResponse[]) {
 		await Promise.all(messages.map(async ({ query, ...message }) => {
 			if (this.liveQueue[query]) {

--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -1,6 +1,8 @@
 import {
+	type LiveQueryResponse,
 	type RawSocketMessageResponse,
 	type Result,
+	type UnprocessedLiveQueryResponse,
 	WebsocketStatus,
 } from "../types.ts";
 import WebSocket from "./WebSocket/deno.ts";
@@ -14,6 +16,12 @@ export class SurrealSocket {
 	private ws?: WebSocket;
 	private status: WebsocketStatus = WebsocketStatus.CLOSED;
 	private queue: Record<string, (data: Result) => unknown> = {};
+	private liveQueue: Record<
+		string,
+		((data: LiveQueryResponse) => unknown)[]
+	> = {};
+
+	private unprocessedLiveResponses: Record<string, LiveQueryResponse[]> = {};
 
 	public ready: Promise<void>;
 	private resolveReady: () => void;
@@ -35,9 +43,9 @@ export class SurrealSocket {
 		onClose?: () => unknown;
 	}) {
 		this.resolveReady = () => {}; // Purely for typescript typing :)
-		this.ready = new Promise((r) => this.resolveReady = r);
+		this.ready = new Promise((r) => (this.resolveReady = r));
 		this.resolveClosed = () => {}; // Purely for typescript typing :)
-		this.closed = new Promise((r) => this.resolveClosed = r);
+		this.closed = new Promise((r) => (this.resolveClosed = r));
 		this.onOpen = onOpen;
 		this.onClose = onClose;
 		this.url = processUrl(url, {
@@ -63,6 +71,19 @@ export class SurrealSocket {
 			this.resolveClosed();
 			this.resetClosed();
 
+			Object.values(this.liveQueue).map((query) => {
+				query.map((cb) =>
+					cb({
+						action: "CLOSE",
+						detail: "Socket closed",
+					})
+				);
+			});
+
+			this.queue = {};
+			this.liveQueue = {};
+			this.unprocessedLiveResponses = {};
+
 			// Connection retry mechanism
 			if (this.status !== WebsocketStatus.CLOSED) {
 				this.status = WebsocketStatus.RECONNECTING;
@@ -79,7 +100,9 @@ export class SurrealSocket {
 			const res = JSON.parse(
 				e.data.toString(),
 			) as RawSocketMessageResponse;
-			if (res.id && res.id in this.queue) {
+			if ("method" in res && res.method === "notify") {
+				this.handleLiveBatch(res.params);
+			} else if (res.id && res.id in this.queue) {
 				this.queue[res.id](res);
 				delete this.queue[res.id];
 			}
@@ -98,6 +121,33 @@ export class SurrealSocket {
 		const id = getIncrementalID();
 		this.queue[id] = callback;
 		this.ws?.send(JSON.stringify({ id, method, params }));
+	}
+
+	async listenLive(
+		query: string,
+		callback: (data: LiveQueryResponse) => unknown,
+	) {
+		if (!(query in this.liveQueue)) this.liveQueue[query] = [];
+		this.liveQueue[query].push(callback);
+
+		// Cleanup unprocessed messages queue
+		await Promise.all(this.unprocessedLiveResponses[query]?.map(callback));
+		delete this.unprocessedLiveResponses[query];
+	}
+
+	private async handleLiveBatch(messages: UnprocessedLiveQueryResponse[]) {
+		await Promise.all(messages.map(async ({ query, ...message }) => {
+			if (this.liveQueue[query]) {
+				await Promise.all(
+					this.liveQueue[query].map(async (cb) => await cb(message)),
+				);
+			} else {
+				if (!(query in this.unprocessedLiveResponses)) {
+					this.unprocessedLiveResponses[query] = [];
+				}
+				this.unprocessedLiveResponses[query].push(message);
+			}
+		}));
 	}
 
 	async close(reason: keyof typeof this.socketClosureReason) {

--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -75,7 +75,7 @@ export class SurrealSocket {
 				query.map((cb) =>
 					cb({
 						action: "CLOSE",
-						detail: "Socket closed",
+						detail: "SOCKET_CLOSED",
 					})
 				);
 			});
@@ -140,7 +140,7 @@ export class SurrealSocket {
 			this.liveQueue[query].forEach((cb) =>
 				cb({
 					action: "CLOSE",
-					detail: "Query killed",
+					detail: "QUERY_KILLED",
 				})
 			);
 

--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -131,7 +131,7 @@ export class SurrealSocket {
 		this.liveQueue[uuid].push(callback);
 
 		// Cleanup unprocessed messages queue
-		await Promise.all(this.unprocessedLiveResponses[uuid]?.map(callback));
+		await Promise.all(this.unprocessedLiveResponses[uuid]?.map(callback) ?? []);
 		delete this.unprocessedLiveResponses[uuid];
 	}
 

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -199,6 +199,11 @@ export class WebSocketStrategy implements Connection {
 		if (res.error) throw new Error(res.error.message);
 	}
 
+	/**
+	 * Start a live query and listen for the responses
+	 * @param query - The query that you want to receive live results for.
+	 * @param callback - Callback function that receives updates.
+	 */
 	async live<T extends Record<string, unknown> = Record<string, unknown>>(
 		query: string,
 		callback?: (data: LiveQueryResponse<T>) => unknown,
@@ -210,6 +215,11 @@ export class WebSocketStrategy implements Connection {
 		return res.result;
 	}
 
+	/**
+	 * Listen for live query responses by it's uuid
+	 * @param query - The LQ uuid that you want to receive live results for.
+	 * @param callback - Callback function that receives updates.
+	 */
 	async listenLive<
 		T extends Record<string, unknown> = Record<string, unknown>,
 	>(
@@ -224,6 +234,10 @@ export class WebSocketStrategy implements Connection {
 		);
 	}
 
+	/**
+	 * Kill a live query
+	 * @param query - The query that you want to kill.
+	 */
 	async kill(query: string) {
 		await this.ready;
 		if (!this.socket) throw new NoActiveSocket();

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -5,6 +5,7 @@ import {
 	type AnyAuth,
 	type Connection,
 	type ConnectionOptions,
+	type LiveQueryResponse,
 	type MapQueryResult,
 	type MergeData,
 	type Patch,
@@ -196,6 +197,26 @@ export class WebSocketStrategy implements Connection {
 	async unset(variable: string) {
 		const res = await this.send("unset", [variable]);
 		if (res.error) throw new Error(res.error.message);
+	}
+
+	async live(
+		query: string,
+		callback?: (data: LiveQueryResponse) => unknown,
+	) {
+		await this.ready;
+		const res = await this.send<string>("live", [query]);
+		if (res.error) throw new Error(res.error.message);
+		if (callback) this.socket?.listenLive(res.result, callback);
+		return res.result;
+	}
+
+	async listenLive(
+		query: string,
+		callback: (data: LiveQueryResponse) => unknown,
+	) {
+		await this.ready;
+		if (!this.socket) throw new NoActiveSocket();
+		this.socket.listenLive(query, callback);
 	}
 
 	/**

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -217,19 +217,19 @@ export class WebSocketStrategy implements Connection {
 
 	/**
 	 * Listen for live query responses by it's uuid
-	 * @param uuid - The LQ uuid that you want to receive live results for.
+	 * @param queryUuid - The LQ uuid that you want to receive live results for.
 	 * @param callback - Callback function that receives updates.
 	 */
 	async listenLive<
 		T extends Record<string, unknown> = Record<string, unknown>,
 	>(
-		uuid: string,
+		queryUuid: string,
 		callback: (data: LiveQueryResponse<T>) => unknown,
 	) {
 		await this.ready;
 		if (!this.socket) throw new NoActiveSocket();
 		this.socket.listenLive(
-			uuid,
+			queryUuid,
 			callback as (data: LiveQueryResponse) => unknown,
 		);
 	}
@@ -238,10 +238,10 @@ export class WebSocketStrategy implements Connection {
 	 * Kill a live query
 	 * @param uuid - The query that you want to kill.
 	 */
-	async kill(uuid: string) {
+	async kill(queryUuid: string) {
 		await this.ready;
 		if (!this.socket) throw new NoActiveSocket();
-		await this.socket.kill(uuid);
+		await this.socket.kill(queryUuid);
 	}
 
 	/**

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -224,6 +224,12 @@ export class WebSocketStrategy implements Connection {
 		);
 	}
 
+	async kill(query: string) {
+		await this.ready;
+		if (!this.socket) throw new NoActiveSocket();
+		await this.socket.kill(query);
+	}
+
 	/**
 	 * Runs a set of SurrealQL statements against the database.
 	 * @param query - Specifies the SurrealQL statements.

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -199,24 +199,29 @@ export class WebSocketStrategy implements Connection {
 		if (res.error) throw new Error(res.error.message);
 	}
 
-	async live(
+	async live<T extends Record<string, unknown> = Record<string, unknown>>(
 		query: string,
-		callback?: (data: LiveQueryResponse) => unknown,
+		callback?: (data: LiveQueryResponse<T>) => unknown,
 	) {
 		await this.ready;
 		const res = await this.send<string>("live", [query]);
 		if (res.error) throw new Error(res.error.message);
-		if (callback) this.socket?.listenLive(res.result, callback);
+		if (callback) this.listenLive<T>(res.result, callback);
 		return res.result;
 	}
 
-	async listenLive(
+	async listenLive<
+		T extends Record<string, unknown> = Record<string, unknown>,
+	>(
 		query: string,
-		callback: (data: LiveQueryResponse) => unknown,
+		callback: (data: LiveQueryResponse<T>) => unknown,
 	) {
 		await this.ready;
 		if (!this.socket) throw new NoActiveSocket();
-		this.socket.listenLive(query, callback);
+		this.socket.listenLive(
+			query,
+			callback as (data: LiveQueryResponse) => unknown,
+		);
 	}
 
 	/**

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -217,31 +217,31 @@ export class WebSocketStrategy implements Connection {
 
 	/**
 	 * Listen for live query responses by it's uuid
-	 * @param query - The LQ uuid that you want to receive live results for.
+	 * @param uuid - The LQ uuid that you want to receive live results for.
 	 * @param callback - Callback function that receives updates.
 	 */
 	async listenLive<
 		T extends Record<string, unknown> = Record<string, unknown>,
 	>(
-		query: string,
+		uuid: string,
 		callback: (data: LiveQueryResponse<T>) => unknown,
 	) {
 		await this.ready;
 		if (!this.socket) throw new NoActiveSocket();
 		this.socket.listenLive(
-			query,
+			uuid,
 			callback as (data: LiveQueryResponse) => unknown,
 		);
 	}
 
 	/**
 	 * Kill a live query
-	 * @param query - The query that you want to kill.
+	 * @param uuid - The query that you want to kill.
 	 */
-	async kill(query: string) {
+	async kill(uuid: string) {
 		await this.ready;
 		if (!this.socket) throw new NoActiveSocket();
-		await this.socket.kill(query);
+		await this.socket.kill(uuid);
 	}
 
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,7 +185,7 @@ export type LiveQueryResponse<
 export type UnprocessedLiveQueryResponse<
 	T extends Record<string, unknown> = Record<string, unknown>,
 > = LiveQueryResponse<T> & {
-	uuid: string;
+	query: string;
 };
 
 /////////////////////////////////////

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,12 +169,13 @@ export type RawQueryResult =
 	| RawQueryResult[]
 	| Record<string | number | symbol, unknown>;
 
+export type LiveQueryClosureReason = "SOCKET_CLOSED" | "QUERY_KILLED";
 export type LiveQueryResponse<
 	T extends Record<string, unknown> = Record<string, unknown>,
 > = {
 	action: "CLOSE";
 	result?: never;
-	detail: string;
+	detail: LiveQueryClosureReason;
 } | {
 	action: "CREATE" | "UPDATE" | "DELETE";
 	result: T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,10 +173,12 @@ export type LiveQueryResponse<
 	T extends Record<string, unknown> = Record<string, unknown>,
 > = {
 	action: "CLOSE";
+	result?: never;
 	detail: string;
 } | {
-	action: string;
+	action: "CREATE" | "UPDATE" | "DELETE";
 	result: T;
+	detail?: never;
 };
 
 export type UnprocessedLiveQueryResponse<

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,7 +185,7 @@ export type LiveQueryResponse<
 export type UnprocessedLiveQueryResponse<
 	T extends Record<string, unknown> = Record<string, unknown>,
 > = LiveQueryResponse<T> & {
-	query: string;
+	uuid: string;
 };
 
 /////////////////////////////////////

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,8 +169,24 @@ export type RawQueryResult =
 	| RawQueryResult[]
 	| Record<string | number | symbol, unknown>;
 
+export type LiveQueryResponse<
+	T extends Record<string, unknown> = Record<string, unknown>,
+> = {
+	action: "CLOSE";
+	detail: string;
+} | {
+	action: string;
+	result: T;
+};
+
+export type UnprocessedLiveQueryResponse<
+	T extends Record<string, unknown> = Record<string, unknown>,
+> = LiveQueryResponse<T> & {
+	query: string;
+};
+
 /////////////////////////////////////
-//////////   QUERY TYPES   //////////
+//////////   PATCH TYPES   //////////
 /////////////////////////////////////
 
 type BasePatch = {
@@ -234,5 +250,5 @@ export type RawSocketMessageResponse =
 export type RawSocketLiveQueryNotification = {
 	id: null;
 	method: "notify";
-	params: unknown[];
+	params: UnprocessedLiveQueryResponse[];
 };


### PR DESCRIPTION
# Adds back LQ functionality

Start a live query
```typescript
const uuid = await surreal.live<{
    id: string;
    prop: number;
}>("query...", (data) => {
    if (data.action === 'CLOSE") return;
    console.log(data.result);
});
```

Register another listener for an LQ
```typescript
await surreal.listenLive<{
    id: string;
    prop: number;
}>("uuid...", (data) => {
    if (data.action === 'CLOSE") return;
    console.log("Second listener! ", data.result);
});
```

Kill a LQ
```typescript
await surreal.kill("uuid...");
```

### Data in callback
```typescript
type close = {
    action: "CLOSE",
    detail: "SOCKET_CLOSED" | "QUERY_KILLED"
};

type create = {
    action: "CREATE";
    result: Record<string, unknown>;  // Generic type that was passed, always extends default type
};

type update = {
    action: "UPDATE";
    result: Record<string, unknown>;  // Generic type that was passed, always extends default type
};

type delete = {
    action: "DELETE";
    result: Record<string, unknown>;  // Generic type that was passed, always extends default type
};
```