### PR TITLE
fix: reject send promise upon catching inner error

### DIFF
--- a/src/strategies/websocket.ts
+++ b/src/strategies/websocket.ts
@@ -449,9 +449,11 @@ export class WebSocketStrategy implements Connection {
 		method: string,
 		params?: unknown[],
 	) {
-		return new Promise<U>((resolve) => {
+		return new Promise<U>((resolve, reject) => {
 			if (!this.socket) throw new NoActiveSocket();
-			this.socket.send(method, params ?? [], (r) => resolve(r as U));
+			this.socket
+				.send(method, params ?? [], (r) => resolve(r as U))
+				.catch((e) => reject(e));
 		});
 	}
 


### PR DESCRIPTION
## What is the motivation?
Currently, errors that occur within `SurrealSocket.send()` are not surfaced properly, making them uncatchable. This leads to issues such as crashing a user's program if an error occurs, without letting them re-establish the database connection or continue execution gracefully.

## What does this change do?
This PR catches any inner errors, upon which the outer `send()` promise is rejected with the subsequent error. This allows for the error to be surfaced and caught.

## What is your testing strategy?
I tested this change by running an infinite loop that would try to insert data into a running in-memory SurrealDB instance. The insert statement was surrounded by a try/catch block which would break the loop upon catching any errors and print a console.log message. While the loop was running, I would stop the SurrealDB instance and observe the results in the terminal. Before the change, the program would simply crash with the uncaught error. After the change, the loop would break gracefully and the console.log would be displayed, indicating the error had been caught and handled as expected. I also tried having the database re-establish the connection after a 5 second timeout instead of breaking the loop, where I would restart the database instance before the timeout would end. When doing this, the loop started running again, successfully inserting data.

## Is this related to any issues?
These changes are related to #203. Ths PR does nothing directly to re-establish the database connection upon losing it, but it does surface otherwise uncatchable errors, allowing for the user to manually re-establish the connection.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [✓] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
