### PR TITLE
Update unws library

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -26,7 +26,7 @@ await build({
 			url: "https://surrealdb.com",
 		},
 		dependencies: {
-			"unws": "^0.2.2",
+			"unws": "^0.2.3",
 			"ws": "^8.13.0",
 		},
 		devDependencies: {


### PR DESCRIPTION
Old version of `unws` is causing issues for people working in a commonjs workspace. [This PR for `unws`](https://github.com/sxzz/unws/pull/5) fixes that issue.