### PR TITLE
Bump v0.7.2

### DIFF
--- a/project.json
+++ b/project.json
@@ -1,4 +1,4 @@
 {
   "name": "surrealdb.js",
-  "version": "0.7.1"
+  "version": "0.7.2"
 }


### PR DESCRIPTION
_Doing a minor bugfix release to unblock some people, there will be more changes but not yet finalized_

# Overview of changes
- No need to pass a URL to the `constructor` function of the `Surreal` class anymore. It's optional which allows you to initialize later with the `.connect()` function
- Adding a dependency on the `URL` class broke the library for react-native. Whilst we don't officially support hermes, be dropped this behaviour for a custom URL parser
- Replace `isomorphic-ws` with `unws`. Issues arrised with nextjs server components importing the `isomorphic-ws` package, which has some fundamental problems and is not maintained.
- The output handler did not properly handle an empty response when querying a non-existent key. Now returns `undefined`.