### PR TITLE
Allow connecting to subpaths

### DIFF
--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -69,7 +69,12 @@ export class Surreal {
 	 */
 	async connect(url: string | URL, opts: ConnectionOptions = {}) {
 		url = new URL(url);
-		url.pathname = "/rpc";
+
+		if (!url.pathname.endsWith("/rpc")) {
+			if (!url.pathname.endsWith("/")) url.pathname += "/";
+			url.pathname += "rpc";
+		}
+
 		const engineName = url.protocol.slice(0, -1);
 		const engine = this.engines[engineName];
 		if (!engine) throw new UnsupportedEngine(engineName);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

You can currently not connect to a SurrealDB database running behind a proxy on a sub path

## What does this change do?

Instead of forcing the path to `/rpc`, `/rpc` will be appended if missing

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
