### PR TITLE
Fix broken .info() type

### DIFF
--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -197,7 +197,7 @@ export class Surreal {
 	 * Make sure the user actually has the permission to select their own record, otherwise you'll get back an empty result.
 	 * @return The record linked to the record ID used for authentication
 	 */
-	async info<T extends Record<string, unknown> = Record<string, unknown>>() {
+	async info<T extends R>(): Promise<ActionResult<T> | undefined> {
 		await this.ready;
 		const res = await this.rpc<ActionResult<T> | undefined>("info");
 		if (res.error) throw new ResponseError(res.error.message);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The type that would be generated for the `.info()` method was faulty.

## What does this change do?

We now manually set the type for `.info()`, causing it not be broken.

## What is your testing strategy?

Ensure all tests still pass

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
