### PR TITLE
Remember auth across possible disconnects

### DIFF
--- a/src/library/SurrealHTTP.ts
+++ b/src/library/SurrealHTTP.ts
@@ -36,9 +36,9 @@ export class SurrealHTTP<TFetcher = typeof fetch> {
 		this.authorization = undefined;
 	}
 
-	use(ns: string, db: string) {
-		this.namespace = ns;
-		this.database = db;
+	use({ ns, db }: { ns?: string; db?: string }) {
+		if (ns) this.namespace = ns;
+		if (db) this.database = db;
 	}
 
 	async request<T = unknown>(path: string, options?: {

--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -33,9 +33,16 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	 */
 	async connect(
 		url: string,
-		{ fetch: fetcher, prepare }: HTTPConnectionOptions<TFetcher> = {},
+		{ fetch: fetcher, prepare, auth, ns, db }: HTTPConnectionOptions<TFetcher> = {},
 	) {
 		this.http = new SurrealHTTP<TFetcher>(url, { fetcher });
+		await this.use({ ns, db })
+		if (typeof auth === "string") {
+			await this.authenticate(auth);
+		} else if (auth) {
+			await this.signin(auth);
+		}
+
 		await prepare?.(this);
 		this.resolveReady();
 		await this.ready;
@@ -76,9 +83,9 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	 * @param ns - Switches to a specific namespace.
 	 * @param db - Switches to a specific database.
 	 */
-	use(ns: string, db: string) {
+	use({ ns, db }: { ns?: string; db?: string }) {
 		if (!this.http) throw new NoConnectionDetails();
-		return this.http.use(ns, db);
+		return this.http.use({ ns, db });
 	}
 
 	/**

--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -33,10 +33,12 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	 */
 	async connect(
 		url: string,
-		{ fetch: fetcher, prepare, auth, ns, db }: HTTPConnectionOptions<TFetcher> = {},
+		{ fetch: fetcher, prepare, auth, ns, db }: HTTPConnectionOptions<
+			TFetcher
+		> = {},
 	) {
 		this.http = new SurrealHTTP<TFetcher>(url, { fetcher });
-		await this.use({ ns, db })
+		await this.use({ ns, db });
 		if (typeof auth === "string") {
 			await this.authenticate(auth);
 		} else if (auth) {

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -53,7 +53,9 @@ export class WebSocketStrategy implements Connection {
 			url,
 			onOpen: async () => {
 				this.pinger?.start(() => this.ping());
-				if (this.connection.ns && this.connection.db) await this.use({});
+				if (this.connection.ns && this.connection.db) {
+					await this.use({});
+				}
 				if (typeof this.connection.auth === "string") {
 					await this.authenticate(this.connection.auth);
 				} else if (this.connection.auth) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface Connection {
 
 	connect: (url: string, options?: ConnectionOptions) => void;
 	ping: () => Promise<void>;
-	use: (ns: string, db: string) => MaybePromise<void>;
+	use: (opt: { ns: string; db: string }) => MaybePromise<void>;
 	info?: () => Promise<void>;
 
 	signup: (vars: ScopeAuth) => Promise<Token>;
@@ -14,7 +14,8 @@ export interface Connection {
 	authenticate: (token: Token) => MaybePromise<void>;
 	invalidate: () => MaybePromise<void>;
 
-	let?: (variable: string, value: unknown) => Promise<string>;
+	let?: (variable: string, value: unknown) => Promise<void>;
+	unset?: (variable: string) => Promise<void>;
 
 	query: <T extends RawQueryResult[]>(
 		query: string,
@@ -53,7 +54,14 @@ export interface Connection {
 
 export type ConnectionOptions = {
 	prepare?: (connection: Connection) => unknown;
-};
+	auth?: AnyAuth | Token;
+} & ({
+	ns: string;
+	db: string;
+} | {
+	ns?: never;
+	db?: never;
+});
 
 export type HTTPConnectionOptions<TFetcher = typeof fetch> =
 	& ConnectionOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,16 +52,18 @@ export interface Connection {
 	) => Promise<(T & { id: string })[]>;
 }
 
-export type ConnectionOptions = {
-	prepare?: (connection: Connection) => unknown;
-	auth?: AnyAuth | Token;
-} & ({
-	ns: string;
-	db: string;
-} | {
-	ns?: never;
-	db?: never;
-});
+export type ConnectionOptions =
+	& {
+		prepare?: (connection: Connection) => unknown;
+		auth?: AnyAuth | Token;
+	}
+	& ({
+		ns: string;
+		db: string;
+	} | {
+		ns?: never;
+		db?: never;
+	});
 
 export type HTTPConnectionOptions<TFetcher = typeof fetch> =
 	& ConnectionOptions

--- a/test/e2e/shared.js
+++ b/test/e2e/shared.js
@@ -67,7 +67,7 @@ export default async (db) => {
 	// Easy way to "reset" for each test while debugging...
 	const rand = (Math.random() + 1).toString(36).substring(7);
 	logger.debug(`Select NS "test", DB "test-${rand}"`);
-	await db.use("test", `test-${rand}`);
+	await db.use({ ns: "test", db: `test-${rand}` });
 
 	await test("Create a new person with a specific id", async (expect) => {
 		let created = await db.create("person:tobie", data["person:tobie"]);


### PR DESCRIPTION
# What changed?
- **Breaking**: The `.use()` function now accepts an object as an argument (`{ ns, db }`).
- You can now pass an `auth` property to the second argument of the constructor and connect functions. This can be a token string or an object you would pass to the `.signin()` function.
- You can now pass a pair of `{ ns, db }` to the constructor and connect functions.
- The auth state and ns/db combo will now be remembered after a possible websocket disconnect and will automatically be restored.