### PR TITLE
Tagged template literals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,6 @@ import { HTTPStrategy } from "./strategies/http.ts";
 export { WebSocketStrategy as Surreal, WebSocketStrategy as SurrealWebSocket };
 export { HTTPStrategy as ExperimentalSurrealHTTP };
 export default WebSocketStrategy;
+
+export { PreparedQuery } from "./library/PreparedQuery.ts";
+export { surrealql, surql } from "./library/tagged-template.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export { HTTPStrategy as ExperimentalSurrealHTTP };
 export default WebSocketStrategy;
 
 export { PreparedQuery } from "./library/PreparedQuery.ts";
-export { surrealql, surql } from "./library/tagged-template.ts";
+export { surql, surrealql } from "./library/tagged-template.ts";

--- a/src/library/PreparedQuery.ts
+++ b/src/library/PreparedQuery.ts
@@ -1,0 +1,9 @@
+export class PreparedQuery {
+	public readonly query: string = '';
+	public readonly bindings: Record<string, unknown> = {};
+
+	constructor(query: string, bindings?: Record<string, unknown>) {
+		this.query = query;
+		if (bindings) this.bindings = bindings;
+	}
+}

--- a/src/library/PreparedQuery.ts
+++ b/src/library/PreparedQuery.ts
@@ -1,5 +1,5 @@
 export class PreparedQuery {
-	public readonly query: string = '';
+	public readonly query: string = "";
 	public readonly bindings: Record<string, unknown> = {};
 
 	constructor(query: string, bindings?: Record<string, unknown>) {

--- a/src/library/tagged-template.ts
+++ b/src/library/tagged-template.ts
@@ -1,0 +1,23 @@
+import { PreparedQuery } from "./PreparedQuery.ts";
+
+export function surrealql(query_raw: string[], ...values: unknown[]) {
+	const mapped_bindings = values.map((v, i) => [`__tagged_template_literal_binding__${i}`, v] as const);
+	const bindings = mapped_bindings.reduce((prev, [k, v]) => ({
+		...prev,
+		[k]: v
+	}), {});
+
+	const query = query_raw
+		.flatMap((segment, i) => {
+			const variable = mapped_bindings[i]?.[0];
+			return [
+				segment,
+				...(variable ? [`$${variable}`] : [])
+			]
+		})
+		.join('');
+
+	return new PreparedQuery(query, bindings);
+}
+
+export { surrealql as surql };

--- a/src/library/tagged-template.ts
+++ b/src/library/tagged-template.ts
@@ -1,10 +1,12 @@
 import { PreparedQuery } from "./PreparedQuery.ts";
 
 export function surrealql(query_raw: string[], ...values: unknown[]) {
-	const mapped_bindings = values.map((v, i) => [`__tagged_template_literal_binding__${i}`, v] as const);
+	const mapped_bindings = values.map((v, i) =>
+		[`__tagged_template_literal_binding__${i}`, v] as const
+	);
 	const bindings = mapped_bindings.reduce((prev, [k, v]) => ({
 		...prev,
-		[k]: v
+		[k]: v,
 	}), {});
 
 	const query = query_raw
@@ -12,10 +14,10 @@ export function surrealql(query_raw: string[], ...values: unknown[]) {
 			const variable = mapped_bindings[i]?.[0];
 			return [
 				segment,
-				...(variable ? [`$${variable}`] : [])
-			]
+				...(variable ? [`$${variable}`] : []),
+			];
 		})
-		.join('');
+		.join("");
 
 	return new PreparedQuery(query, bindings);
 }

