### PR TITLE
Replace isomorphic-ws with unws

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -26,7 +26,7 @@ await build({
 			url: "https://surrealdb.com",
 		},
 		dependencies: {
-			"isomorphic-ws": "^5.0.0",
+			"unws": "^0.2.2",
 		},
 		devDependencies: {
 			"@types/node": "^18.7.18",

--- a/src/library/WebSocket/node.ts
+++ b/src/library/WebSocket/node.ts
@@ -1,2 +1,2 @@
 // @ts-ignore this is a node import!
-export { default } from "isomorphic-ws";
+export { WebSocket as default } from "unws";


### PR DESCRIPTION
# Motivation
Issues arrised with nextjs server components importing the `isomorphic-ws` package, which has some fundamental problems and is not maintained.

# Solution
`unws` is an alternative package that provides solutions to issues `isomorphic-ws` has.