### PR TITLE
feature: add optional `flatMode` flag to flatten surrealdb responses to plain js objects

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,14 @@
+class Config {
+	private _flatMode: boolean = false;
+
+	get flatMode(): boolean {
+		return this._flatMode;
+	}
+
+	set flatMode(value: boolean) {
+		this._flatMode = value;
+	}
+}
+
+const config = new Config();
+export default config;

--- a/src/library/flatten.ts
+++ b/src/library/flatten.ts
@@ -1,0 +1,27 @@
+import { RecordId } from "./cbor/recordid.ts";
+
+/**
+ * Recursively converts CBOR class instances into a JavaScript object format.
+ *
+ * @param {T} obj - The object or array to be flattened to a JavaScript object.
+ * @return {T} The flattened JavaScript object or array.
+ */
+export function flatten<T>(obj: T): T {
+	if (Array.isArray(obj)) {
+		return obj.map(flatten) as unknown as T;
+	} else if (obj !== null && typeof obj === "object") {
+		if (obj instanceof RecordId) {
+			return obj.toJSON() as unknown as T;
+		}
+
+		const flat = {} as T;
+		for (const key in obj) {
+			// deno-lint-ignore no-explicit-any
+			(flat as any)[key] = flatten((obj as any)[key]);
+		}
+
+		return flat;
+	}
+
+	return obj;
+}

--- a/tests/integration/surreal.ts
+++ b/tests/integration/surreal.ts
@@ -14,16 +14,18 @@ declare global {
 export async function createSurreal({
 	protocol,
 	auth,
+	flatMode,
 }: {
 	protocol?: Protocol;
 	auth?: PremadeAuth;
+	flatMode?: boolean;
 } = {}) {
 	protocol = protocol
 		? protocol
 		: "protocol" in globalThis
-		? globalThis.protocol as Protocol
+		? (globalThis.protocol as Protocol)
 		: "ws";
-	const surreal = new Surreal();
+	const surreal = new Surreal({ flatMode });
 	await surreal.connect(`${protocol}://127.0.0.1:${SURREAL_PORT}/rpc`, {
 		namespace: SURREAL_NS,
 		database: SURREAL_DB,

--- a/tests/integration/tests/auth.ts
+++ b/tests/integration/tests/auth.ts
@@ -4,6 +4,7 @@ import { createSurreal } from "../surreal.ts";
 
 import { assertEquals } from "https://deno.land/std@0.223.0/assert/mod.ts";
 import { RecordId, ResponseError } from "../../../mod.ts";
+import { flatten } from "../../../src/library/flatten.ts";
 
 Deno.test("root signin", async () => {
 	const surreal = await createSurreal();
@@ -26,14 +27,12 @@ Deno.test("invalid credentials", async () => {
 Deno.test("scope signup/signin/info", async () => {
 	const surreal = await createSurreal();
 
-	await surreal.query(
-		/* surql */ `
+	await surreal.query(/* surql */ `
 			DEFINE TABLE user PERMISSIONS FOR select WHERE id = $auth;
 			DEFINE SCOPE user
 				SIGNUP ( CREATE type::thing('user', $id) )
 				SIGNIN ( SELECT * FROM type::thing('user', $id) );
-		`,
-	);
+		`);
 
 	{
 		const signup = await surreal.signup({
@@ -56,6 +55,45 @@ Deno.test("scope signup/signin/info", async () => {
 	{
 		const info = await surreal.info<{ id: RecordId<"user"> }>();
 		assertEquals(info, { id: new RecordId("user", 123) }, "scope info");
+	}
+
+	await surreal.close();
+});
+Deno.test("scope signup/signin/info - flatMode", async () => {
+	const surreal = await createSurreal({ flatMode: true });
+
+	await surreal.query(/* surql */ `
+			DEFINE TABLE user PERMISSIONS FOR select WHERE id = $auth;
+			DEFINE SCOPE user
+				SIGNUP ( CREATE type::thing('user', $id) )
+				SIGNIN ( SELECT * FROM type::thing('user', $id) );
+		`);
+
+	{
+		const signup = await surreal.signup({
+			scope: "user",
+			id: 1234,
+		});
+
+		assertEquals(typeof signup, "string", "scope signin");
+	}
+
+	{
+		const signin = await surreal.signin({
+			scope: "user",
+			id: 1234,
+		});
+
+		assertEquals(typeof signin, "string", "scope signin");
+	}
+
+	{
+		const info = await surreal.info<{ id: RecordId<"user"> }>();
+		assertEquals(
+			info,
+			flatten({ id: new RecordId("user", 1234) }),
+			"scope info",
+		);
 	}
 
 	await surreal.close();


### PR DESCRIPTION
## What is the motivation?

Switching from `JSON` to `CBOR` and the subsequent introduction of classes such as `RecordId` significantly lowers the DX in its current form, for example, when working with frameworks like SvelteKit. SvelteKit only supports data transmission between the server and the client in JSON format, and attempting to send the current response from SurrealDB will result in an error Error: Data returned from 'load' while rendering / is not serializable: Cannot stringify arbitrary non-POJOs.

The `toJSON()` method available in the RecordId class solves this problem, but it does not improve DX because before any data can be sent, it must first be destructured and the method used in all occurrences of `RecordId`.


## What does this change do?

This change introduces an optional `flatMode` flag in the constructor of the `Surreal` class. When `flatMode: true`, all responses from SurrealDB that may contain RecordId are recursively flattened into a JavaScript object format via the flatten() function.

Creating new instances:
Regular: `new Surreal()`
flatMode: `new Surreal({ flatMode: true })`

Example Outputs:
Regular: 
```js
{
   id: RecordId {
      tb: "person", 
      id: 1
   },
   firstname: "John",
   lastname: "Doe",
   age: 30,
},
```
flatMode: 
```js
{
   id: {
      tb: "person", 
      id: 1
   },
   firstname: "John",
   lastname: "Doe",
   age: 30,
},
```
## What is your testing strategy?

I added tests based on existing ones, each test includes the suffix ` - flatMode`. I also compared the performance between the `query` and `query - flatMode` tests, which show a performance difference of less than `1ms`.

## Is this related to any issues?

#247

Related to, but this is partial or alternative solution for #241 #242 

Also I saw related messages on Discord (but this is partial or alternative solution):
<img width="1238" alt="Zrzut ekranu 2024-04-24 o 11 44 02" src="https://github.com/surrealdb/surrealdb.js/assets/53402105/df0b3380-268c-4fe8-8a7c-c070eeb39df2">


<img width="935" alt="Zrzut ekranu 2024-04-24 o 11 31 15" src="https://github.com/surrealdb/surrealdb.js/assets/53402105/3e6dd75e-20c5-451f-a483-7429dadcc772">


<img width="659" alt="Zrzut ekranu 2024-04-28 o 19 33 15" src="https://github.com/surrealdb/surrealdb.js/assets/53402105/373ba8f9-392d-4e38-b485-a2d63fbd27ee">



## To do
- [ ] add support for live queries
- [ ] add tests for live queries

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
