### PR TITLE
fix: stringify all variables

### DIFF
--- a/project.json
+++ b/project.json
@@ -1,4 +1,4 @@
 {
   "name": "surrealdb.js",
-  "version": "0.9.1"
+  "version": "0.9.0"
 }

--- a/project.json
+++ b/project.json
@@ -1,4 +1,4 @@
 {
   "name": "surrealdb.js",
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -181,7 +181,7 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 					Object.fromEntries(
 						Object.entries(vars).map(([k, v]) => [
 							k,
-							typeof v == "object" ? JSON.stringify(v) : `${v}`,
+							JSON.stringify(v),
 						]),
 					),
 				),


### PR DESCRIPTION
## What is the motivation?

Query variables are not working when using HTTP strategy. This change unblocks being able to use HTTP strategy in next-auth (https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-surrealdb/tests/rest.test.ts).

## What does this change do?

Stringifies all types of variables, not only objects.

## What is your testing strategy?

Without the change, this doesn't work as expected (i.e. with the socket strategy).

```typescript
const sessions = await surreal.query<[SessionDoc<UserDoc>[]]>(
  `SELECT *
   FROM session
   WHERE sessionToken = $sessionToken
   FETCH userId`,
  { sessionToken }
)
```

This works, but is not how it's supposed to:

```typescript
const sessions = await surreal.query<[SessionDoc<UserDoc>[]]>(
  `SELECT *
   FROM session
   WHERE sessionToken = $sessionToken
   FETCH userId`,
  { sessionToken: `"${sessionToken}"` } // or JSON.stringify(sessionToken)
)
```

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)

CONTRIBUTING.md file doesn't exist :'(