### PR TITLE
Don't require NS/DB for scope authentication

### DIFF
--- a/src/library/SurrealHTTP.ts
+++ b/src/library/SurrealHTTP.ts
@@ -4,8 +4,8 @@ import { processUrl } from "./processUrl.ts";
 export class SurrealHTTP<TFetcher = typeof fetch> {
 	private url: string;
 	private authorization?: string;
-	private namespace?: string;
-	private database?: string;
+	private _namespace?: string;
+	private _database?: string;
 	private fetch: TFetcher;
 
 	constructor(url: string, {
@@ -21,7 +21,7 @@ export class SurrealHTTP<TFetcher = typeof fetch> {
 	}
 
 	ready() {
-		return !!(this.url && this.namespace && this.database);
+		return !!(this.url && this._namespace && this._database);
 	}
 
 	setTokenAuth(token: string) {
@@ -37,8 +37,16 @@ export class SurrealHTTP<TFetcher = typeof fetch> {
 	}
 
 	use({ ns, db }: { ns?: string; db?: string }) {
-		if (ns) this.namespace = ns;
-		if (db) this.database = db;
+		if (ns) this._namespace = ns;
+		if (db) this._database = db;
+	}
+
+	get namespace() {
+		return this._namespace;
+	}
+
+	get database() {
+		return this._database;
 	}
 
 	async request<T = unknown>(path: string, options?: {
@@ -57,8 +65,8 @@ export class SurrealHTTP<TFetcher = typeof fetch> {
 						? "text/plain"
 						: "application/json",
 					"Accept": "application/json",
-					"NS": this.namespace!,
-					"DB": this.database!,
+					"NS": this._namespace!,
+					"DB": this._database!,
 					...(this.authorization
 						? { "Authorization": this.authorization }
 						: {}),

--- a/src/library/isNil.ts
+++ b/src/library/isNil.ts
@@ -1,0 +1,3 @@
+export function isNil(v: unknown): v is undefined | null {
+	return v === undefined || v === null;
+}

--- a/src/library/processAuthVars.ts
+++ b/src/library/processAuthVars.ts
@@ -1,0 +1,16 @@
+import { AnyAuth } from "../types.ts";
+import { isNil } from "./isNil.ts";
+
+export function processAuthVars<T extends AnyAuth>(vars: T, fallback?: {
+	namespace?: string;
+	database?: string;
+}) {
+	if ("SC" in vars) {
+		if (!vars.NS) vars.NS = fallback?.namespace;
+		if (!vars.DB) vars.DB = fallback?.database;
+		if (isNil(vars.NS)) throw new Error("No namespace was specified!");
+		if (isNil(vars.DB)) throw new Error("No database was specified!");
+	}
+
+	return vars;
+}

--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -1,5 +1,6 @@
 import { NoConnectionDetails } from "../errors.ts";
 import { SurrealHTTP } from "../library/SurrealHTTP.ts";
+import { processAuthVars } from "../library/processAuthVars.ts";
 import {
 	type ActionResult,
 	type AnyAuth,
@@ -104,6 +105,11 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	 * @return The authentication token.
 	 */
 	async signup(vars: ScopeAuth) {
+		vars = processAuthVars(vars, {
+			namespace: this.http?.namespace,
+			database: this.http?.database,
+		});
+
 		const res = await this.request<HTTPAuthenticationResponse>("/signup", {
 			method: "POST",
 			body: vars,
@@ -121,6 +127,11 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	 * @return The authentication token, unless signed in as root.
 	 */
 	async signin(vars: AnyAuth) {
+		vars = processAuthVars(vars, {
+			namespace: this.http?.namespace,
+			database: this.http?.database,
+		});
+
 		const res = await this.request<HTTPAuthenticationResponse>("/signin", {
 			method: "POST",
 			body: vars,

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -1,6 +1,7 @@
 import { NoActiveSocket, UnexpectedResponse } from "../errors.ts";
 import { Pinger } from "../library/Pinger.ts";
 import { SurrealSocket } from "../library/SurrealSocket.ts";
+import { processAuthVars } from "../library/processAuthVars.ts";
 import {
 	type ActionResult,
 	type AnyAuth,
@@ -151,6 +152,11 @@ export class WebSocketStrategy implements Connection {
 	 * @return The authentication token.
 	 */
 	async signup(vars: ScopeAuth) {
+		vars = processAuthVars(vars, {
+			namespace: this.connection.ns,
+			database: this.connection.db,
+		});
+
 		const res = await this.send<string>("signup", [vars]);
 		if (res.error) throw new Error(res.error.message);
 		this.connection.auth = res.result;
@@ -163,6 +169,11 @@ export class WebSocketStrategy implements Connection {
 	 * @return The authentication token.
 	 */
 	async signin(vars: AnyAuth) {
+		vars = processAuthVars(vars, {
+			namespace: this.connection.ns,
+			database: this.connection.db,
+		});
+
 		const res = await this.send<string | undefined>("signin", [vars]);
 		if (res.error) throw new Error(res.error.message);
 		this.connection.auth = res.result ?? vars;

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,8 +110,8 @@ export type DatabaseAuth = {
 };
 
 export type ScopeAuth = {
-	NS: string;
-	DB: string;
+	NS?: string;
+	DB?: string;
 	SC: string;
 	[T: string]: unknown;
 };

--- a/test/e2e/scripts/docker-restart.sh
+++ b/test/e2e/scripts/docker-restart.sh
@@ -20,7 +20,7 @@ fi
 
 echo "Checking if docker deamon is running"
 
-if (! docker stats --no-stream ); then
+if ! docker info > /dev/null 2>&1; then
   echo "Please start the docker daemon"
   exit 1
 fi

--- a/test/e2e/scripts/run-e2e.sh
+++ b/test/e2e/scripts/run-e2e.sh
@@ -12,7 +12,9 @@ echo "-----------------------------------------"
 deno task build
 
 sh $WORKING_DIR/docker-restart.sh
-
+if [ $? -eq 1 ]; then
+	exit 1;
+fi
 
 echo " "
 echo "Running deno tests"


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #133 for more details. Furthermore, this PR is a continuation of #141.

## What does this change do?

This PR makes the passing of the `NS` and `DB` properties optional for scope authentication as we already store them in the class. It also adds a test for scope authentication which specifically does not use the `NS` or `DB` properties, and some improvements to the shell scripts.

## What is your testing strategy?

Added a test which tests this new behaviour

## Is this related to any issues?

See #133 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
