### PR TITLE
Implement `.live()` diff option

### DIFF
--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -222,13 +222,15 @@ export class WebSocketStrategy implements Connection {
 	 * Start a live query and listen for the responses
 	 * @param query - The query that you want to receive live results for.
 	 * @param callback - Callback function that receives updates.
+	 * @param diff - If set to true, will return a set of patches instead of complete records
 	 */
 	async live<T extends Record<string, unknown> = Record<string, unknown>>(
 		query: string,
 		callback?: (data: LiveQueryResponse<T>) => unknown,
+		diff?: boolean,
 	) {
 		await this.ready;
-		const res = await this.send<string>("live", [query]);
+		const res = await this.send<string>("live", [query, diff]);
 		if (res.error) throw new Error(res.error.message);
 		if (callback) this.listenLive<T>(res.result, callback);
 		return res.result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,27 +217,27 @@ export type UnprocessedLiveQueryResponse<
 //////////   PATCH TYPES   //////////
 /////////////////////////////////////
 
-type BasePatch = {
-	path: string;
+type BasePatch<T = string> = {
+	path: T;
 };
 
-export type AddPatch = BasePatch & {
+export type AddPatch<T = string, U = unknown> = BasePatch<T> & {
 	op: "add";
-	value: unknown;
+	value: U;
 };
 
-export type RemovePatch = BasePatch & {
+export type RemovePatch<T = string> = BasePatch<T> & {
 	op: "remove";
 };
 
-export type ReplacePatch = BasePatch & {
+export type ReplacePatch<T = string, U = unknown> = BasePatch<T> & {
 	op: "replace";
-	value: unknown;
+	value: U;
 };
 
-export type ChangePatch = BasePatch & {
+export type ChangePatch<T = string, U = string> = BasePatch<T> & {
 	op: "change";
-	value: string;
+	value: U;
 };
 
 export type Patch = AddPatch | RemovePatch | ReplacePatch | ChangePatch;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The websocket protocol introduced a new option to return changes in the form of patches instead of complete records.

## What does this change do?

This pull request implements the option to enable these patches.

## What is your testing strategy?

Will be done in a separate PR, live queries are not yet ready

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
