### PR TITLE
Implement version check

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -28,6 +28,7 @@ await build({
 		dependencies: {
 			"isows": "^1.0.4",
 			"ws": "^8.16.0",
+			"semver": "^7.5.4",
 		},
 		optionalDependencies: {
 			"bufferutil": "^4.0.8",
@@ -37,6 +38,7 @@ await build({
 			"@types/node": "^18.7.18",
 			"@types/ws": "8.5.3",
 			"esbuild": "0.15.8",
+			"@types/semver": "^7.5.8",
 		},
 		scripts: {
 			"build:web":

--- a/deno.json
+++ b/deno.json
@@ -22,9 +22,9 @@
 	},
 	"test": {
 		"include": [
+			"tests/unit/*.ts",
 			"tests/integration/ws.ts",
-			"tests/integration/http.ts",
-			"tests/unit/*.ts"
+			"tests/integration/http.ts"
 		]
 	}
 }

--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
       "npm:decimal.js@^10.4.3": "npm:decimal.js@10.4.3",
       "npm:isows@^1.0.4": "npm:isows@1.0.4_ws@8.16.0",
       "npm:node-fetch@^3.3.1": "npm:node-fetch@3.3.2",
+      "npm:semver": "npm:semver@7.5.4",
       "npm:typescript@^5.3.3": "npm:typescript@5.4.3",
       "npm:uuidv7@0.6.3": "npm:uuidv7@0.6.3",
       "npm:uuidv7@^0.6.3": "npm:uuidv7@0.6.3",
@@ -75,6 +76,12 @@
           "ws": "ws@8.16.0"
         }
       },
+      "lru-cache@6.0.0": {
+        "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+        "dependencies": {
+          "yallist": "yallist@4.0.0"
+        }
+      },
       "node-domexception@1.0.0": {
         "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
         "dependencies": {}
@@ -85,6 +92,12 @@
           "data-uri-to-buffer": "data-uri-to-buffer@4.0.1",
           "fetch-blob": "fetch-blob@3.2.0",
           "formdata-polyfill": "formdata-polyfill@4.0.10"
+        }
+      },
+      "semver@7.5.4": {
+        "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+        "dependencies": {
+          "lru-cache": "lru-cache@6.0.0"
         }
       },
       "typescript@5.4.3": {
@@ -111,6 +124,10 @@
       },
       "ws@8.16.0": {
         "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+        "dependencies": {}
+      },
+      "yallist@4.0.0": {
+        "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
         "dependencies": {}
       },
       "zod@3.22.4": {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -102,3 +102,23 @@ export class NoTokenReturned extends SurrealDbError {
 	name = "NoTokenReturned";
 	message = "Did not receive an authentication token.";
 }
+
+export class UnsupportedVersion extends SurrealDbError {
+	name = "UnsupportedVersion";
+	version: string;
+	supportedRange: string;
+
+	constructor(version: string, supportedRange: string) {
+		super();
+		this.version = version;
+		this.supportedRange = supportedRange;
+		this.message =
+			`The version "${version}" reported by the engine is not supported by this library, expected a version that satisfies "${supportedRange}".`;
+	}
+}
+
+export class VersionRetrievalFailure extends SurrealDbError {
+	name = "VersionRetrievalFailure";
+	message =
+		"Failed to retrieve remote version. If the server is behind a proxy, make sure it's configured correctly.";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export { PreparedQuery } from "./library/PreparedQuery.ts";
 export * from "./errors.ts";
 export * from "./types.ts";
 export * from "./library/jsonify.ts";
+export * from "./library/versionCheck.ts";

--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -19,6 +19,7 @@ import {
 	UnexpectedConnectionError,
 	UnexpectedServerResponse,
 } from "../errors.ts";
+import { retrieveRemoteVersion } from "./versionCheck.ts";
 
 export type EngineEvents = {
 	connecting: [];
@@ -55,6 +56,8 @@ export abstract class Engine {
 		database?: string;
 		token?: string;
 	};
+
+	abstract version(url: URL): Promise<string>;
 }
 
 export class WebsocketEngine implements Engine {
@@ -80,6 +83,10 @@ export class WebsocketEngine implements Engine {
 	) {
 		this.status = status;
 		this.emitter.emit(status, args);
+	}
+
+	version(url: URL): Promise<string> {
+		return retrieveRemoteVersion(url);
 	}
 
 	async connect(url: URL) {
@@ -245,6 +252,10 @@ export class HttpEngine implements Engine {
 	) {
 		this.status = status;
 		this.emitter.emit(status, args);
+	}
+
+	version(url: URL): Promise<string> {
+		return retrieveRemoteVersion(url);
 	}
 
 	connect(url: URL) {

--- a/src/library/versionCheck.ts
+++ b/src/library/versionCheck.ts
@@ -1,0 +1,44 @@
+import semver from "npm:semver";
+import { UnsupportedVersion, VersionRetrievalFailure } from "../errors.ts";
+
+export const supportedSurrealDbVersionRange = ">= 1.4.2 < 2.0.0";
+
+export function versionCheck(version: string): true {
+	if (!isVersionSupported(version)) {
+		throw new UnsupportedVersion(version, supportedSurrealDbVersionRange);
+	}
+
+	return true;
+}
+
+export function isVersionSupported(version: string) {
+	return semver.satisfies(version, supportedSurrealDbVersionRange);
+}
+
+export async function retrieveRemoteVersion(url: URL) {
+	const mappedProtocols = {
+		"ws:": "http:",
+		"wss:": "https:",
+		"http:": "http:",
+		"https:": "https:",
+	} as Record<string, string>;
+
+	const protocol = mappedProtocols[url.protocol];
+	if (protocol) {
+		url = new URL(url);
+		url.protocol = protocol;
+		url.pathname = url.pathname.slice(0, -4) + "/version";
+
+		const versionPrefix = "surrealdb-";
+		const version = await fetch(url)
+			.then((res) => res.text())
+			.then((version) => version.slice(versionPrefix.length))
+			.catch(() => {
+				throw new VersionRetrievalFailure();
+			});
+
+		return version;
+	}
+
+	throw new VersionRetrievalFailure();
+}

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -33,6 +33,7 @@ import {
 	TransformAuth,
 } from "./types.ts";
 import { ConnectionStatus } from "./library/engine.ts";
+import { versionCheck } from "./library/versionCheck.ts";
 
 type Engines = Record<string, new (emitter: Emitter<EngineEvents>) => Engine>;
 type R = Prettify<Record<string, unknown>>;
@@ -92,6 +93,12 @@ export class Surreal {
 
 		// The promise does not know if `this.connection` is undefined or not, but it does about `connection`
 		const connection = new engine(this.emitter);
+
+		// If not disabled, run a version check
+		if (opts.versionCheck !== false) {
+			const version = await connection.version(url);
+			versionCheck(version);
+		}
 
 		this.connection = connection;
 		this.pinger = new Pinger(30000);

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,7 @@ export type Patch =
 
 export type ConnectionOptions =
 	& {
+		versionCheck?: boolean;
 		prepare?: (connection: Surreal) => unknown;
 		auth?: AnyAuth | Token;
 	}

--- a/tests/unit/isVersionSupported.ts
+++ b/tests/unit/isVersionSupported.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from "https://deno.land/std@0.223.0/assert/assert_equals.ts";
+import { isVersionSupported } from "../../src/library/versionCheck.ts";
+
+Deno.test("isVersionSupported", () => {
+	assertEquals(
+		isVersionSupported("1.0.0"),
+		false,
+		"1.0.0 should be unsupported",
+	);
+	assertEquals(
+		isVersionSupported("1.4.1"),
+		false,
+		"1.4.1 should be unsupported",
+	);
+	assertEquals(
+		isVersionSupported("1.4.2"),
+		true,
+		"1.4.2 should be supported",
+	);
+	assertEquals(
+		isVersionSupported("1.99.99"),
+		true,
+		"1.99.99 should be supported",
+	);
+	assertEquals(
+		isVersionSupported("2.0.0"),
+		false,
+		"2.0.0 should be unsupported",
+	);
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Especially now, where the minimum required version for the library is 1.4.2, it's very useful to implement a version check to ensure people are on the correct version.

## What does this change do?

It implements a version check.

## What is your testing strategy?

Added a test for the version checking logic. Besides that, tests integration tests will fail if the remote version is not supported.

## Is this related to any issues?

Fixes #84 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
