### PR TITLE
Improve status handling

### DIFF
--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -127,16 +127,17 @@ export class WebsocketEngine implements Engine {
 		});
 
 		this.ready = ready;
-		return await ready.finally(() => {
+		return await ready.then(() => {
 			this.socket = socket;
 		});
 	}
 
 	async disconnect(): Promise<void> {
 		this.connection = {};
-		await this.ready;
-		if (!this.socket) throw new ConnectionUnavailable();
-		await this.socket.close();
+		await this.ready?.catch(() => {});
+		await this.socket?.close();
+		this.ready = undefined;
+		this.socket = undefined;
 	}
 
 	async rpc<


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Trying to disconnect or reconnect from a failed connection via the WebsocketEngine would throw the error of the previous failed connection. Additionally, because `ready` and `status` props were optional on the abstract `Engine` class, they were not implemented everywhere.

## What does this change do?

The `.disconnect()` method now suppresses any thrown errors from the previous ready state and simply discards the socket and ready state.

## What is your testing strategy?

Ensure tests pass

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
