### PR TITLE
Explicit error when namespace and/or database are missing for HTTP engine

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -62,6 +62,11 @@ export class ConnectionUnavailable extends SurrealDbError {
 	message = "There is no connection available at this moment.";
 }
 
+export class MissingNamespaceDatabase extends SurrealDbError {
+	name = "MissingNamespaceDatabase";
+	message = "There are no namespace and/or database configured.";
+}
+
 export class HttpConnectionError extends SurrealDbError {
 	name = "HttpConnectionError";
 

--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -14,6 +14,7 @@ import {
 	ConnectionUnavailable,
 	EngineDisconnected,
 	HttpConnectionError,
+	MissingNamespaceDatabase,
 	ResponseError,
 	UnexpectedConnectionError,
 	UnexpectedServerResponse,
@@ -310,7 +311,7 @@ export class HttpEngine implements Engine {
 		}
 
 		if (!this.connection.namespace || !this.connection.database) {
-			throw new ConnectionUnavailable();
+			throw new MissingNamespaceDatabase();
 		}
 
 		const id = getIncrementalID();


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When no namespace and/or database is set a `ConnectionUnavailable` error will be thrown, this can be confusing as it does not clearly represent the problem.

## What does this change do?

It introduces a new `MissingNamespaceDatabase` error with a better description of what the problem is.

## What is your testing strategy?

N/A

## Is this related to any issues?

fixes #245 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