--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -194,7 +194,7 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 		query: string | PreparedQuery,
 		bindings?: Record<string, unknown>,
 	) {
-		if (typeof query !== 'string') {
+		if (typeof query !== "string") {
 			bindings = bindings ?? {};
 			bindings = { ...bindings, ...query.bindings };
 			query = query.query;

--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -1,4 +1,5 @@
 import { NoConnectionDetails } from "../errors.ts";
+import { PreparedQuery } from "../index.ts";
 import { SurrealHTTP } from "../library/SurrealHTTP.ts";
 import { processAuthVars } from "../library/processAuthVars.ts";
 import {
@@ -171,13 +172,13 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	/**
 	 * Runs a set of SurrealQL statements against the database.
 	 * @param query - Specifies the SurrealQL statements.
-	 * @param vars - Assigns variables which can be used in the query.
+	 * @param bindings - Assigns variables which can be used in the query.
 	 */
 	async query<T extends RawQueryResult[]>(
-		query: string,
-		vars?: Record<string, unknown>,
+		query: string | PreparedQuery,
+		bindings?: Record<string, unknown>,
 	) {
-		const raw = await this.query_raw<T>(query, vars);
+		const raw = await this.query_raw<T>(query, bindings);
 		return raw.map(({ status, result, detail }) => {
 			if (status == "ERR") throw new Error(detail ?? result);
 			return result;
@@ -187,21 +188,27 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 	/**
 	 * Runs a set of SurrealQL statements against the database.
 	 * @param query - Specifies the SurrealQL statements.
-	 * @param vars - Assigns variables which can be used in the query.
+	 * @param bindings - Assigns variables which can be used in the query.
 	 */
 	async query_raw<T extends RawQueryResult[]>(
-		query: string,
-		vars?: Record<string, unknown>,
+		query: string | PreparedQuery,
+		bindings?: Record<string, unknown>,
 	) {
+		if (typeof query !== 'string') {
+			bindings = bindings ?? {};
+			bindings = { ...bindings, ...query.bindings };
+			query = query.query;
+		}
+
 		await this.ready;
 		const res = await this.request<InvalidSQL | MapQueryResult<T>>("/sql", {
 			body: query,
 			plainBody: true,
 			method: "POST",
-			searchParams: vars &&
+			searchParams: bindings &&
 				new URLSearchParams(
 					Object.fromEntries(
-						Object.entries(vars).map(([k, v]) => [
+						Object.entries(bindings).map(([k, v]) => [
 							k,
 							JSON.stringify(v),
 						]),

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -1,4 +1,5 @@
 import { NoActiveSocket, UnexpectedResponse } from "../errors.ts";
+import { PreparedQuery } from "../index.ts";
 import { Pinger } from "../library/Pinger.ts";
 import { SurrealSocket } from "../library/SurrealSocket.ts";
 import { processAuthVars } from "../library/processAuthVars.ts";
@@ -298,13 +299,13 @@ export class WebSocketStrategy implements Connection {
 	/**
 	 * Runs a set of SurrealQL statements against the database.
 	 * @param query - Specifies the SurrealQL statements.
-	 * @param vars - Assigns variables which can be used in the query.
+	 * @param bindings - Assigns variables which can be used in the query.
 	 */
 	async query<T extends RawQueryResult[]>(
-		query: string,
-		vars?: Record<string, unknown>,
+		query: string | PreparedQuery,
+		bindings?: Record<string, unknown>,
 	) {
-		const raw = await this.query_raw<T>(query, vars);
+		const raw = await this.query_raw<T>(query, bindings);
 		return raw.map(({ status, result, detail }) => {
 			if (status == "ERR") throw new Error(detail ?? result);
 			return result;
@@ -314,14 +315,20 @@ export class WebSocketStrategy implements Connection {
 	/**
 	 * Runs a set of SurrealQL statements against the database.
 	 * @param query - Specifies the SurrealQL statements.
-	 * @param vars - Assigns variables which can be used in the query.
+	 * @param bindings - Assigns variables which can be used in the query.
 	 */
 	async query_raw<T extends RawQueryResult[]>(
-		query: string,
-		vars?: Record<string, unknown>,
+		query: string | PreparedQuery,
+		bindings?: Record<string, unknown>,
 	) {
+		if (typeof query !== 'string') {
+			bindings = bindings ?? {};
+			bindings = { ...bindings, ...query.bindings };
+			query = query.query;
+		}
+
 		await this.ready;
-		const res = await this.send<MapQueryResult<T>>("query", [query, vars]);
+		const res = await this.send<MapQueryResult<T>>("query", [query, bindings]);
 		if (res.error) throw new Error(res.error.message);
 		return res.result;
 	}

--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -321,14 +321,17 @@ export class WebSocketStrategy implements Connection {
 		query: string | PreparedQuery,
 		bindings?: Record<string, unknown>,
 	) {
-		if (typeof query !== 'string') {
+		if (typeof query !== "string") {
 			bindings = bindings ?? {};
 			bindings = { ...bindings, ...query.bindings };
 			query = query.query;
 		}
 
 		await this.ready;
-		const res = await this.send<MapQueryResult<T>>("query", [query, bindings]);
+		const res = await this.send<MapQueryResult<T>>("query", [
+			query,
+			bindings,
+		]);
 		if (res.error) throw new Error(res.error.message);
 		return res.result;
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { z } from "npm:zod@^3.22.4";
+import { PreparedQuery } from "./index.ts";
 
 export type ConnectionStrategy = "websocket" | "experimental_http";
 export interface Connection {
@@ -35,13 +36,13 @@ export interface Connection {
 	kill?: (queryUuid: string) => Promise<void>;
 
 	query: <T extends RawQueryResult[]>(
-		query: string,
-		vars?: Record<string, unknown>,
+		query: string | PreparedQuery,
+		bindings?: Record<string, unknown>,
 	) => Promise<T>;
 
 	query_raw: <T extends RawQueryResult[]>(
-		query: string,
-		vars?: Record<string, unknown>,
+		query: string | PreparedQuery,
+		bindings?: Record<string, unknown>,
 	) => Promise<MapQueryResult<T>>;
 
 	select: <T extends Record<string, unknown>>(

--- a/test/e2e/bun.js
+++ b/test/e2e/bun.js
@@ -1,4 +1,5 @@
 import Surreal, { ExperimentalSurrealHTTP } from "../../npm/esm/index.js";
+import * as exports from "../../npm/esm/index.js";
 import handler from "./shared.js";
 import fetch from 'node-fetch';
 
@@ -9,10 +10,10 @@ await ws.connect("http://127.0.0.1:8000");
 await http.connect("http://127.0.0.1:8000");
 
 console.log("\n Testing Websocket");
-await handler(ws);
+await handler(ws, exports);
 
 console.log("\n Testing HTTP");
-await handler(http);
+await handler(http, exports);
 
 ws.close();
 http.close();

--- a/test/e2e/deno.js
+++ b/test/e2e/deno.js
@@ -1,4 +1,5 @@
 import Surreal, { ExperimentalSurrealHTTP } from "../../src/index.ts";
+import * as exports from "../../src/index.ts";
 import handler from "./shared.js";
 
 const ws = new Surreal();
@@ -8,10 +9,10 @@ await ws.connect("http://127.0.0.1:8000");
 await http.connect("http://127.0.0.1:8000");
 
 console.log("\n Testing Websocket");
-await handler(ws);
+await handler(ws, exports);
 
 console.log("\n Testing HTTP");
-await handler(http);
+await handler(http, exports);
 
 ws.close();
 http.close();

--- a/test/e2e/node.js
+++ b/test/e2e/node.js
@@ -1,4 +1,5 @@
 import Surreal, { ExperimentalSurrealHTTP } from "../../npm/esm/index.js";
+import * as exports from "../../npm/esm/index.js";
 import handler from "./shared.js";
 import fetch from 'node-fetch';
 
@@ -9,10 +10,10 @@ await ws.connect("http://127.0.0.1:8000");
 await http.connect("http://127.0.0.1:8000");
 
 console.log("\n Testing Websocket");
-await handler(ws);
+await handler(ws, exports);
 
 console.log("\n Testing HTTP");
-await handler(http);
+await handler(http, exports);
 
 ws.close();
 http.close();

--- a/test/e2e/shared.js
+++ b/test/e2e/shared.js
@@ -1,3 +1,5 @@
+import { surrealql, PreparedQuery } from "../../npm/esm/index.js";
+
 const logger = {
 	error(...args) {
 		console.error("TEST ERROR: ", ...args);
@@ -179,6 +181,29 @@ export default async (db) => {
 			expect(e.message).toBe("An error occurred: example error");
 		}
 	});
+
+	await test("Prepared queries and tagged templates", async (expect) => {
+		const name = "John Doe";
+		const age = 44;
+
+		{
+			const query = new PreparedQuery(
+				/* surql */`RETURN $name; RETURN $age`,
+				{ name, age }
+			);
+
+			const res = await db.query(query);
+			expect(res).toEqualStringified([name, age]);
+		};
+
+		{
+			const res = await db.query(
+				surrealql`RETURN ${name}; RETURN ${age}`
+			);
+
+			expect(res).toEqualStringified([name, age]);
+		};
+	})
 
 	if (db.strategy === 'ws') {
 		logger.debug("== Running WS specific tests ==");

--- a/test/e2e/shared.js
+++ b/test/e2e/shared.js
@@ -1,5 +1,3 @@
-import { surrealql, PreparedQuery } from "../../npm/esm/index.js";
-
 const logger = {
 	error(...args) {
 		console.error("TEST ERROR: ", ...args);
@@ -68,7 +66,7 @@ async function test(name, cb) {
 /**
  * @type{(a: import('../../src/index.ts').default) => void}
  */
-export default async (db) => {
+export default async (db, { surrealql, PreparedQuery }) => {
 	logger.debug("Signin as a namespace, database, or root user");
 
 	// We need a random database because some tests depend on row count.


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #185 

## What does this change do?

- It exposes a `PreparedQuery` class which can be passed to the `.query()` and `.query_raw()` methods.
- It exposes a `surrealql` (and `surql` as a shortcut) function which can be used as a tagged template literal

```js
const name = "John Doe";
const age = 44;

// With PreparedQuery
const query = new PreparedQuery(
	/* surql */`RETURN $name; RETURN $age`,
	{ name, age }
);

const prepared = await db.query(query);

// With a tagged template literal
const templated = await db.query(
	surrealql`RETURN ${name}; RETURN ${age}`
);
```

## What is your testing strategy?

Added tests to test both

## Is this related to any issues?

Fixes #185 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
