### PR TITLE
fix: allow TemplateStringsArray as argument to `surrealql()`

### DIFF
--- a/src/library/tagged-template.ts
+++ b/src/library/tagged-template.ts
@@ -1,6 +1,6 @@
 import { PreparedQuery } from "./PreparedQuery.ts";
 
-export function surrealql(query_raw: string[], ...values: unknown[]) {
+export function surrealql(query_raw: string[] | TemplateStringsArray, ...values: unknown[]) {
 	const mapped_bindings = values.map((v, i) =>
 		[`__tagged_template_literal_binding__${i}`, v] as const
 	);

--- a/src/library/tagged-template.ts
+++ b/src/library/tagged-template.ts
@@ -1,6 +1,9 @@
 import { PreparedQuery } from "./PreparedQuery.ts";
 
-export function surrealql(query_raw: string[] | TemplateStringsArray, ...values: unknown[]) {
+export function surrealql(
+	query_raw: string[] | TemplateStringsArray,
+	...values: unknown[]
+) {
 	const mapped_bindings = values.map((v, i) =>
 		[`__tagged_template_literal_binding__${i}`, v] as const
 	);


### PR DESCRIPTION
## What is the motivation?

Currently, calling `surrealql` as a tagged function gives a TypeScript error complaining about the argument type of 'TemplateStringsArray` not being assignable to the parameter type of 'string[]'

## What does this change do?

This change adds 'TemplateStringsArray' as a valid argument type to the `surrealql` function. It does not remove 'string[]' as a valid argument, and thus should not be breaking for any existing usage of the function. As `surrealql` does not make use of any properties specific to either 'TemplateStringsArray' or 'string[]', there should be no conflict in allowing both argument types.

## What is your testing strategy?

I imported the package from the change branch in a test project and observed that the error no longer was shown when calling `surrealql` as a tagged function. I also checked that the function still accepted an argument of type 'string[]'.

## Is this related to any issues?

Related to #221

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [✓] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
