### PR TITLE
Add test for `.insert()`

### DIFF
--- a/test/e2e/shared.js
+++ b/test/e2e/shared.js
@@ -114,67 +114,85 @@ export default async (db) => {
 		expect(people).toEqualStringified([dataFilled["person:jaime"]]);
 	});
 
-	if (db.strategy === 'ws') await test("Live queries", async (expect) => {
-		let round = 0;
-		let responses = [
-			{
-				action: "CREATE",
-				result: {
-					id: "live_test:1"
-				}
-			},
-			{
-				action: "CREATE",
-				result: {
-					id: "live_test:2",
-					prop: 1,
-				}
-			},
-			{
-				action: "UPDATE",
-				result: {
-					id: "live_test:2",
-					prop: 2,
-				}
-			},
-			{
-				action: "DELETE",
-				result: "live_test:1"
-			},
-			{
-				action: "DELETE",
-				result: "live_test:2"
-			},
-		];
-
-		const uuid = await db.live('live_test', (data) => {
-			if (data.action !== 'CLOSE') {
-				expect(data).toEqualStringified(responses[round]);
-				round++;
-			}
+	if (db.strategy === 'ws') {
+		logger.debug("== Running WS specific tests ==");
+		await test("Insert a record", async (expect) => {
+			const record = { id: "insert_test:1" };
+			const inserted = await db.insert("insert_test", record);
+			expect(inserted).toEqualStringified([record])
 		});
 
-		// We need to wait a bit every time to ensure that we are processing the correct message
+		await test("Insert in bulk", async (expect) => {
+			const record1 = { id: "insert_bulk:1" };
+			const record2 = { id: "insert_bulk:2" };
+			const inserted = await db.insert("insert_bulk", [record1, record2]);
+			expect(inserted).toEqualStringified([record1, record2])
+		});
 
-		const wait = () => new Promise(r => setTimeout(r, 100))
+		await test("Live queries", async (expect) => {
+			let round = 0;
+			let responses = [
+				{
+					action: "CREATE",
+					result: {
+						id: "live_test:1"
+					}
+				},
+				{
+					action: "CREATE",
+					result: {
+						id: "live_test:2",
+						prop: 1,
+					}
+				},
+				{
+					action: "UPDATE",
+					result: {
+						id: "live_test:2",
+						prop: 2,
+					}
+				},
+				{
+					action: "DELETE",
+					result: "live_test:1"
+				},
+				{
+					action: "DELETE",
+					result: "live_test:2"
+				},
+			];
 
-		await db.create("live_test:1");
-		await wait();
+			const uuid = await db.live('live_test', (data) => {
+				if (data.action !== 'CLOSE') {
+					expect(data).toEqualStringified(responses[round]);
+					round++;
+				}
+			});
 
-		await db.create("live_test:2", { prop: 1 });
-		await wait();
+			// We need to wait a bit every time to ensure that we are processing the correct message
 
-		await db.update("live_test:2", { prop: 2 });
-		await wait();
+			const wait = () => new Promise(r => setTimeout(r, 100))
 
-		await db.delete("live_test:1");
-		await wait();
+			await db.create("live_test:1");
+			await wait();
 
-		await db.delete("live_test:2");
-		await wait();
+			await db.create("live_test:2", { prop: 1 });
+			await wait();
 
-		await db.kill(uuid);
-	});
+			await db.update("live_test:2", { prop: 2 });
+			await wait();
+
+			await db.delete("live_test:1");
+			await wait();
+
+			await db.delete("live_test:2");
+			await wait();
+
+			await db.kill(uuid);
+		});
+
+		logger.debug("== Finished WS specific tests ==");
+	}
 
 	// !!!! WARNING: The scope tests musts always be last because we change auth
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `.insert()` method is currently not being tested

## What does this change do?

It adds tests for the `.insert()` method.

## What is your testing strategy?

- Add a test to insert a single record
- Add a test to test bulk insert of records

## Is this related to any issues?

Not directly, but the `.insert()` method is currently not being test which is an issue.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
