### PR TITLE
Status hooks

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { z } from "npm:zod@^3.22.4";
 
 export type ConnectionStrategy = "websocket" | "experimental_http";
 export interface Connection {
-	constructor: Constructor<() => void>;
+	constructor: Constructor<(hooks: StatusHooks) => void>;
 
 	strategy: "ws" | "http";
 	connect: (url: string, options?: ConnectionOptions) => void;
@@ -83,6 +83,12 @@ export interface Connection {
 		thing: string,
 	) => Promise<ActionResult<T>[]>;
 }
+
+export type StatusHooks = {
+	onConnect?: () => unknown;
+	onClose?: () => unknown;
+	onError?: () => unknown;
+};
 
 export const UseOptions = z.object({
 	namespace: z.coerce.string(),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There was no way to listen for connection closure.

## What does this change do?

This PR allows you to pass the `onConnect`, `onClose` and `onError` methods to the constructor of the `Surreal` class. These hooks will be reused across all socket connections.

## What is your testing strategy?

Ensure tests still pass

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
