### PR TITLE
Add `run` and `relate` method

### DIFF
--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -615,6 +615,64 @@ export class Surreal {
 	}
 
 	/**
+	 * Run a SurrealQL function
+	 * @param name - The full name of the function
+	 * @param args - The arguments supplied to the function. You can also supply a version here as a string, in which case the third argument becomes the parameter list.
+	 */
+	async run<T extends unknown>(name: string, args?: unknown[]): Promise<T>;
+	/**
+	 * Run a SurrealQL function
+	 * @param name - The full name of the function
+	 * @param version - The version of the function. If omitted, the second argument is the parameter list.
+	 * @param args - The arguments supplied to the function.
+	 */
+	async run<T extends unknown>(
+		name: string,
+		version: string,
+		args?: unknown[],
+	): Promise<T>;
+	async run(name: string, arg2?: string | unknown[], arg3?: unknown[]) {
+		await this.ready;
+		const [version, args] = Array.isArray(arg2)
+			? [undefined, arg2]
+			: [arg2, arg3];
+		const res = await this.rpc("run", [name, version, args]);
+		if (res.error) throw new ResponseError(res.error.message);
+		return res.result;
+	}
+
+	/**
+	 * Obtain the version of the SurrealDB instance
+	 * @param from - The in property on the edge record
+	 * @param thing - The id of the edge record
+	 * @param to - The out property on the edge record
+	 * @param data - Optionally, provide a body for the edge record
+	 */
+	async relate<T extends R, U extends R = T>(
+		from: string | RecordId | RecordId[],
+		thing: string,
+		to: string | RecordId | RecordId[],
+		data?: U,
+	): Promise<T[]>;
+	async relate<T extends R, U extends R = T>(
+		from: string | RecordId | RecordId[],
+		thing: RecordId,
+		to: string | RecordId | RecordId[],
+		data?: U,
+	): Promise<T>;
+	async relate<T extends R, U extends R = T>(
+		from: string | RecordId | RecordId[],
+		thing: string | RecordId,
+		to: string | RecordId | RecordId[],
+		data?: U,
+	) {
+		await this.ready;
+		const res = await this.rpc("relate", [from, thing, to, data]);
+		if (res.error) throw new ResponseError(res.error.message);
+		return res.result;
+	}
+
+	/**
 	 * Send a raw message to the SurrealDB instance
 	 * @param method - Type of message to send.
 	 * @param params - Parameters for the message.

--- a/tests/integration/tests/querying.ts
+++ b/tests/integration/tests/querying.ts
@@ -246,6 +246,56 @@ Deno.test("delete", async () => {
 	await surreal.close();
 });
 
+Deno.test("relate", async () => {
+	const surreal = await createSurreal();
+
+	const single = await surreal.relate(
+		new RecordId("edge", "in"),
+		new RecordId("graph", 1),
+		new RecordId("edge", "out"),
+		{
+			num: 123,
+		},
+	);
+
+	assertEquals(single, {
+		id: new RecordId("graph", 1),
+		in: new RecordId("edge", "in"),
+		out: new RecordId("edge", "out"),
+		num: 123,
+	}, "single");
+
+	const multiple = await surreal.relate(
+		new RecordId("edge", "in"),
+		"graph",
+		new RecordId("edge", "out"),
+		{
+			id: new RecordId("graph", 2),
+			num: 456,
+		},
+	);
+
+	assertEquals(multiple, [
+		{
+			id: new RecordId("graph", 2),
+			in: new RecordId("edge", "in"),
+			out: new RecordId("edge", "out"),
+			num: 456,
+		},
+	], "multiple");
+
+	await surreal.close();
+});
+
+Deno.test("run", async () => {
+	const surreal = await createSurreal();
+
+	const res = await surreal.run<number[]>("array::add", [[1, 2], 3]);
+	assertEquals(res, [1, 2, 3]);
+
+	await surreal.close();
+});
+
 Deno.test("query", async () => {
 	const surreal = await createSurreal();
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

SurrealDB 1.5.0 introduces new `run` and `relate` methods to the RPC protocol.

## What does this change do?

It implements the new `run` and `relate` methods.

## What is your testing strategy?

Added a test for both `run` and `relate`

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
