### PR TITLE
select.ts limit,start fix

### DIFF
--- a/src/library/orm/builder/select.ts
+++ b/src/library/orm/builder/select.ts
@@ -91,7 +91,7 @@ export class SelectQuery<
 		}
 
 		if (start) query += /* surql */ ` START $${start}`;
-		if (start) query += /* surql */ ` LIMIT $${limit}`;
+		if (limit) query += /* surql */ ` LIMIT $${limit}`;
 
 		return query;
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Obvious possibility of having the query fail

## What does this change do?

Fixes the `limit` parameter check that erroneously looks at `start`

## What is your testing strategy?

obviously passing start parameter will also trigger limit which can be undefined

## Is this related to any issues?

not seen

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
