### PR TITLE
Fix sending too many fields on auth vars

### DIFF
--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -388,8 +388,8 @@ export class Surreal {
 		bindings?: Record<string, unknown>,
 	) {
 		const raw = await this.query_raw<T>(query, bindings);
-		return raw.map(({ status, result, detail }) => {
-			if (status == "ERR") throw new ResponseError(detail ?? result);
+		return raw.map(({ status, result }) => {
+			if (status == "ERR") throw new ResponseError(result);
 			return result;
 		});
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,14 +126,12 @@ export type QueryResultOk<T> = {
 	status: "OK";
 	time: string;
 	result: T;
-	detail?: never;
 };
 
 export type QueryResultErr = {
 	status: "ERR";
 	time: string;
-	result?: never;
-	detail: string;
+	result: string;
 };
 
 export type MapQueryResult<T> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,12 +85,21 @@ export const TransformAuth = z.union([
 		database,
 		username,
 		password,
-	}) => ({
-		ns: namespace,
-		db: database,
-		user: username,
-		pass: password,
-	})),
+	}) => {
+		const vars: Record<string, unknown> = {
+			user: username,
+			pass: password,
+		};
+
+		if (namespace) {
+			vars.ns = namespace;
+			if (database) {
+				vars.db = database;
+			}
+		}
+
+		return vars;
+	}),
 	z.object({
 		namespace: z.string(),
 		database: z.string(),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

We were sending too many fields on auth vars, causing signin to silently fail. Additionally, we were checking for a `detail` field for errors, while it was simply `result`

## What does this change do?

Fixes above

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
