### PR TITLE
`.info()` should await ready state

### DIFF
--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -139,6 +139,7 @@ export class WebSocketStrategy implements Connection {
 	 * @return The record linked to the record ID used for authentication
 	 */
 	async info<T extends Record<string, unknown> = Record<string, unknown>>() {
+		await this.ready;
 		const res = await this.send<ActionResult<T> | undefined>("info");
 		if (res.error) throw new Error(res.error.message);
 		return res.result ?? undefined;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `.info()` method currently does not await the ready state of the database, whilst it should.

## What does this change do?

This PR ensures that the `.info()` method will await the ready state.

## What is your testing strategy?

Ensure that tests still pass

## Is this related to any issues?

Not directly

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
