### PR TITLE
Require Node v18

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/compile.ts
+++ b/compile.ts
@@ -45,6 +45,9 @@ await build({
 				"esbuild ./esm/index.js --format=esm --minify --bundle --sourcemap --outfile=./web/index.js",
 		},
 		browser: "./web/index.js",
+		engines: {
+			node: ">=18.0.0"
+		}
 	},
 	// skipSourceOutput: true,
 	mappings: {
@@ -59,3 +62,4 @@ await build({
 // post build steps
 Deno.copyFileSync("LICENSE", "npm/LICENSE");
 Deno.copyFileSync("README.md", "npm/README.md");
+Deno.copyFileSync(".npmrc", "npm/.npmrc");

--- a/compile.ts
+++ b/compile.ts
@@ -46,8 +46,8 @@ await build({
 		},
 		browser: "./web/index.js",
 		engines: {
-			node: ">=18.0.0"
-		}
+			node: ">=18.0.0",
+		},
 	},
 	// skipSourceOutput: true,
 	mappings: {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Due to the usage of `fetch`, the minimum version of NodeJS for surrealdb.js is 18.0.0

## What does this change do?

It sets the engines minimum version for NodeJS

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
