### PR TITLE
Change tests so that `.authenticate()` is tested for both scope and root users

### DIFF
--- a/test/e2e/shared.js
+++ b/test/e2e/shared.js
@@ -75,9 +75,20 @@ export default async (db) => {
 	logger.debug(`Select NS "test", DB "test-${rand}"`);
 	await db.use({ namespace: "test", database: `test-${rand}` });
 
-	await db.signin({
-		username: "root",
-		password: "root",
+	await test("Root authentication", async (expect) => {
+		const token = await db.signin({
+			username: "root",
+			password: "root",
+		});
+
+		expect(typeof token).toBe('string');
+
+		const res = await new Promise((r) => r(db.authenticate(token))).catch((e) => {
+			console.error(e);
+			return false;
+		});
+
+		expect(res).toBe(true);
 	});
 
 	await test("Create a new person with a specific id", async (expect) => {
@@ -258,6 +269,13 @@ export default async (db) => {
 		});
 
 		expect(typeof token).toBe('string');
+
+		const res = await new Promise((r) => r(db.authenticate(token))).catch((e) => {
+			console.error(e);
+			return false;
+		});
+
+		expect(res).toBe(true);
 
 		const [{ username }] = await db.select('user');
 		expect(username).toBe('johndoe');


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #180

## What does this change do?

It changes the tests so that `.authenticate()` method is tested for both scope and root users

## What is your testing strategy?

See above

## Is this related to any issues?

invalidates #180 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
