### PR TITLE
Implement `.insert()` method

### DIFF
--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -120,6 +120,7 @@ export class SurrealSocket {
 
 		const id = getIncrementalID();
 		this.queue[id] = callback;
+		console.log("message", JSON.stringify({ id, method, params }));
 		this.ws?.send(JSON.stringify({ id, method, params }));
 	}
 

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -303,6 +303,23 @@ export class WebSocketStrategy implements Connection {
 	}
 
 	/**
+	 * Inserts one or multiple records in the database.
+	 * @param thing - The table name or the specific record ID to create.
+	 * @param data - The document(s) / record(s) to insert.
+	 */
+	async insert<
+		T extends Record<string, unknown>,
+		U extends Record<string, unknown> = T,
+	>(thing: string, data?: U | U[]) {
+		await this.ready;
+		const res = await this.send<ActionResult<T, U>>("insert", [
+			thing,
+			data,
+		]);
+		return this.outputHandler(res);
+	}
+
+	/**
 	 * Updates all records in a table, or a specific record, in the database.
 	 *
 	 * ***NOTE: This function replaces the current document / record data with the specified data.***

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface Connection {
 	connect: (url: string, options?: ConnectionOptions) => void;
 	ping: () => Promise<void>;
 	use: (opt: { ns: string; db: string }) => MaybePromise<void>;
+
+	// Info method is not available in the HTTP REST API
 	info?: <T extends Record<string, unknown> = Record<string, unknown>>() =>
 		Promise<T | undefined>;
 
@@ -16,6 +18,7 @@ export interface Connection {
 	authenticate: (token: Token) => MaybePromise<void>;
 	invalidate: () => MaybePromise<void>;
 
+	// Let/unset methods are not available in the HTTP REST API
 	let?: (variable: string, value: unknown) => Promise<void>;
 	unset?: (variable: string) => Promise<void>;
 
@@ -34,6 +37,15 @@ export interface Connection {
 	>(
 		thing: string,
 		data?: U,
+	) => Promise<ActionResult<T, U>[]>;
+
+	// Insert method is not available in the HTTP REST API
+	insert?: <
+		T extends Record<string, unknown>,
+		U extends Record<string, unknown> = T,
+	>(
+		thing: string,
+		data?: U | U[],
 	) => Promise<ActionResult<T, U>[]>;
 
 	update: <


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The insert method was implemented in the websocket protocol to allow for batch inserting of data.

## What does this change do?

This pull request implements the `.insert()` method for the websocket strategy.

## What is your testing strategy?

To be implemented in a separate PR.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
