### PR TITLE
bugfix: Fix resource leaks in the WebSocket engine

### DIFF
--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -138,9 +138,6 @@ export class WebsocketEngine implements Engine {
 		await this.socket?.close();
 		this.ready = undefined;
 		this.socket = undefined;
-		if (this.status !== ConnectionStatus.Disconnected) {
-			this.setStatus(ConnectionStatus.Disconnected);
-		}
 	}
 
 	async rpc<


### PR DESCRIPTION
Thank you for the great work on this project.

## What is the motivation?

Recently, CI has been failing due to WebSocket resource leaks.

Surreal's `close` method waits until the engine it is using transitions to a "disconnected" status. However, the WebSocket engine's `disconnect` method immediately transitions to the "disconnected" status after requesting that the socket be disconnected. The `close` method of socket (not Surreal) only requests that the connection be closed, and certainly does not wait for the connection to close. Therefore, if the socket "close" event occurs before `setStatus` is resolved, there will be no resource leak, but if `setStatus` is resolved first, a resource leak will occur.

![a](https://github.com/surrealdb/surrealdb.js/assets/87357925/00501812-0caa-4e78-b0bb-f4a7c23d06fa)

## What does this change do?

In order to detect a WebSocket disconnection, prevent the WebSocket engine from immediately transitioning to the "disconnected" status.

## What is your testing strategy?

I have verified that all existing tests pass.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
