### PR TITLE
Implement info method for WS strategy

### DIFF
--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -131,12 +131,17 @@ export class WebSocketStrategy implements Connection {
 	}
 
 	/**
-	 * Retrieve info about the current Surreal instance
-	 * @return Returns nothing!
+	 * Selects everything from the [$auth](https://surrealdb.com/docs/surrealql/parameters) variable.
+	 * ```sql
+	 * SELECT * FROM $auth;
+	 * ```
+	 * Make sure the user actually has the permission to select their own record, otherwise you'll get back an empty result.
+	 * @return The record linked to the record ID used for authentication
 	 */
-	async info() {
-		const res = await this.send("info");
+	async info<T extends Record<string, unknown> = Record<string, unknown>>() {
+		const res = await this.send<ActionResult<T> | undefined>("info");
 		if (res.error) throw new Error(res.error.message);
+		return res.result ?? undefined;
 	}
 
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,8 @@ export interface Connection {
 	connect: (url: string, options?: ConnectionOptions) => void;
 	ping: () => Promise<void>;
 	use: (opt: { ns: string; db: string }) => MaybePromise<void>;
-	info?: () => Promise<void>;
+	info?: <T extends Record<string, unknown> = Record<string, unknown>>() =>
+		Promise<T | undefined>;
 
 	signup: (vars: ScopeAuth) => Promise<Token>;
 	signin: (vars: AnyAuth) => Promise<Token | void>;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Just recently discovered what the `info` method on the websocket protocol actually does

## What does this change do?

This PR implements the `.info<T>()` method. The info method will essentially execute the following query: `SELECT * FROM $auth`.

## What is your testing strategy?

Ensure that tests still pass

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
