### PR TITLE
Version check timeout

### DIFF
--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -57,7 +57,7 @@ export abstract class Engine {
 		token?: string;
 	};
 
-	abstract version(url: URL, timeout?: number): Promise<string>;
+	abstract version(url: URL, timeout: number): Promise<string>;
 }
 
 export class WebsocketEngine implements Engine {
@@ -85,7 +85,7 @@ export class WebsocketEngine implements Engine {
 		this.emitter.emit(status, args);
 	}
 
-	version(url: URL, timeout = 5): Promise<string> {
+	version(url: URL, timeout: number): Promise<string> {
 		return retrieveRemoteVersion(url, timeout);
 	}
 
@@ -254,7 +254,7 @@ export class HttpEngine implements Engine {
 		this.emitter.emit(status, args);
 	}
 
-	version(url: URL, timeout = 5): Promise<string> {
+	version(url: URL, timeout: number): Promise<string> {
 		return retrieveRemoteVersion(url, timeout);
 	}
 

--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -57,7 +57,7 @@ export abstract class Engine {
 		token?: string;
 	};
 
-	abstract version(url: URL): Promise<string>;
+	abstract version(url: URL, timeout?: number): Promise<string>;
 }
 
 export class WebsocketEngine implements Engine {
@@ -85,8 +85,8 @@ export class WebsocketEngine implements Engine {
 		this.emitter.emit(status, args);
 	}
 
-	version(url: URL): Promise<string> {
-		return retrieveRemoteVersion(url);
+	version(url: URL, timeout = 5): Promise<string> {
+		return retrieveRemoteVersion(url, timeout);
 	}
 
 	async connect(url: URL) {
@@ -254,8 +254,8 @@ export class HttpEngine implements Engine {
 		this.emitter.emit(status, args);
 	}
 
-	version(url: URL): Promise<string> {
-		return retrieveRemoteVersion(url);
+	version(url: URL, timeout = 5): Promise<string> {
+		return retrieveRemoteVersion(url, timeout);
 	}
 
 	connect(url: URL) {

--- a/src/library/versionCheck.ts
+++ b/src/library/versionCheck.ts
@@ -33,8 +33,8 @@ export async function retrieveRemoteVersion(url: URL, timeout: number) {
 		const version = await fetch(
 			url,
 			{
-				signal: AbortSignal.timeout(timeout)
-			}
+				signal: AbortSignal.timeout(timeout),
+			},
 		)
 			.then((res) => res.text())
 			.then((version) => version.slice(versionPrefix.length))

--- a/src/library/versionCheck.ts
+++ b/src/library/versionCheck.ts
@@ -29,17 +29,22 @@ export async function retrieveRemoteVersion(url: URL, timeout: number) {
 		url.protocol = protocol;
 		url.pathname = url.pathname.slice(0, -4) + "/version";
 
+		const controller = new AbortController();
+		const id = setTimeout(() => controller.abort(), timeout);
 		const versionPrefix = "surrealdb-";
 		const version = await fetch(
 			url,
 			{
-				signal: AbortSignal.timeout(timeout),
+				signal: controller.signal,
 			},
 		)
 			.then((res) => res.text())
 			.then((version) => version.slice(versionPrefix.length))
 			.catch(() => {
 				throw new VersionRetrievalFailure();
+			})
+			.finally(() => {
+				clearTimeout(id);
 			});
 
 		return version;

--- a/src/library/versionCheck.ts
+++ b/src/library/versionCheck.ts
@@ -15,7 +15,7 @@ export function isVersionSupported(version: string) {
 	return semver.satisfies(version, supportedSurrealDbVersionRange);
 }
 
-export async function retrieveRemoteVersion(url: URL) {
+export async function retrieveRemoteVersion(url: URL, timeout = 5) {
 	const mappedProtocols = {
 		"ws:": "http:",
 		"wss:": "https:",
@@ -30,7 +30,12 @@ export async function retrieveRemoteVersion(url: URL) {
 		url.pathname = url.pathname.slice(0, -4) + "/version";
 
 		const versionPrefix = "surrealdb-";
-		const version = await fetch(url)
+		const version = await fetch(
+			url,
+			{
+				signal: AbortSignal.timeout(timeout)
+			}
+		)
 			.then((res) => res.text())
 			.then((version) => version.slice(versionPrefix.length))
 			.catch(() => {

--- a/src/library/versionCheck.ts
+++ b/src/library/versionCheck.ts
@@ -15,7 +15,7 @@ export function isVersionSupported(version: string) {
 	return semver.satisfies(version, supportedSurrealDbVersionRange);
 }
 
-export async function retrieveRemoteVersion(url: URL, timeout = 5) {
+export async function retrieveRemoteVersion(url: URL, timeout: number) {
 	const mappedProtocols = {
 		"ws:": "http:",
 		"wss:": "https:",

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -96,7 +96,7 @@ export class Surreal {
 
 		// If not disabled, run a version check
 		if (opts.versionCheck !== false) {
-			const version = await connection.version(url);
+			const version = await connection.version(url, opts.versionCheckTimeout);
 			versionCheck(version);
 		}
 

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -96,7 +96,7 @@ export class Surreal {
 
 		// If not disabled, run a version check
 		if (opts.versionCheck !== false) {
-			const version = await connection.version(url, opts.versionCheckTimeout);
+			const version = await connection.version(url, opts.versionCheckTimeout ?? 5000);
 			versionCheck(version);
 		}
 

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -96,7 +96,10 @@ export class Surreal {
 
 		// If not disabled, run a version check
 		if (opts.versionCheck !== false) {
-			const version = await connection.version(url, opts.versionCheckTimeout ?? 5000);
+			const version = await connection.version(
+				url,
+				opts.versionCheckTimeout ?? 5000,
+			);
 			versionCheck(version);
 		}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,7 @@ export type Patch =
 export type ConnectionOptions =
 	& {
 		versionCheck?: boolean;
+		versionCheckTimeout?: number;
 		prepare?: (connection: Surreal) => unknown;
 		auth?: AnyAuth | Token;
 	}

--- a/tests/integration/env.ts
+++ b/tests/integration/env.ts
@@ -3,8 +3,15 @@ import { getAvailablePortSync } from "https://deno.land/x/port@1.0.0/mod.ts";
 const port = getAvailablePortSync();
 if (typeof port != "number") throw new Error("Could not claim port");
 
+const port_unreachable = getAvailablePortSync();
+if (typeof port_unreachable != "number") {
+	throw new Error("Could not claim port");
+}
+
 export const SURREAL_PORT = port.toString();
 export const SURREAL_BIND = `0.0.0.0:${SURREAL_PORT}`;
+export const SURREAL_PORT_UNREACHABLE = port_unreachable.toString();
+export const SURREAL_BIND_UNREACHABLE = `0.0.0.0:${SURREAL_PORT}`;
 export const SURREAL_USER = "root";
 export const SURREAL_PASS = "root";
 export const SURREAL_NS = "test";

--- a/tests/integration/surreal.ts
+++ b/tests/integration/surreal.ts
@@ -1,5 +1,5 @@
 import Surreal from "../../mod.ts";
-import { SURREAL_USER } from "./env.ts";
+import { SURREAL_PORT_UNREACHABLE, SURREAL_USER } from "./env.ts";
 import { SURREAL_PASS } from "./env.ts";
 import { SURREAL_DB } from "./env.ts";
 import { SURREAL_NS } from "./env.ts";
@@ -14,9 +14,11 @@ declare global {
 export async function createSurreal({
 	protocol,
 	auth,
+	reachable,
 }: {
 	protocol?: Protocol;
 	auth?: PremadeAuth;
+	reachable?: boolean;
 } = {}) {
 	protocol = protocol
 		? protocol
@@ -24,7 +26,8 @@ export async function createSurreal({
 		? globalThis.protocol as Protocol
 		: "ws";
 	const surreal = new Surreal();
-	await surreal.connect(`${protocol}://127.0.0.1:${SURREAL_PORT}/rpc`, {
+	const port = reachable == false ? SURREAL_PORT_UNREACHABLE : SURREAL_PORT;
+	await surreal.connect(`${protocol}://127.0.0.1:${port}/rpc`, {
 		namespace: SURREAL_NS,
 		database: SURREAL_DB,
 		auth: auth ? createAuth(auth) : auth,

--- a/tests/integration/tests/connection.ts
+++ b/tests/integration/tests/connection.ts
@@ -1,5 +1,8 @@
+import { assertInstanceOf } from "https://deno.land/std@0.223.0/assert/assert_instance_of.ts";
 import { createSurreal } from "../surreal.ts";
 import { assertEquals } from "https://deno.land/std@0.223.0/assert/mod.ts";
+import { VersionRetrievalFailure } from "../../../mod.ts";
+import { assertLess } from "https://deno.land/std@0.223.0/assert/assert_less.ts";
 
 Deno.test("check version", async () => {
 	const surreal = await createSurreal();
@@ -8,4 +11,14 @@ Deno.test("check version", async () => {
 	assertEquals(res.startsWith("surrealdb-"), true, "Version to be returned");
 
 	await surreal.close();
+});
+
+Deno.test("version check timeout", async () => {
+	const start = new Date();
+	const res = await createSurreal({ reachable: false }).catch((err) => err);
+	const end = new Date();
+	const diff = end.getTime() - start.getTime();
+
+	assertInstanceOf(res, VersionRetrievalFailure);
+	assertLess(diff, 5100); // 100ms margin
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Version check would take a long time to complete if the server was unreachable, due to default fetch timeouts in runtimes.

## What does this change do?

It adds a `versionCheckTimeout` option to the `.connect({ .. })` method, with a default value of 5000ms.

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
