### PR TITLE
A Line is actually a LineString, which accepts two or more Points

### DIFF
--- a/src/library/cbor/geometry.ts
+++ b/src/library/cbor/geometry.ts
@@ -34,9 +34,11 @@ export class GeometryPoint extends Geometry {
 }
 
 export class GeometryLine extends Geometry {
-	readonly line: [GeometryPoint, GeometryPoint];
+	readonly line: [GeometryPoint, GeometryPoint, ...GeometryPoint[]];
 
-	constructor(line: [GeometryPoint, GeometryPoint] | GeometryLine) {
+	// SurrealDB only has the context of a "Line", which is two points.
+	// SurrealDB's "Line" is actually a "LineString" under the hood, which accepts two or more points
+	constructor(line: [GeometryPoint, GeometryPoint, ...GeometryPoint[]] | GeometryLine) {
 		super();
 		line = line instanceof GeometryLine ? line.line : line;
 		this.line = [new GeometryPoint(line[0]), new GeometryPoint(line[1])];

--- a/src/library/cbor/geometry.ts
+++ b/src/library/cbor/geometry.ts
@@ -38,7 +38,9 @@ export class GeometryLine extends Geometry {
 
 	// SurrealDB only has the context of a "Line", which is two points.
 	// SurrealDB's "Line" is actually a "LineString" under the hood, which accepts two or more points
-	constructor(line: [GeometryPoint, GeometryPoint, ...GeometryPoint[]] | GeometryLine) {
+	constructor(
+		line: [GeometryPoint, GeometryPoint, ...GeometryPoint[]] | GeometryLine,
+	) {
 		super();
 		line = line instanceof GeometryLine ? line.line : line;
 		this.line = [new GeometryPoint(line[0]), new GeometryPoint(line[1])];


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Our initial understanding of `Line` was that it's a Line, which is represented by two Points. SurrealDB's Line is actually a LineString however under the hood, which is represented by two _or more_ Points. The types for that are currently incorrect, as pointed out in #263.

## What does this change do?

It corrects the types.

## What is your testing strategy?

N/A

## Is this related to any issues?

Fixes #263 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
