### PR TITLE
Fix broken types

### DIFF
--- a/src/strategies/http.ts
+++ b/src/strategies/http.ts
@@ -331,7 +331,7 @@ export class HTTPStrategy<TFetcher = typeof fetch> implements Connection {
 		return res.result;
 	}
 
-	protected get request() {
+	protected get request(): SurrealHTTP<TFetcher>["request"] {
 		if (!this.http) throw new NoConnectionDetails();
 		return this.http.request.bind(this.http);
 	}


### PR DESCRIPTION
## What is the motivation?

Types are currently broken resulting `.status` and `.result` to be unavailable when library is used when using TypeScript 5.3.2.

![image](https://github.com/surrealdb/surrealdb.js/assets/65633/5ea2ab5b-2c75-41ed-8921-8b3330622748)

## What does this change do?

Fixes the types.

## What is your testing strategy?

Verifying with TypeScript.

## Is this related to any issues?

* https://github.com/sebastianwessel/surrealdb-client-generator/issues/3

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
