### PR TITLE
Allow vars in HTTP query method

### DIFF
--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -166,18 +166,24 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	 * @param query - Specifies the SurrealQL statements.
 	 * @param vars - Assigns variables which can be used in the query.
 	 */
-	async query<T extends RawQueryResult[]>(query: string) {
-		if (arguments[1]) {
-			throw new Error(
-				"The query function in the HTTP strategy does not support data as the second argument.",
-			);
-		}
-
+	async query<T extends RawQueryResult[]>(
+		query: string,
+		vars?: Record<string, unknown>,
+	) {
 		await this.ready;
 		const res = await this.request<InvalidSQL | MapQueryResult<T>>("/sql", {
 			body: query,
 			plainBody: true,
 			method: "POST",
+			searchParams: vars &&
+				new URLSearchParams(
+					Object.fromEntries(
+						Object.entries(vars).map(([k, v]) => [
+							k,
+							typeof v == "object" ? JSON.stringify(v) : `${v}`,
+						]),
+					),
+				),
 		});
 
 		if ("information" in res) throw new Error(res.information);

--- a/test/e2e/shared.js
+++ b/test/e2e/shared.js
@@ -94,18 +94,12 @@ export default async (db) => {
 	});
 
 	await test("Perform a custom advanced query", async (expect) => {
-		let groups =
-			db.strategy == "ws"
-				? await db.query(
-						"SELECT marketing, count() FROM type::table($tb) GROUP BY marketing",
-						{
-							tb: "person",
-						}
-				  )
-				: // The HTTP protocol cannot accept variables, so needs to test different
-				  await db.query(
-						"SELECT marketing, count() FROM person GROUP BY marketing"
-				  );
+		let groups = await db.query(
+			"SELECT marketing, count() FROM type::table($tb) GROUP BY marketing",
+			{
+				tb: "person",
+			}
+	    );
 
 		expect(groups[0].status).toBe("OK");
 		expect(groups[0].result).toEqualStringified([


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The http `/sql` not accepting variables was a misconception.

## What does this change do?

This PR implements support for variables alongside a query for the HTTP strategy's `.query()` method.
## What is your testing strategy?

Update test to also validate that the vars parameter works for both WS and HTTP strategies.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
