### PR TITLE
fix: forgot type in constructor for some geometry classes

### DIFF
--- a/src/library/cbor/geometry.ts
+++ b/src/library/cbor/geometry.ts
@@ -48,7 +48,7 @@ export class GeometryPolygon extends Geometry {
 export class GeometryMultiPoint extends Geometry {
 	readonly points: [GeometryPoint, ...GeometryPoint[]];
 
-	constructor(points: [GeometryPoint, ...GeometryPoint[]]) {
+	constructor(points: [GeometryPoint, ...GeometryPoint[]] | GeometryMultiPoint) {
 		super();
 		points = points instanceof GeometryMultiPoint ? points.points : points;
 		this.points = points.map((point) => new GeometryPoint(point)) as [
@@ -61,7 +61,7 @@ export class GeometryMultiPoint extends Geometry {
 export class GeometryMultiLine extends Geometry {
 	readonly lines: [GeometryLine, ...GeometryLine[]];
 
-	constructor(lines: [GeometryLine, ...GeometryLine[]]) {
+	constructor(lines: [GeometryLine, ...GeometryLine[]] | GeometryMultiLine) {
 		super();
 		lines = lines instanceof GeometryMultiLine ? lines.lines : lines;
 		this.lines = lines.map((line) => new GeometryLine(line)) as [
@@ -74,7 +74,7 @@ export class GeometryMultiLine extends Geometry {
 export class GeometryMultiPolygon extends Geometry {
 	readonly polygons: [GeometryPolygon, ...GeometryPolygon[]];
 
-	constructor(polygons: [GeometryPolygon, ...GeometryPolygon[]]) {
+	constructor(polygons: [GeometryPolygon, ...GeometryPolygon[]] | GeometryMultiPolygon) {
 		super();
 		polygons = polygons instanceof GeometryMultiPolygon
 			? polygons.polygons
@@ -89,7 +89,7 @@ export class GeometryMultiPolygon extends Geometry {
 export class GeometryCollection extends Geometry {
 	readonly collection: [Geometry, ...Geometry[]];
 
-	constructor(collection: [Geometry, ...Geometry[]]) {
+	constructor(collection: [Geometry, ...Geometry[]] | GeometryCollection) {
 		super();
 		collection = collection instanceof GeometryCollection
 			? collection.collection


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When I was reading the code I noticed a few forgotten types that were checked with `instanceof` inside the constructor.

## What does this change do?

Make sure it accepts the missing type as an argument.

## What is your testing strategy?

Before the change when you instantiated a new GeometryCollection with the given argument of another GeometryCollection instance that already exists. The error that typescript gives is:
`Argument of type 'GeometryCollection' is not assignable to parameter of type '[Geometry, ...Geometry[]]'`

After the change the argument accepts a other GeometryCollection class.

The following classes had the same forgotten type issue:
- GeometryMultiLine
- GeometryMultiPolygon
- GeometryCollection 

## Is this related to any issues?

There are no related issues.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
