### PR TITLE
Fix the discussions link, again...

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or idea
-    url: https://github.com/surrealdb/discussions
+    url: https://github.com/orgs/surrealdb/discussions
     about: Ask questions and discuss ideas here.
   - name: Security issues
     url: https://surrealdb.com/legal/security


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The discussions link currently links to a non-existing page

## What does this change do?

It corrects the faulty link

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
