### PR TITLE
fix - fixed import of isomorphic-ws to work with nextjs server components

### DIFF
--- a/src/library/WebSocket/node.ts
+++ b/src/library/WebSocket/node.ts
@@ -1,2 +1,3 @@
 // @ts-ignore this is a node import!
-export { default } from "isomorphic-ws";
+import { WebSocket } from "isomorphic-ws";
+export default WebSocket;


### PR DESCRIPTION
Fixed the import of `isomporhic-ws` for nodejs so that the library can be used within nextjs server components and apis