### PR TITLE
Always forward rejection, no matter the error type

### DIFF
--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -68,12 +68,10 @@ export class SurrealSocket {
 			});
 
 			ws.addEventListener("error", (e) => {
-				if (e instanceof ErrorEvent) {
-					this.status = WebsocketStatus.CLOSED;
-					if (!resolved) {
-						resolved = true;
-						reject(e.error);
-					}
+				this.status = WebsocketStatus.CLOSED;
+				if (!resolved) {
+					resolved = true;
+					reject('error' in e ? e.error : e.toString());
 				}
 			});
 		});

--- a/src/library/SurrealSocket.ts
+++ b/src/library/SurrealSocket.ts
@@ -71,7 +71,7 @@ export class SurrealSocket {
 				this.status = WebsocketStatus.CLOSED;
 				if (!resolved) {
 					resolved = true;
-					reject('error' in e ? e.error : e.toString());
+					reject("error" in e ? e.error : e.toString());
 				}
 			});
 		});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

#172 

## What does this change do?

Websocket errors are now always forwarded, no matter the error type. This also fixes #172 

## What is your testing strategy?

N/A

## Is this related to any issues?

fixes #172 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
