### PR TITLE
Migrate to JSR + minor updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup deno
         uses: denoland/setup-deno@v1
         with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup deno
         uses: denoland/setup-deno@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno fmt --check
-      - run: deno test
+      - run: deno task test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,14 @@
+name: Pull Request
+
+on: pull_request
+
+jobs:
+  pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno fmt --check
+      - run: deno test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,20 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: deno task build
       - run: cd ./npm && npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  publish-to-jsr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write 
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx jsr publish

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "deno.enable": true
+  "deno.enable": true,
+  "editor.defaultFormatter": "denoland.vscode-deno",
+  "editor.formatOnSave": true
 }

--- a/compile.ts
+++ b/compile.ts
@@ -4,6 +4,8 @@ import project from "./deno.json" with { type: "json" };
 await emptyDir("./npm");
 
 await build({
+	// Remove when https://github.com/denoland/dnt/issues/399 is fixed
+	importMap: "./deno.json",
 	entryPoints: ["./src/index.ts"],
 	outDir: "./npm",
 	shims: {

--- a/compile.ts
+++ b/compile.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from "https://deno.land/x/dnt@0.34.0/mod.ts";
+import { build, emptyDir } from "@deno/dnt";
 import project from "./deno.json" with { type: "json" };
 
 await emptyDir("./npm");
@@ -54,7 +54,7 @@ await build({
 		"./src/library/WebSocket/deno.ts": "./src/library/WebSocket/node.ts",
 	},
 	compilerOptions: {
-		lib: ["dom", "es2021.string"],
+		lib: ["DOM", "ES2021.String"],
 		sourceMap: true,
 	},
 });

--- a/compile.ts
+++ b/compile.ts
@@ -1,5 +1,5 @@
 import { build, emptyDir } from "https://deno.land/x/dnt@0.34.0/mod.ts";
-import project from "./project.json" with { type: "json" };
+import project from "./deno.json" with { type: "json" };
 
 await emptyDir("./npm");
 

--- a/deno.json
+++ b/deno.json
@@ -31,6 +31,7 @@
 		]
 	},
 	"imports": {
+		"@deno/dnt": "jsr:@deno/dnt@^0.41.2",
 		"@icholy/duration": "npm:@icholy/duration@^5.1.0",
 		"@std/assert": "jsr:@std/assert@^0.225.3",
 		"@std/semver": "jsr:@std/semver@^0.224.1",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"name": "@surrealdb/surrealdb",
-  "version": "1.0.0-beta.8",
-  "description": "SurrealDB SDK for JavaScript",
+	"version": "1.0.0-beta.8",
+	"description": "SurrealDB SDK for JavaScript",
 	"lint": {
 		"include": ["src/", "tests/", "./mod.ts", "./compile.ts", "./deno.json"]
 	},
@@ -29,5 +29,19 @@
 			"tests/integration/ws.ts",
 			"tests/integration/http.ts"
 		]
+	},
+	"imports": {
+		"@icholy/duration": "npm:@icholy/duration@^5.1.0",
+		"@std/assert": "jsr:@std/assert@^0.225.3",
+		"@std/testing": "jsr:@std/testing@^0.224.0",
+		"cbor-redux": "npm:cbor-redux@^1.0.0",
+		"decimal.js": "npm:decimal.js@^10.4.3",
+		"isows": "npm:isows@^1.0.4",
+		"semver": "npm:semver@^7.6.2",
+		"uuidv7": "npm:uuidv7@^1.0.0",
+		"zod": "npm:zod@^3.23.8"
+	},
+	"exports": {
+		".": "./mod.ts"
 	}
 }

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,7 @@
 {
+	"name": "@surrealdb/surrealdb",
+  "version": "1.0.0-beta.8",
+  "description": "SurrealDB SDK for JavaScript",
 	"lint": {
 		"include": ["src/", "tests/", "./mod.ts", "./compile.ts", "./deno.json"]
 	},

--- a/deno.json
+++ b/deno.json
@@ -33,11 +33,11 @@
 	"imports": {
 		"@icholy/duration": "npm:@icholy/duration@^5.1.0",
 		"@std/assert": "jsr:@std/assert@^0.225.3",
+		"@std/semver": "jsr:@std/semver@^0.224.1",
 		"@std/testing": "jsr:@std/testing@^0.224.0",
 		"cbor-redux": "npm:cbor-redux@^1.0.0",
 		"decimal.js": "npm:decimal.js@^10.4.3",
 		"isows": "npm:isows@^1.0.4",
-		"semver": "npm:semver@^7.6.2",
 		"uuidv7": "npm:uuidv7@^1.0.0",
 		"zod": "npm:zod@^3.23.8"
 	},

--- a/deno.lock
+++ b/deno.lock
@@ -2,6 +2,14 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
+      "jsr:@std/assert@^0.225.3": "jsr:@std/assert@0.225.3",
+      "jsr:@std/fmt@^0.224.0": "jsr:@std/fmt@0.224.0",
+      "jsr:@std/fs@^0.224.0": "jsr:@std/fs@0.224.0",
+      "jsr:@std/internal@^0.224.0": "jsr:@std/internal@0.224.0",
+      "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.0",
+      "jsr:@std/path@^0.224.0": "jsr:@std/path@0.224.0",
+      "jsr:@std/testing@^0.224.0": "jsr:@std/testing@0.224.0",
       "npm:@icholy/duration@^5.1.0": "npm:@icholy/duration@5.1.0",
       "npm:@types/node@^20.11.16": "npm:@types/node@20.12.2",
       "npm:cbor-redux@1.0.0": "npm:cbor-redux@1.0.0",
@@ -11,11 +19,55 @@
       "npm:isows@^1.0.4": "npm:isows@1.0.4_ws@8.16.0",
       "npm:node-fetch@^3.3.1": "npm:node-fetch@3.3.2",
       "npm:semver": "npm:semver@7.5.4",
+      "npm:semver@^7.6.2": "npm:semver@7.6.2",
       "npm:typescript@^5.3.3": "npm:typescript@5.4.3",
       "npm:uuidv7@0.6.3": "npm:uuidv7@0.6.3",
       "npm:uuidv7@^0.6.3": "npm:uuidv7@0.6.3",
+      "npm:uuidv7@^1.0.0": "npm:uuidv7@1.0.0",
       "npm:zod": "npm:zod@3.22.4",
-      "npm:zod@^3.22.4": "npm:zod@3.22.4"
+      "npm:zod@^3.22.4": "npm:zod@3.22.4",
+      "npm:zod@^3.23.8": "npm:zod@3.23.8"
+    },
+    "jsr": {
+      "@std/assert@0.224.0": {
+        "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f",
+        "dependencies": [
+          "jsr:@std/internal@^0.224.0"
+        ]
+      },
+      "@std/assert@0.225.3": {
+        "integrity": "b3c2847aecf6955b50644cdb9cf072004ea3d1998dd7579fc0acb99dbb23bd4f",
+        "dependencies": [
+          "jsr:@std/internal@^1.0.0"
+        ]
+      },
+      "@std/fmt@0.224.0": {
+        "integrity": "e20e9a2312a8b5393272c26191c0a68eda8d2c4b08b046bad1673148f1d69851"
+      },
+      "@std/fs@0.224.0": {
+        "integrity": "52a5ec89731ac0ca8f971079339286f88c571a4d61686acf75833f03a89d8e69",
+        "dependencies": [
+          "jsr:@std/path@^0.224.0"
+        ]
+      },
+      "@std/internal@0.224.0": {
+        "integrity": "afc50644f9cdf4495eeb80523a8f6d27226b4b36c45c7c195dfccad4b8509291"
+      },
+      "@std/internal@1.0.0": {
+        "integrity": "ac6a6dfebf838582c4b4f61a6907374e27e05bedb6ce276e0f1608fe84e7cd9a"
+      },
+      "@std/path@0.224.0": {
+        "integrity": "55bca6361e5a6d158b9380e82d4981d82d338ec587de02951e2b7c3a24910ee6"
+      },
+      "@std/testing@0.224.0": {
+        "integrity": "371b8a929aa7132240d5dd766a439be8f780ef5c176ab194e0bcab72370c761e",
+        "dependencies": [
+          "jsr:@std/assert@^0.224.0",
+          "jsr:@std/fmt@^0.224.0",
+          "jsr:@std/fs@^0.224.0",
+          "jsr:@std/path@^0.224.0"
+        ]
+      }
     },
     "npm": {
       "@deno/shim-deno-test@0.4.0": {
@@ -100,6 +152,10 @@
           "lru-cache": "lru-cache@6.0.0"
         }
       },
+      "semver@7.6.2": {
+        "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+        "dependencies": {}
+      },
       "typescript@5.4.3": {
         "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
         "dependencies": {}
@@ -110,6 +166,10 @@
       },
       "uuidv7@0.6.3": {
         "integrity": "sha512-zV3eW2NlXTsun/aJ7AixxZjH/byQcH/r3J99MI0dDEkU2cJIBJxhEWUHDTpOaLPRNhebPZoeHuykYREkI9HafA==",
+        "dependencies": {}
+      },
+      "uuidv7@1.0.0": {
+        "integrity": "sha512-XkvPwTtSmYwxIE1FSYQTYg79zHL1ZWV5vM/Qyl9ahXCU8enOPPA4bTjzvafvYUB7l2+miv4EqK/qEe75cOXIdA==",
         "dependencies": {}
       },
       "web-streams-polyfill@3.3.3": {
@@ -132,6 +192,10 @@
       },
       "zod@3.22.4": {
         "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+        "dependencies": {}
+      },
+      "zod@3.23.8": {
+        "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
         "dependencies": {}
       }
     }
@@ -300,5 +364,18 @@
     "https://deno.land/x/ts_morph@18.0.0/common/mod.ts": "01985d2ee7da8d1caee318a9d07664774fbee4e31602bc2bb6bb62c3489555ed",
     "https://deno.land/x/ts_morph@18.0.0/common/ts_morph_common.js": "845671ca951073400ce142f8acefa2d39ea9a51e29ca80928642f3f8cf2b7700",
     "https://deno.land/x/ts_morph@18.0.0/common/typescript.js": "d5c598b6a2db2202d0428fca5fd79fc9a301a71880831a805d778797d2413c59"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@^0.225.3",
+      "jsr:@std/testing@^0.224.0",
+      "npm:@icholy/duration@^5.1.0",
+      "npm:cbor-redux@^1.0.0",
+      "npm:decimal.js@^10.4.3",
+      "npm:isows@^1.0.4",
+      "npm:semver@^7.6.2",
+      "npm:uuidv7@^1.0.0",
+      "npm:zod@^3.23.8"
+    ]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,15 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
+      "jsr:@std/assert@^0.225.3": "jsr:@std/assert@0.225.3",
+      "jsr:@std/fmt@^0.224.0": "jsr:@std/fmt@0.224.0",
+      "jsr:@std/fs@^0.224.0": "jsr:@std/fs@0.224.0",
+      "jsr:@std/internal@^0.224.0": "jsr:@std/internal@0.224.0",
+      "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.0",
+      "jsr:@std/path@^0.224.0": "jsr:@std/path@0.224.0",
       "jsr:@std/semver@^0.224.1": "jsr:@std/semver@0.224.1",
+      "jsr:@std/testing@^0.224.0": "jsr:@std/testing@0.224.0",
       "npm:@icholy/duration@^5.1.0": "npm:@icholy/duration@5.1.0",
       "npm:cbor-redux@^1.0.0": "npm:cbor-redux@1.0.0",
       "npm:decimal.js@^10.4.3": "npm:decimal.js@10.4.3",
@@ -10,8 +18,47 @@
       "npm:zod@^3.23.8": "npm:zod@3.23.8"
     },
     "jsr": {
+      "@std/assert@0.224.0": {
+        "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f",
+        "dependencies": [
+          "jsr:@std/internal@^0.224.0"
+        ]
+      },
+      "@std/assert@0.225.3": {
+        "integrity": "b3c2847aecf6955b50644cdb9cf072004ea3d1998dd7579fc0acb99dbb23bd4f",
+        "dependencies": [
+          "jsr:@std/internal@^1.0.0"
+        ]
+      },
+      "@std/fmt@0.224.0": {
+        "integrity": "e20e9a2312a8b5393272c26191c0a68eda8d2c4b08b046bad1673148f1d69851"
+      },
+      "@std/fs@0.224.0": {
+        "integrity": "52a5ec89731ac0ca8f971079339286f88c571a4d61686acf75833f03a89d8e69",
+        "dependencies": [
+          "jsr:@std/path@^0.224.0"
+        ]
+      },
+      "@std/internal@0.224.0": {
+        "integrity": "afc50644f9cdf4495eeb80523a8f6d27226b4b36c45c7c195dfccad4b8509291"
+      },
+      "@std/internal@1.0.0": {
+        "integrity": "ac6a6dfebf838582c4b4f61a6907374e27e05bedb6ce276e0f1608fe84e7cd9a"
+      },
+      "@std/path@0.224.0": {
+        "integrity": "55bca6361e5a6d158b9380e82d4981d82d338ec587de02951e2b7c3a24910ee6"
+      },
       "@std/semver@0.224.1": {
         "integrity": "d3f34db1d5047add33614a54bdec56b5f9f590c36b0cc87eaaee2c3d38ad60c5"
+      },
+      "@std/testing@0.224.0": {
+        "integrity": "371b8a929aa7132240d5dd766a439be8f780ef5c176ab194e0bcab72370c761e",
+        "dependencies": [
+          "jsr:@std/assert@^0.224.0",
+          "jsr:@std/fmt@^0.224.0",
+          "jsr:@std/fs@^0.224.0",
+          "jsr:@std/path@^0.224.0"
+        ]
       }
     },
     "npm": {
@@ -60,7 +107,10 @@
       }
     }
   },
-  "remote": {},
+  "remote": {
+    "https://deno.land/x/port@1.0.0/mod.ts": "2dc04ce1ccf133ae09205e30b550044c4c6f64a1a7d00ea91c66dbb9f6cc00f5",
+    "https://deno.land/x/port@1.0.0/types.ts": "42d6ae4147d5d67408d60209da070ddfa79ec8389c6cab1b8002df0cf6c03af6"
+  },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^0.225.3",

--- a/deno.lock
+++ b/deno.lock
@@ -2,22 +2,59 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "jsr:@deno/cache-dir@^0.8.0": "jsr:@deno/cache-dir@0.8.0",
+      "jsr:@deno/dnt@^0.41.2": "jsr:@deno/dnt@0.41.2",
+      "jsr:@deno/graph@^0.69.7": "jsr:@deno/graph@0.69.10",
+      "jsr:@std/assert@^0.218.2": "jsr:@std/assert@0.218.2",
       "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
       "jsr:@std/assert@^0.225.3": "jsr:@std/assert@0.225.3",
+      "jsr:@std/bytes@^0.218.2": "jsr:@std/bytes@0.218.2",
+      "jsr:@std/fmt@^0.218.2": "jsr:@std/fmt@0.218.2",
       "jsr:@std/fmt@^0.224.0": "jsr:@std/fmt@0.224.0",
+      "jsr:@std/fs@^0.218.2": "jsr:@std/fs@0.218.2",
       "jsr:@std/fs@^0.224.0": "jsr:@std/fs@0.224.0",
       "jsr:@std/internal@^0.224.0": "jsr:@std/internal@0.224.0",
       "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.0",
+      "jsr:@std/io@^0.218.2": "jsr:@std/io@0.218.2",
+      "jsr:@std/path@^0.218.2": "jsr:@std/path@0.218.2",
       "jsr:@std/path@^0.224.0": "jsr:@std/path@0.224.0",
       "jsr:@std/semver@^0.224.1": "jsr:@std/semver@0.224.1",
       "jsr:@std/testing@^0.224.0": "jsr:@std/testing@0.224.0",
       "npm:@icholy/duration@^5.1.0": "npm:@icholy/duration@5.1.0",
+      "npm:@ts-morph/bootstrap@0.22": "npm:@ts-morph/bootstrap@0.22.0",
       "npm:cbor-redux@^1.0.0": "npm:cbor-redux@1.0.0",
+      "npm:code-block-writer@^13.0.1": "npm:code-block-writer@13.0.1",
       "npm:decimal.js@^10.4.3": "npm:decimal.js@10.4.3",
+      "npm:isows@^1.0.4": "npm:isows@1.0.4_ws@8.17.0",
       "npm:uuidv7@^1.0.0": "npm:uuidv7@1.0.0",
       "npm:zod@^3.23.8": "npm:zod@3.23.8"
     },
     "jsr": {
+      "@deno/cache-dir@0.8.0": {
+        "integrity": "e87e80a404958f6350d903e6238b72afb92468378b0b32111f7a1e4916ac7fe7",
+        "dependencies": [
+          "jsr:@deno/graph@^0.69.7",
+          "jsr:@std/fs@^0.218.2",
+          "jsr:@std/io@^0.218.2"
+        ]
+      },
+      "@deno/dnt@0.41.2": {
+        "integrity": "27bd0b42ab92ec1e892cb1f95e4b3bce84151dad89dadb422ccf5b3d7d026e9c",
+        "dependencies": [
+          "jsr:@deno/cache-dir@^0.8.0",
+          "jsr:@std/fmt@^0.218.2",
+          "jsr:@std/fs@^0.218.2",
+          "jsr:@std/path@^0.218.2",
+          "npm:@ts-morph/bootstrap@0.22",
+          "npm:code-block-writer@^13.0.1"
+        ]
+      },
+      "@deno/graph@0.69.10": {
+        "integrity": "38fe22ac5686f6ece5daeec5a4df65c6314d7d32adcc33f77917a13cfaffa26f"
+      },
+      "@std/assert@0.218.2": {
+        "integrity": "7f0a5a1a8cf86607cd6c2c030584096e1ffad27fc9271429a8cb48cfbdee5eaf"
+      },
       "@std/assert@0.224.0": {
         "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f",
         "dependencies": [
@@ -30,8 +67,21 @@
           "jsr:@std/internal@^1.0.0"
         ]
       },
+      "@std/bytes@0.218.2": {
+        "integrity": "91fe54b232dcca73856b79a817247f4a651dbb60d51baafafb6408c137241670"
+      },
+      "@std/fmt@0.218.2": {
+        "integrity": "99526449d2505aa758b6cbef81e7dd471d8b28ec0dcb1491d122b284c548788a"
+      },
       "@std/fmt@0.224.0": {
         "integrity": "e20e9a2312a8b5393272c26191c0a68eda8d2c4b08b046bad1673148f1d69851"
+      },
+      "@std/fs@0.218.2": {
+        "integrity": "dd9431453f7282e8c577cc22c9e6d036055a9a980b5549f887d6012969fabcca",
+        "dependencies": [
+          "jsr:@std/assert@^0.218.2",
+          "jsr:@std/path@^0.218.2"
+        ]
       },
       "@std/fs@0.224.0": {
         "integrity": "52a5ec89731ac0ca8f971079339286f88c571a4d61686acf75833f03a89d8e69",
@@ -44,6 +94,18 @@
       },
       "@std/internal@1.0.0": {
         "integrity": "ac6a6dfebf838582c4b4f61a6907374e27e05bedb6ce276e0f1608fe84e7cd9a"
+      },
+      "@std/io@0.218.2": {
+        "integrity": "c64fbfa087b7c9d4d386c5672f291f607d88cb7d44fc299c20c713e345f2785f",
+        "dependencies": [
+          "jsr:@std/bytes@^0.218.2"
+        ]
+      },
+      "@std/path@0.218.2": {
+        "integrity": "b568fd923d9e53ad76d17c513e7310bda8e755a3e825e6289a0ce536404e2662",
+        "dependencies": [
+          "jsr:@std/assert@^0.218.2"
+        ]
       },
       "@std/path@0.224.0": {
         "integrity": "55bca6361e5a6d158b9380e82d4981d82d338ec587de02951e2b7c3a24910ee6"
@@ -77,19 +139,169 @@
         "integrity": "sha512-I/zdjC6qYdwWJ2H1/PZbI3g58pPIiI/eOe5XDTtQ/v36d0ogcvAylqwOIWj/teY1rBnIMzUyWfX7PMm9I67WWg==",
         "dependencies": {}
       },
+      "@nodelib/fs.scandir@2.1.5": {
+        "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+        "dependencies": {
+          "@nodelib/fs.stat": "@nodelib/fs.stat@2.0.5",
+          "run-parallel": "run-parallel@1.2.0"
+        }
+      },
+      "@nodelib/fs.stat@2.0.5": {
+        "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+        "dependencies": {}
+      },
+      "@nodelib/fs.walk@1.2.8": {
+        "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+        "dependencies": {
+          "@nodelib/fs.scandir": "@nodelib/fs.scandir@2.1.5",
+          "fastq": "fastq@1.17.1"
+        }
+      },
+      "@ts-morph/bootstrap@0.22.0": {
+        "integrity": "sha512-MI5q7pid4swAlE2lcHwHRa6rcjoIMyT6fy8uuZm8BGg7DHGi/H5bQ0GMZzbk3N0r/LfStMdOYPkl+3IwvfIQ2g==",
+        "dependencies": {
+          "@ts-morph/common": "@ts-morph/common@0.22.0"
+        }
+      },
+      "@ts-morph/common@0.22.0": {
+        "integrity": "sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==",
+        "dependencies": {
+          "fast-glob": "fast-glob@3.3.2",
+          "minimatch": "minimatch@9.0.4",
+          "mkdirp": "mkdirp@3.0.1",
+          "path-browserify": "path-browserify@1.0.1"
+        }
+      },
+      "balanced-match@1.0.2": {
+        "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+        "dependencies": {}
+      },
+      "brace-expansion@2.0.1": {
+        "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+        "dependencies": {
+          "balanced-match": "balanced-match@1.0.2"
+        }
+      },
+      "braces@3.0.3": {
+        "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+        "dependencies": {
+          "fill-range": "fill-range@7.1.1"
+        }
+      },
       "cbor-redux@1.0.0": {
         "integrity": "sha512-nqCD/Yu2FON0XgZYdUNsMx1Tc08MOY3noh9bO2MvkjlyLZyqIVWjuz6A0mDrPJncdOfacokFUtF7zlzzP5oK5A==",
         "dependencies": {
           "@deno/shim-deno": "@deno/shim-deno@0.16.1"
         }
       },
+      "code-block-writer@13.0.1": {
+        "integrity": "sha512-c5or4P6erEA69TxaxTNcHUNcIn+oyxSRTOWV+pSYF+z4epXqNvwvJ70XPGjPNgue83oAFAPBRQYwpAJ/Hpe/Sg==",
+        "dependencies": {}
+      },
       "decimal.js@10.4.3": {
         "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+        "dependencies": {}
+      },
+      "fast-glob@3.3.2": {
+        "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+        "dependencies": {
+          "@nodelib/fs.stat": "@nodelib/fs.stat@2.0.5",
+          "@nodelib/fs.walk": "@nodelib/fs.walk@1.2.8",
+          "glob-parent": "glob-parent@5.1.2",
+          "merge2": "merge2@1.4.1",
+          "micromatch": "micromatch@4.0.7"
+        }
+      },
+      "fastq@1.17.1": {
+        "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+        "dependencies": {
+          "reusify": "reusify@1.0.4"
+        }
+      },
+      "fill-range@7.1.1": {
+        "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+        "dependencies": {
+          "to-regex-range": "to-regex-range@5.0.1"
+        }
+      },
+      "glob-parent@5.1.2": {
+        "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+        "dependencies": {
+          "is-glob": "is-glob@4.0.3"
+        }
+      },
+      "is-extglob@2.1.1": {
+        "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+        "dependencies": {}
+      },
+      "is-glob@4.0.3": {
+        "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+        "dependencies": {
+          "is-extglob": "is-extglob@2.1.1"
+        }
+      },
+      "is-number@7.0.0": {
+        "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
         "dependencies": {}
       },
       "isexe@2.0.0": {
         "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
         "dependencies": {}
+      },
+      "isows@1.0.4_ws@8.17.0": {
+        "integrity": "sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==",
+        "dependencies": {
+          "ws": "ws@8.17.0"
+        }
+      },
+      "merge2@1.4.1": {
+        "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+        "dependencies": {}
+      },
+      "micromatch@4.0.7": {
+        "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+        "dependencies": {
+          "braces": "braces@3.0.3",
+          "picomatch": "picomatch@2.3.1"
+        }
+      },
+      "minimatch@9.0.4": {
+        "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+        "dependencies": {
+          "brace-expansion": "brace-expansion@2.0.1"
+        }
+      },
+      "mkdirp@3.0.1": {
+        "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+        "dependencies": {}
+      },
+      "path-browserify@1.0.1": {
+        "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+        "dependencies": {}
+      },
+      "picomatch@2.3.1": {
+        "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+        "dependencies": {}
+      },
+      "queue-microtask@1.2.3": {
+        "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+        "dependencies": {}
+      },
+      "reusify@1.0.4": {
+        "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+        "dependencies": {}
+      },
+      "run-parallel@1.2.0": {
+        "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+        "dependencies": {
+          "queue-microtask": "queue-microtask@1.2.3"
+        }
+      },
+      "to-regex-range@5.0.1": {
+        "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+        "dependencies": {
+          "is-number": "is-number@7.0.0"
+        }
       },
       "uuidv7@1.0.0": {
         "integrity": "sha512-XkvPwTtSmYwxIE1FSYQTYg79zHL1ZWV5vM/Qyl9ahXCU8enOPPA4bTjzvafvYUB7l2+miv4EqK/qEe75cOXIdA==",
@@ -100,6 +312,10 @@
         "dependencies": {
           "isexe": "isexe@2.0.0"
         }
+      },
+      "ws@8.17.0": {
+        "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+        "dependencies": {}
       },
       "zod@3.23.8": {
         "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
@@ -113,6 +329,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@deno/dnt@^0.41.2",
       "jsr:@std/assert@^0.225.3",
       "jsr:@std/semver@^0.224.1",
       "jsr:@std/testing@^0.224.0",

--- a/deno.lock
+++ b/deno.lock
@@ -2,71 +2,16 @@
   "version": "3",
   "packages": {
     "specifiers": {
-      "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
-      "jsr:@std/assert@^0.225.3": "jsr:@std/assert@0.225.3",
-      "jsr:@std/fmt@^0.224.0": "jsr:@std/fmt@0.224.0",
-      "jsr:@std/fs@^0.224.0": "jsr:@std/fs@0.224.0",
-      "jsr:@std/internal@^0.224.0": "jsr:@std/internal@0.224.0",
-      "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.0",
-      "jsr:@std/path@^0.224.0": "jsr:@std/path@0.224.0",
-      "jsr:@std/testing@^0.224.0": "jsr:@std/testing@0.224.0",
+      "jsr:@std/semver@^0.224.1": "jsr:@std/semver@0.224.1",
       "npm:@icholy/duration@^5.1.0": "npm:@icholy/duration@5.1.0",
-      "npm:@types/node@^20.11.16": "npm:@types/node@20.12.2",
-      "npm:cbor-redux@1.0.0": "npm:cbor-redux@1.0.0",
       "npm:cbor-redux@^1.0.0": "npm:cbor-redux@1.0.0",
-      "npm:decimal.js@10.4.3": "npm:decimal.js@10.4.3",
       "npm:decimal.js@^10.4.3": "npm:decimal.js@10.4.3",
-      "npm:isows@^1.0.4": "npm:isows@1.0.4_ws@8.16.0",
-      "npm:node-fetch@^3.3.1": "npm:node-fetch@3.3.2",
-      "npm:semver": "npm:semver@7.5.4",
-      "npm:semver@^7.6.2": "npm:semver@7.6.2",
-      "npm:typescript@^5.3.3": "npm:typescript@5.4.3",
-      "npm:uuidv7@0.6.3": "npm:uuidv7@0.6.3",
-      "npm:uuidv7@^0.6.3": "npm:uuidv7@0.6.3",
       "npm:uuidv7@^1.0.0": "npm:uuidv7@1.0.0",
-      "npm:zod": "npm:zod@3.22.4",
-      "npm:zod@^3.22.4": "npm:zod@3.22.4",
       "npm:zod@^3.23.8": "npm:zod@3.23.8"
     },
     "jsr": {
-      "@std/assert@0.224.0": {
-        "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f",
-        "dependencies": [
-          "jsr:@std/internal@^0.224.0"
-        ]
-      },
-      "@std/assert@0.225.3": {
-        "integrity": "b3c2847aecf6955b50644cdb9cf072004ea3d1998dd7579fc0acb99dbb23bd4f",
-        "dependencies": [
-          "jsr:@std/internal@^1.0.0"
-        ]
-      },
-      "@std/fmt@0.224.0": {
-        "integrity": "e20e9a2312a8b5393272c26191c0a68eda8d2c4b08b046bad1673148f1d69851"
-      },
-      "@std/fs@0.224.0": {
-        "integrity": "52a5ec89731ac0ca8f971079339286f88c571a4d61686acf75833f03a89d8e69",
-        "dependencies": [
-          "jsr:@std/path@^0.224.0"
-        ]
-      },
-      "@std/internal@0.224.0": {
-        "integrity": "afc50644f9cdf4495eeb80523a8f6d27226b4b36c45c7c195dfccad4b8509291"
-      },
-      "@std/internal@1.0.0": {
-        "integrity": "ac6a6dfebf838582c4b4f61a6907374e27e05bedb6ce276e0f1608fe84e7cd9a"
-      },
-      "@std/path@0.224.0": {
-        "integrity": "55bca6361e5a6d158b9380e82d4981d82d338ec587de02951e2b7c3a24910ee6"
-      },
-      "@std/testing@0.224.0": {
-        "integrity": "371b8a929aa7132240d5dd766a439be8f780ef5c176ab194e0bcab72370c761e",
-        "dependencies": [
-          "jsr:@std/assert@^0.224.0",
-          "jsr:@std/fmt@^0.224.0",
-          "jsr:@std/fs@^0.224.0",
-          "jsr:@std/path@^0.224.0"
-        ]
+      "@std/semver@0.224.1": {
+        "integrity": "d3f34db1d5047add33614a54bdec56b5f9f590c36b0cc87eaaee2c3d38ad60c5"
       }
     },
     "npm": {
@@ -85,95 +30,22 @@
         "integrity": "sha512-I/zdjC6qYdwWJ2H1/PZbI3g58pPIiI/eOe5XDTtQ/v36d0ogcvAylqwOIWj/teY1rBnIMzUyWfX7PMm9I67WWg==",
         "dependencies": {}
       },
-      "@types/node@20.12.2": {
-        "integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
-        "dependencies": {
-          "undici-types": "undici-types@5.26.5"
-        }
-      },
       "cbor-redux@1.0.0": {
         "integrity": "sha512-nqCD/Yu2FON0XgZYdUNsMx1Tc08MOY3noh9bO2MvkjlyLZyqIVWjuz6A0mDrPJncdOfacokFUtF7zlzzP5oK5A==",
         "dependencies": {
           "@deno/shim-deno": "@deno/shim-deno@0.16.1"
         }
       },
-      "data-uri-to-buffer@4.0.1": {
-        "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-        "dependencies": {}
-      },
       "decimal.js@10.4.3": {
         "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
         "dependencies": {}
-      },
-      "fetch-blob@3.2.0": {
-        "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-        "dependencies": {
-          "node-domexception": "node-domexception@1.0.0",
-          "web-streams-polyfill": "web-streams-polyfill@3.3.3"
-        }
-      },
-      "formdata-polyfill@4.0.10": {
-        "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-        "dependencies": {
-          "fetch-blob": "fetch-blob@3.2.0"
-        }
       },
       "isexe@2.0.0": {
         "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
         "dependencies": {}
       },
-      "isows@1.0.4_ws@8.16.0": {
-        "integrity": "sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==",
-        "dependencies": {
-          "ws": "ws@8.16.0"
-        }
-      },
-      "lru-cache@6.0.0": {
-        "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-        "dependencies": {
-          "yallist": "yallist@4.0.0"
-        }
-      },
-      "node-domexception@1.0.0": {
-        "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-        "dependencies": {}
-      },
-      "node-fetch@3.3.2": {
-        "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-        "dependencies": {
-          "data-uri-to-buffer": "data-uri-to-buffer@4.0.1",
-          "fetch-blob": "fetch-blob@3.2.0",
-          "formdata-polyfill": "formdata-polyfill@4.0.10"
-        }
-      },
-      "semver@7.5.4": {
-        "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-        "dependencies": {
-          "lru-cache": "lru-cache@6.0.0"
-        }
-      },
-      "semver@7.6.2": {
-        "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-        "dependencies": {}
-      },
-      "typescript@5.4.3": {
-        "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
-        "dependencies": {}
-      },
-      "undici-types@5.26.5": {
-        "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-        "dependencies": {}
-      },
-      "uuidv7@0.6.3": {
-        "integrity": "sha512-zV3eW2NlXTsun/aJ7AixxZjH/byQcH/r3J99MI0dDEkU2cJIBJxhEWUHDTpOaLPRNhebPZoeHuykYREkI9HafA==",
-        "dependencies": {}
-      },
       "uuidv7@1.0.0": {
         "integrity": "sha512-XkvPwTtSmYwxIE1FSYQTYg79zHL1ZWV5vM/Qyl9ahXCU8enOPPA4bTjzvafvYUB7l2+miv4EqK/qEe75cOXIdA==",
-        "dependencies": {}
-      },
-      "web-streams-polyfill@3.3.3": {
-        "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
         "dependencies": {}
       },
       "which@2.0.2": {
@@ -182,198 +54,22 @@
           "isexe": "isexe@2.0.0"
         }
       },
-      "ws@8.16.0": {
-        "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-        "dependencies": {}
-      },
-      "yallist@4.0.0": {
-        "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-        "dependencies": {}
-      },
-      "zod@3.22.4": {
-        "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-        "dependencies": {}
-      },
       "zod@3.23.8": {
         "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
         "dependencies": {}
       }
     }
   },
-  "redirects": {
-    "https://deno.land/x/port/mod.ts": "https://deno.land/x/port@1.0.0/mod.ts"
-  },
-  "remote": {
-    "https://deno.land/std@0.140.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
-    "https://deno.land/std@0.140.0/_util/os.ts": "3b4c6e27febd119d36a416d7a97bd3b0251b77c88942c8f16ee5953ea13e2e49",
-    "https://deno.land/std@0.140.0/bytes/bytes_list.ts": "67eb118e0b7891d2f389dad4add35856f4ad5faab46318ff99653456c23b025d",
-    "https://deno.land/std@0.140.0/bytes/equals.ts": "fc16dff2090cced02497f16483de123dfa91e591029f985029193dfaa9d894c9",
-    "https://deno.land/std@0.140.0/bytes/mod.ts": "763f97d33051cc3f28af1a688dfe2830841192a9fea0cbaa55f927b49d49d0bf",
-    "https://deno.land/std@0.140.0/fmt/colors.ts": "30455035d6d728394781c10755351742dd731e3db6771b1843f9b9e490104d37",
-    "https://deno.land/std@0.140.0/fs/_util.ts": "0fb24eb4bfebc2c194fb1afdb42b9c3dda12e368f43e8f2321f84fc77d42cb0f",
-    "https://deno.land/std@0.140.0/fs/ensure_dir.ts": "9dc109c27df4098b9fc12d949612ae5c9c7169507660dcf9ad90631833209d9d",
-    "https://deno.land/std@0.140.0/hash/sha256.ts": "803846c7a5a8a5a97f31defeb37d72f519086c880837129934f5d6f72102a8e8",
-    "https://deno.land/std@0.140.0/io/buffer.ts": "bd0c4bf53db4b4be916ca5963e454bddfd3fcd45039041ea161dbf826817822b",
-    "https://deno.land/std@0.140.0/path/_constants.ts": "df1db3ffa6dd6d1252cc9617e5d72165cd2483df90e93833e13580687b6083c3",
-    "https://deno.land/std@0.140.0/path/_interface.ts": "ee3b431a336b80cf445441109d089b70d87d5e248f4f90ff906820889ecf8d09",
-    "https://deno.land/std@0.140.0/path/_util.ts": "c1e9686d0164e29f7d880b2158971d805b6e0efc3110d0b3e24e4b8af2190d2b",
-    "https://deno.land/std@0.140.0/path/common.ts": "bee563630abd2d97f99d83c96c2fa0cca7cee103e8cb4e7699ec4d5db7bd2633",
-    "https://deno.land/std@0.140.0/path/glob.ts": "cb5255638de1048973c3e69e420c77dc04f75755524cb3b2e160fe9277d939ee",
-    "https://deno.land/std@0.140.0/path/mod.ts": "d3e68d0abb393fb0bf94a6d07c46ec31dc755b544b13144dee931d8d5f06a52d",
-    "https://deno.land/std@0.140.0/path/posix.ts": "293cdaec3ecccec0a9cc2b534302dfe308adb6f10861fa183275d6695faace44",
-    "https://deno.land/std@0.140.0/path/separator.ts": "fe1816cb765a8068afb3e8f13ad272351c85cbc739af56dacfc7d93d710fe0f9",
-    "https://deno.land/std@0.140.0/path/win32.ts": "31811536855e19ba37a999cd8d1b62078235548d67902ece4aa6b814596dd757",
-    "https://deno.land/std@0.140.0/streams/conversion.ts": "712585bfa0172a97fb68dd46e784ae8ad59d11b88079d6a4ab098ff42e697d21",
-    "https://deno.land/std@0.181.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
-    "https://deno.land/std@0.181.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
-    "https://deno.land/std@0.181.0/fs/_util.ts": "65381f341af1ff7f40198cee15c20f59951ac26e51ddc651c5293e24f9ce6f32",
-    "https://deno.land/std@0.181.0/fs/ensure_dir.ts": "dc64c4c75c64721d4e3fb681f1382f803ff3d2868f08563ff923fdd20d071c40",
-    "https://deno.land/std@0.181.0/fs/expand_glob.ts": "e4f56259a0a70fe23f05215b00de3ac5e6ba46646ab2a06ebbe9b010f81c972a",
-    "https://deno.land/std@0.181.0/fs/walk.ts": "ea95ffa6500c1eda6b365be488c056edc7c883a1db41ef46ec3bf057b1c0fe32",
-    "https://deno.land/std@0.181.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
-    "https://deno.land/std@0.181.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
-    "https://deno.land/std@0.181.0/path/_util.ts": "d7abb1e0dea065f427b89156e28cdeb32b045870acdf865833ba808a73b576d0",
-    "https://deno.land/std@0.181.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
-    "https://deno.land/std@0.181.0/path/glob.ts": "d479e0a695621c94d3fd7fe7abd4f9499caf32a8de13f25073451c6ef420a4e1",
-    "https://deno.land/std@0.181.0/path/mod.ts": "bf718f19a4fdd545aee1b06409ca0805bd1b68ecf876605ce632e932fe54510c",
-    "https://deno.land/std@0.181.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
-    "https://deno.land/std@0.181.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
-    "https://deno.land/std@0.181.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba",
-    "https://deno.land/std@0.182.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
-    "https://deno.land/std@0.182.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
-    "https://deno.land/std@0.182.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.182.0/fs/_util.ts": "65381f341af1ff7f40198cee15c20f59951ac26e51ddc651c5293e24f9ce6f32",
-    "https://deno.land/std@0.182.0/fs/empty_dir.ts": "c3d2da4c7352fab1cf144a1ecfef58090769e8af633678e0f3fabaef98594688",
-    "https://deno.land/std@0.182.0/fs/expand_glob.ts": "e4f56259a0a70fe23f05215b00de3ac5e6ba46646ab2a06ebbe9b010f81c972a",
-    "https://deno.land/std@0.182.0/fs/walk.ts": "920be35a7376db6c0b5b1caf1486fb962925e38c9825f90367f8f26b5e5d0897",
-    "https://deno.land/std@0.182.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
-    "https://deno.land/std@0.182.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
-    "https://deno.land/std@0.182.0/path/_util.ts": "d7abb1e0dea065f427b89156e28cdeb32b045870acdf865833ba808a73b576d0",
-    "https://deno.land/std@0.182.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
-    "https://deno.land/std@0.182.0/path/glob.ts": "d479e0a695621c94d3fd7fe7abd4f9499caf32a8de13f25073451c6ef420a4e1",
-    "https://deno.land/std@0.182.0/path/mod.ts": "bf718f19a4fdd545aee1b06409ca0805bd1b68ecf876605ce632e932fe54510c",
-    "https://deno.land/std@0.182.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
-    "https://deno.land/std@0.182.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
-    "https://deno.land/std@0.182.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba",
-    "https://deno.land/std@0.223.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
-    "https://deno.land/std@0.223.0/assert/_diff.ts": "4bf42969aa8b1a33aaf23eb8e478b011bfaa31b82d85d2ff4b5c4662d8780d2b",
-    "https://deno.land/std@0.223.0/assert/_format.ts": "0ba808961bf678437fb486b56405b6fefad2cf87b5809667c781ddee8c32aff4",
-    "https://deno.land/std@0.223.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
-    "https://deno.land/std@0.223.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
-    "https://deno.land/std@0.223.0/assert/assert_array_includes.ts": "167b2c29997defd49a1835de52b54ae3cbb2bcba52df7c7ee45fe64b473264f1",
-    "https://deno.land/std@0.223.0/assert/assert_equals.ts": "cc1f4b0ff4ad511e69f965535b56a6cdbbbc0f086bf376e0243214df6039c883",
-    "https://deno.land/std@0.223.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
-    "https://deno.land/std@0.223.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
-    "https://deno.land/std@0.223.0/assert/assert_greater.ts": "26903fc7170a9eb37ee6c6606c772b5a0465a85e719cfe46f57de35555931419",
-    "https://deno.land/std@0.223.0/assert/assert_greater_or_equal.ts": "10527cf379a71a55a88b96d9b3373d0346ea2bdd8d73d2faaab1224e2cedb727",
-    "https://deno.land/std@0.223.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
-    "https://deno.land/std@0.223.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
-    "https://deno.land/std@0.223.0/assert/assert_less.ts": "091f0cc80f53425be22b14c9b6ae410fea08e16eca391a476303c5f4852fcd9e",
-    "https://deno.land/std@0.223.0/assert/assert_less_or_equal.ts": "9418b2f809023f778d58fd6834410814900eacb8a91708647970ae1085553813",
-    "https://deno.land/std@0.223.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
-    "https://deno.land/std@0.223.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
-    "https://deno.land/std@0.223.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
-    "https://deno.land/std@0.223.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
-    "https://deno.land/std@0.223.0/assert/assert_not_strict_equals.ts": "61e4adfd80eddaab5da5e5444431dfb19457f26b1f1e7a8be27c5d981b7f50b9",
-    "https://deno.land/std@0.223.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
-    "https://deno.land/std@0.223.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
-    "https://deno.land/std@0.223.0/assert/assert_strict_equals.ts": "dbcdcb5b8b74e6c06bce6a9fa43ff4d1089793e7832baff251e514954b9b266b",
-    "https://deno.land/std@0.223.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
-    "https://deno.land/std@0.223.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
-    "https://deno.land/std@0.223.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
-    "https://deno.land/std@0.223.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
-    "https://deno.land/std@0.223.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
-    "https://deno.land/std@0.223.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
-    "https://deno.land/std@0.223.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
-    "https://deno.land/std@0.223.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
-    "https://deno.land/std@0.223.0/fmt/colors.ts": "d239d84620b921ea520125d778947881f62c50e78deef2657073840b8af9559a",
-    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
-    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
-    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
-    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
-    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
-    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
-    "https://deno.land/std@0.224.0/fs/_get_file_info_type.ts": "da7bec18a7661dba360a1db475b826b18977582ce6fc9b25f3d4ee0403fe8cbd",
-    "https://deno.land/std@0.224.0/fs/_to_path_string.ts": "29bfc9c6c112254961d75cbf6ba814d6de5349767818eb93090cecfa9665591e",
-    "https://deno.land/std@0.224.0/fs/ensure_dir.ts": "51a6279016c65d2985f8803c848e2888e206d1b510686a509fa7cc34ce59d29f",
-    "https://deno.land/std@0.224.0/fs/ensure_file.ts": "67608cf550529f3d4aa1f8b6b36bf817bdc40b14487bf8f60e61cbf68f507cf3",
-    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
-    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
-    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
-    "https://deno.land/std@0.224.0/path/_common/assert_path.ts": "dbdd757a465b690b2cc72fc5fb7698c51507dec6bfafce4ca500c46b76ff7bd8",
-    "https://deno.land/std@0.224.0/path/_common/constants.ts": "dc5f8057159f4b48cd304eb3027e42f1148cf4df1fb4240774d3492b5d12ac0c",
-    "https://deno.land/std@0.224.0/path/_common/dirname.ts": "684df4aa71a04bbcc346c692c8485594fc8a90b9408dfbc26ff32cf3e0c98cc8",
-    "https://deno.land/std@0.224.0/path/_common/from_file_url.ts": "d672bdeebc11bf80e99bf266f886c70963107bdd31134c4e249eef51133ceccf",
-    "https://deno.land/std@0.224.0/path/_common/normalize_string.ts": "33edef773c2a8e242761f731adeb2bd6d683e9c69e4e3d0092985bede74f4ac3",
-    "https://deno.land/std@0.224.0/path/_common/strip_trailing_separators.ts": "7024a93447efcdcfeaa9339a98fa63ef9d53de363f1fbe9858970f1bba02655a",
-    "https://deno.land/std@0.224.0/path/_common/to_file_url.ts": "7f76adbc83ece1bba173e6e98a27c647712cab773d3f8cbe0398b74afc817883",
-    "https://deno.land/std@0.224.0/path/_interface.ts": "8dfeb930ca4a772c458a8c7bbe1e33216fe91c253411338ad80c5b6fa93ddba0",
-    "https://deno.land/std@0.224.0/path/_os.ts": "8fb9b90fb6b753bd8c77cfd8a33c2ff6c5f5bc185f50de8ca4ac6a05710b2c15",
-    "https://deno.land/std@0.224.0/path/dirname.ts": "85bd955bf31d62c9aafdd7ff561c4b5fb587d11a9a5a45e2b01aedffa4238a7c",
-    "https://deno.land/std@0.224.0/path/from_file_url.ts": "911833ae4fd10a1c84f6271f36151ab785955849117dc48c6e43b929504ee069",
-    "https://deno.land/std@0.224.0/path/parse.ts": "77ad91dcb235a66c6f504df83087ce2a5471e67d79c402014f6e847389108d5a",
-    "https://deno.land/std@0.224.0/path/posix/_util.ts": "1e3937da30f080bfc99fe45d7ed23c47dd8585c5e473b2d771380d3a6937cf9d",
-    "https://deno.land/std@0.224.0/path/posix/dirname.ts": "76cd348ffe92345711409f88d4d8561d8645353ac215c8e9c80140069bf42f00",
-    "https://deno.land/std@0.224.0/path/posix/from_file_url.ts": "951aee3a2c46fd0ed488899d024c6352b59154c70552e90885ed0c2ab699bc40",
-    "https://deno.land/std@0.224.0/path/posix/is_absolute.ts": "cebe561ad0ae294f0ce0365a1879dcfca8abd872821519b4fcc8d8967f888ede",
-    "https://deno.land/std@0.224.0/path/posix/parse.ts": "09dfad0cae530f93627202f28c1befa78ea6e751f92f478ca2cc3b56be2cbb6a",
-    "https://deno.land/std@0.224.0/path/posix/resolve.ts": "08b699cfeee10cb6857ccab38fa4b2ec703b0ea33e8e69964f29d02a2d5257cf",
-    "https://deno.land/std@0.224.0/path/posix/to_file_url.ts": "7aa752ba66a35049e0e4a4be5a0a31ac6b645257d2e031142abb1854de250aaf",
-    "https://deno.land/std@0.224.0/path/resolve.ts": "a6f977bdb4272e79d8d0ed4333e3d71367cc3926acf15ac271f1d059c8494d8d",
-    "https://deno.land/std@0.224.0/path/to_file_url.ts": "88f049b769bce411e2d2db5bd9e6fd9a185a5fbd6b9f5ad8f52bef517c4ece1b",
-    "https://deno.land/std@0.224.0/path/windows/_util.ts": "d5f47363e5293fced22c984550d5e70e98e266cc3f31769e1710511803d04808",
-    "https://deno.land/std@0.224.0/path/windows/dirname.ts": "33e421be5a5558a1346a48e74c330b8e560be7424ed7684ea03c12c21b627bc9",
-    "https://deno.land/std@0.224.0/path/windows/from_file_url.ts": "ced2d587b6dff18f963f269d745c4a599cf82b0c4007356bd957cb4cb52efc01",
-    "https://deno.land/std@0.224.0/path/windows/is_absolute.ts": "4a8f6853f8598cf91a835f41abed42112cebab09478b072e4beb00ec81f8ca8a",
-    "https://deno.land/std@0.224.0/path/windows/parse.ts": "08804327b0484d18ab4d6781742bf374976de662f8642e62a67e93346e759707",
-    "https://deno.land/std@0.224.0/path/windows/resolve.ts": "8dae1dadfed9d46ff46cc337c9525c0c7d959fb400a6308f34595c45bdca1972",
-    "https://deno.land/std@0.224.0/path/windows/to_file_url.ts": "40e560ee4854fe5a3d4d12976cef2f4e8914125c81b11f1108e127934ced502e",
-    "https://deno.land/std@0.224.0/testing/snapshot.ts": "35ca1c8e8bfb98d7b7e794f1b7be8d992483fcff572540e41396f22a5bddb944",
-    "https://deno.land/x/code_block_writer@12.0.0/mod.ts": "2c3448060e47c9d08604c8f40dee34343f553f33edcdfebbf648442be33205e5",
-    "https://deno.land/x/code_block_writer@12.0.0/utils/string_utils.ts": "60cb4ec8bd335bf241ef785ccec51e809d576ff8e8d29da43d2273b69ce2a6ff",
-    "https://deno.land/x/deno_cache@0.4.1/auth_tokens.ts": "5fee7e9155e78cedf3f6ff3efacffdb76ac1a76c86978658d9066d4fb0f7326e",
-    "https://deno.land/x/deno_cache@0.4.1/cache.ts": "51f72f4299411193d780faac8c09d4e8cbee951f541121ef75fcc0e94e64c195",
-    "https://deno.land/x/deno_cache@0.4.1/deno_dir.ts": "f2a9044ce8c7fe1109004cda6be96bf98b08f478ce77e7a07f866eff1bdd933f",
-    "https://deno.land/x/deno_cache@0.4.1/deps.ts": "8974097d6c17e65d9a82d39377ae8af7d94d74c25c0cbb5855d2920e063f2343",
-    "https://deno.land/x/deno_cache@0.4.1/dirs.ts": "d2fa473ef490a74f2dcb5abb4b9ab92a48d2b5b6320875df2dee64851fa64aa9",
-    "https://deno.land/x/deno_cache@0.4.1/disk_cache.ts": "1f3f5232cba4c56412d93bdb324c624e95d5dd179d0578d2121e3ccdf55539f9",
-    "https://deno.land/x/deno_cache@0.4.1/file_fetcher.ts": "07a6c5f8fd94bf50a116278cc6012b4921c70d2251d98ce1c9f3c352135c39f7",
-    "https://deno.land/x/deno_cache@0.4.1/http_cache.ts": "f632e0d6ec4a5d61ae3987737a72caf5fcdb93670d21032ddb78df41131360cd",
-    "https://deno.land/x/deno_cache@0.4.1/mod.ts": "ef1cda9235a93b89cb175fe648372fc0f785add2a43aa29126567a05e3e36195",
-    "https://deno.land/x/deno_cache@0.4.1/util.ts": "8cb686526f4be5205b92c819ca2ce82220aa0a8dd3613ef0913f6dc269dbbcfe",
-    "https://deno.land/x/dnt@0.34.0/lib/compiler.ts": "dd589db479d6d7e69999865003ab83c41544e251ece4f21f2f2ee74557097ba6",
-    "https://deno.land/x/dnt@0.34.0/lib/compiler_transforms.ts": "cbb1fd5948f5ced1aa5c5aed9e45134e2357ce1e7220924c1d7bded30dcd0dd0",
-    "https://deno.land/x/dnt@0.34.0/lib/mod.deps.ts": "30367fc68bcd2acf3b7020cf5cdd26f817f7ac9ac35c4bfb6c4551475f91bc3e",
-    "https://deno.land/x/dnt@0.34.0/lib/npm_ignore.ts": "ddc1a7a76b288ca471bf1a6298527887a0f9eb7e25008072fd9c9fa9bb28c71a",
-    "https://deno.land/x/dnt@0.34.0/lib/package_json.ts": "2d629dbaef8004971e38ce3661f04b915a35342b905c3d98ff4a25343c2a8293",
-    "https://deno.land/x/dnt@0.34.0/lib/pkg/dnt_wasm.generated.js": "ad5c205f018b2bc6258d00d6a0539c2ffa94275f16f106f0f072bcf77f3c786b",
-    "https://deno.land/x/dnt@0.34.0/lib/pkg/snippets/dnt-wasm-a15ef721fa5290c5/helpers.js": "a6b95adc943a68d513fe8ed9ec7d260ac466b7a4bced4e942f733e494bb9f1be",
-    "https://deno.land/x/dnt@0.34.0/lib/shims.ts": "f6030d8dab258dd2d12bad93353e11143ee7fba8718d24d13d71f40b10c5df47",
-    "https://deno.land/x/dnt@0.34.0/lib/test_runner/get_test_runner_code.ts": "2a4e26aa33120f3cc9e03b8538211a5047a4bad4c64e895944b87f2dcd55d904",
-    "https://deno.land/x/dnt@0.34.0/lib/test_runner/test_runner.ts": "b91d77d9d4b82984cb2ba7431ba6935756ba72f62e7dd4db22cd47a680ebd952",
-    "https://deno.land/x/dnt@0.34.0/lib/transform.deps.ts": "e42f2bdef46d098453bdba19261a67cf90b583f5d868f7fe83113c1380d9b85c",
-    "https://deno.land/x/dnt@0.34.0/lib/types.ts": "34e45a3136c2f21f797173ea46d9ea5d1639eb7b834a5bd565aad4214fa32603",
-    "https://deno.land/x/dnt@0.34.0/lib/utils.ts": "d13b5b3148a2c71e9b2f1c84c7be7393b825ae972505e23c2f6b1e5287e96b43",
-    "https://deno.land/x/dnt@0.34.0/mod.ts": "3ee53f4d4d41df72e57ecbca9f3c2b7cf86166ef57fa04452865780f83c555a9",
-    "https://deno.land/x/dnt@0.34.0/transform.ts": "1b127c5f22699c8ab2545b98aeca38c4e5c21405b0f5342ea17e9c46280ed277",
-    "https://deno.land/x/port@1.0.0/mod.ts": "2dc04ce1ccf133ae09205e30b550044c4c6f64a1a7d00ea91c66dbb9f6cc00f5",
-    "https://deno.land/x/port@1.0.0/types.ts": "42d6ae4147d5d67408d60209da070ddfa79ec8389c6cab1b8002df0cf6c03af6",
-    "https://deno.land/x/ts_morph@18.0.0/bootstrap/mod.ts": "b53aad517f106c4079971fcd4a81ab79fadc40b50061a3ab2b741a09119d51e9",
-    "https://deno.land/x/ts_morph@18.0.0/bootstrap/ts_morph_bootstrap.js": "6645ac03c5e6687dfa8c78109dc5df0250b811ecb3aea2d97c504c35e8401c06",
-    "https://deno.land/x/ts_morph@18.0.0/common/DenoRuntime.ts": "6a7180f0c6e90dcf23ccffc86aa8271c20b1c4f34c570588d08a45880b7e172d",
-    "https://deno.land/x/ts_morph@18.0.0/common/mod.ts": "01985d2ee7da8d1caee318a9d07664774fbee4e31602bc2bb6bb62c3489555ed",
-    "https://deno.land/x/ts_morph@18.0.0/common/ts_morph_common.js": "845671ca951073400ce142f8acefa2d39ea9a51e29ca80928642f3f8cf2b7700",
-    "https://deno.land/x/ts_morph@18.0.0/common/typescript.js": "d5c598b6a2db2202d0428fca5fd79fc9a301a71880831a805d778797d2413c59"
-  },
+  "remote": {},
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^0.225.3",
+      "jsr:@std/semver@^0.224.1",
       "jsr:@std/testing@^0.224.0",
       "npm:@icholy/duration@^5.1.0",
       "npm:cbor-redux@^1.0.0",
       "npm:decimal.js@^10.4.3",
       "npm:isows@^1.0.4",
-      "npm:semver@^7.6.2",
       "npm:uuidv7@^1.0.0",
       "npm:zod@^3.23.8"
     ]

--- a/project.json
+++ b/project.json
@@ -1,4 +1,0 @@
-{
-  "name": "surrealdb.js",
-  "version": "1.0.0-beta.8"
-}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,6 @@
+import type { Range, SemVer } from "@std/semver";
+import { format } from "@std/semver";
+
 export class SurrealDbError extends Error {}
 
 export class NoActiveSocket extends SurrealDbError {
@@ -105,15 +108,16 @@ export class NoTokenReturned extends SurrealDbError {
 
 export class UnsupportedVersion extends SurrealDbError {
 	name = "UnsupportedVersion";
-	version: string;
-	supportedRange: string;
+	version: SemVer;
+	supportedRange: Range;
 
-	constructor(version: string, supportedRange: string) {
+	constructor(version: SemVer, supportedRange: Range) {
 		super();
 		this.version = version;
 		this.supportedRange = supportedRange;
-		this.message =
-			`The version "${version}" reported by the engine is not supported by this library, expected a version that satisfies "${supportedRange}".`;
+		this.message = `The version "${
+			format(version)
+		}" reported by the engine is not supported by this library, expected a version that satisfies "${supportedRange}".`;
 	}
 }
 

--- a/src/library/WebSocket/node.ts
+++ b/src/library/WebSocket/node.ts
@@ -1,1 +1,1 @@
-export { WebSocket as default } from "npm:isows@^1.0.4";
+export { WebSocket as default } from "isows";

--- a/src/library/cbor/decimal.ts
+++ b/src/library/cbor/decimal.ts
@@ -1,1 +1,1 @@
-export { Decimal } from "npm:decimal.js@^10.4.3";
+export { Decimal } from "decimal.js";

--- a/src/library/cbor/duration.ts
+++ b/src/library/cbor/duration.ts
@@ -1,12 +1,12 @@
 import { Duration as IcholyDuration } from "@icholy/duration";
 
 export class Duration extends IcholyDuration {
-	toJSON() {
+	toJSON(): string {
 		return this.toString();
 	}
 }
 
-export function durationToCborCustomDuration(duration: Duration) {
+export function durationToCborCustomDuration(duration: Duration): number[] {
 	const ms = duration.milliseconds();
 	const s = Math.floor(ms / 1000);
 	const ns = Math.floor((ms - s * 1000) * 1000000);

--- a/src/library/cbor/duration.ts
+++ b/src/library/cbor/duration.ts
@@ -1,4 +1,4 @@
-import { Duration as IcholyDuration } from "npm:@icholy/duration@^5.1.0";
+import { Duration as IcholyDuration } from "@icholy/duration";
 
 export class Duration extends IcholyDuration {
 	toJSON() {

--- a/src/library/cbor/geometry.ts
+++ b/src/library/cbor/geometry.ts
@@ -21,14 +21,17 @@ export class GeometryPoint extends Geometry {
 		];
 	}
 
-	toJSON() {
+	toJSON(): {
+		type: "Point";
+		coordinates: [Decimal, Decimal];
+	} {
 		return {
 			type: "Point" as const,
 			coordinates: this.coordinates,
 		};
 	}
 
-	get coordinates() {
+	get coordinates(): [Decimal, Decimal] {
 		return this.point;
 	}
 }
@@ -46,14 +49,17 @@ export class GeometryLine extends Geometry {
 		this.line = [new GeometryPoint(line[0]), new GeometryPoint(line[1])];
 	}
 
-	toJSON() {
+	toJSON(): {
+		type: "LineString";
+		coordinates: [Decimal, Decimal][];
+	} {
 		return {
 			type: "LineString" as const,
 			coordinates: this.coordinates,
 		};
 	}
 
-	get coordinates() {
+	get coordinates(): [Decimal, Decimal][] {
 		return this.line.map((g) => g.coordinates);
 	}
 }
@@ -77,14 +83,17 @@ export class GeometryPolygon extends Geometry {
 		];
 	}
 
-	toJSON() {
+	toJSON(): {
+		type: "Polygon";
+		coordinates: [Decimal, Decimal][][];
+	} {
 		return {
 			type: "Polygon" as const,
 			coordinates: this.coordinates,
 		};
 	}
 
-	get coordinates() {
+	get coordinates(): [Decimal, Decimal][][] {
 		return this.polygon.map((g) => g.coordinates);
 	}
 }
@@ -103,14 +112,17 @@ export class GeometryMultiPoint extends Geometry {
 		];
 	}
 
-	toJSON() {
+	toJSON(): {
+		type: "MultiPoint";
+		coordinates: [Decimal, Decimal][];
+	} {
 		return {
 			type: "MultiPoint" as const,
 			coordinates: this.coordinates,
 		};
 	}
 
-	get coordinates() {
+	get coordinates(): [Decimal, Decimal][] {
 		return this.points.map((g) => g.coordinates);
 	}
 }
@@ -127,14 +139,17 @@ export class GeometryMultiLine extends Geometry {
 		];
 	}
 
-	toJSON() {
+	toJSON(): {
+		type: "MultiLineString";
+		coordinates: [Decimal, Decimal][][];
+	} {
 		return {
 			type: "MultiLineString" as const,
 			coordinates: this.coordinates,
 		};
 	}
 
-	get coordinates() {
+	get coordinates(): [Decimal, Decimal][][] {
 		return this.lines.map((g) => g.coordinates);
 	}
 }
@@ -157,14 +172,17 @@ export class GeometryMultiPolygon extends Geometry {
 		) as [GeometryPolygon, ...GeometryPolygon[]];
 	}
 
-	toJSON() {
+	toJSON(): {
+		type: "MultiPolygon";
+		coordinates: [Decimal, Decimal][][][];
+	} {
 		return {
 			type: "MultiPolygon" as const,
 			coordinates: this.coordinates,
 		};
 	}
 
-	get coordinates() {
+	get coordinates(): [Decimal, Decimal][][][] {
 		return this.polygons.map((g) => g.coordinates);
 	}
 }
@@ -181,14 +199,17 @@ export class GeometryCollection<T extends [Geometry, ...Geometry[]]>
 		this.collection = collection;
 	}
 
-	toJSON() {
+	toJSON(): {
+		type: "GeometryCollection";
+		coordinates: { [K in keyof T]: ReturnType<T[K]["toJSON"]> };
+	} {
 		return {
 			type: "GeometryCollection" as const,
 			coordinates: this.coordinates,
 		};
 	}
 
-	get coordinates() {
+	get coordinates(): { [K in keyof T]: ReturnType<T[K]["toJSON"]> } {
 		return this.collection.map((g) => g.toJSON()) as {
 			[K in keyof T]: ReturnType<T[K]["toJSON"]>;
 		};

--- a/src/library/cbor/geometry.ts
+++ b/src/library/cbor/geometry.ts
@@ -1,4 +1,4 @@
-import { Decimal } from "npm:decimal.js@^10.4.3";
+import { Decimal } from "decimal.js";
 
 export abstract class Geometry {
 	abstract toJSON(): {

--- a/src/library/cbor/index.ts
+++ b/src/library/cbor/index.ts
@@ -47,7 +47,7 @@ const TAG_GEOMETRY_MULTILINE = 92;
 const TAG_GEOMETRY_MULTIPOLYGON = 93;
 const TAG_GEOMETRY_COLLECTION = 94;
 
-export function encodeCbor<T extends unknown>(data: T) {
+export function encodeCbor<T extends unknown>(data: T): ArrayBuffer {
 	return encode_cbor<T>(data, (_, v) => {
 		if (v instanceof Date) {
 			return new TaggedValue(
@@ -100,7 +100,7 @@ export function encodeCbor<T extends unknown>(data: T) {
 	});
 }
 
-export function decodeCbor(data: ArrayBuffer) {
+export function decodeCbor(data: ArrayBuffer): any {
 	return decode_cbor(data, (_, v) => {
 		if (!(v instanceof TaggedValue)) return v;
 

--- a/src/library/cbor/index.ts
+++ b/src/library/cbor/index.ts
@@ -2,7 +2,7 @@ import {
 	decode as decode_cbor,
 	encode as encode_cbor,
 	TaggedValue,
-} from "npm:cbor-redux@1.0.0";
+} from "cbor-redux";
 import { RecordId, StringRecordId } from "./recordid.ts";
 import { UUID, uuidv4, uuidv7 } from "./uuid.ts";
 import {

--- a/src/library/cbor/recordid.ts
+++ b/src/library/cbor/recordid.ts
@@ -1,4 +1,4 @@
-import { z } from "npm:zod";
+import { z } from "zod";
 
 export const RecordIdValue = z.union([
 	z.string(),

--- a/src/library/cbor/recordid.ts
+++ b/src/library/cbor/recordid.ts
@@ -19,11 +19,11 @@ export class RecordId<Tb extends string = string> {
 		this.id = RecordIdValue.parse(id);
 	}
 
-	toJSON() {
+	toJSON(): string {
 		return this.toString();
 	}
 
-	toString() {
+	toString(): string {
 		const tb = escape_ident(this.tb);
 		const id = typeof this.id == "string"
 			? escape_ident(this.id)
@@ -39,11 +39,11 @@ export class StringRecordId {
 		this.rid = z.string().parse(rid);
 	}
 
-	toJSON() {
+	toJSON(): string {
 		return this.rid;
 	}
 
-	toString() {
+	toString(): string {
 		return this.rid;
 	}
 }

--- a/src/library/cbor/table.ts
+++ b/src/library/cbor/table.ts
@@ -1,4 +1,4 @@
-import { z } from "npm:zod";
+import { z } from "zod";
 
 export class Table<Tb extends string = string> {
 	public readonly tb: Tb;

--- a/src/library/cbor/table.ts
+++ b/src/library/cbor/table.ts
@@ -7,11 +7,11 @@ export class Table<Tb extends string = string> {
 		this.tb = z.string().parse(tb) as Tb;
 	}
 
-	toJSON() {
+	toJSON(): Tb {
 		return this.tb;
 	}
 
-	toString() {
+	toString(): Tb {
 		return this.tb;
 	}
 }

--- a/src/library/cbor/uuid.ts
+++ b/src/library/cbor/uuid.ts
@@ -1,1 +1,1 @@
-export { UUID, uuidv4, uuidv7 } from "npm:uuidv7@0.6.3";
+export { UUID, uuidv4, uuidv7 } from "uuidv7";

--- a/src/library/emitter.ts
+++ b/src/library/emitter.ts
@@ -54,7 +54,10 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 		}
 	}
 
-	subscribeOnce<Event extends keyof Events>(event: Event, historic = false) {
+	subscribeOnce<Event extends keyof Events>(
+		event: Event,
+		historic = false,
+	): Promise<Events[Event]> {
 		return new Promise<Events[Event]>((resolve) => {
 			let resolved = false;
 			const listener = (...args: Events[Event]) => {
@@ -86,7 +89,7 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 	isSubscribed<Event extends keyof Events>(
 		event: Event,
 		listener: Listener<Events[Event]>,
-	) {
+	): boolean {
 		return !!this.listeners[event]?.includes(listener);
 	}
 
@@ -133,7 +136,7 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 		}
 	}
 
-	scanListeners(filter?: (k: keyof Events) => boolean) {
+	scanListeners(filter?: (k: keyof Events) => boolean): (keyof Events)[] {
 		let listeners = Object.keys(this.listeners) as (keyof Events)[];
 		if (filter) listeners = listeners.filter(filter);
 		return listeners;

--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -1,15 +1,10 @@
 import { z } from "zod";
-import { Emitter } from "./emitter.ts";
+import type { Emitter } from "./emitter.ts";
 import { getIncrementalID } from "./getIncrementalID.ts";
 import WebSocket from "./WebSocket/deno.ts";
 import { decodeCbor, encodeCbor } from "./cbor/index.ts";
-import {
-	Action,
-	LiveResult,
-	Patch,
-	RpcRequest,
-	RpcResponse,
-} from "../types.ts";
+import type { Action, Patch, RpcRequest, RpcResponse } from "../types.ts";
+import { LiveResult } from "../types.ts";
 import {
 	ConnectionUnavailable,
 	EngineDisconnected,

--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -15,6 +15,7 @@ import {
 	UnexpectedServerResponse,
 } from "../errors.ts";
 import { retrieveRemoteVersion } from "./versionCheck.ts";
+import type { SemVer } from "@std/semver";
 
 export type EngineEvents = {
 	connecting: [];
@@ -52,7 +53,7 @@ export abstract class Engine {
 		token?: string;
 	};
 
-	abstract version(url: URL, timeout: number): Promise<string>;
+	abstract version(url: URL, timeout: number): Promise<SemVer>;
 }
 
 export class WebsocketEngine implements Engine {
@@ -80,7 +81,7 @@ export class WebsocketEngine implements Engine {
 		this.emitter.emit(status, args);
 	}
 
-	version(url: URL, timeout: number): Promise<string> {
+	version(url: URL, timeout: number): Promise<SemVer> {
 		return retrieveRemoteVersion(url, timeout);
 	}
 
@@ -249,7 +250,7 @@ export class HttpEngine implements Engine {
 		this.emitter.emit(status, args);
 	}
 
-	version(url: URL, timeout: number): Promise<string> {
+	version(url: URL, timeout: number): Promise<SemVer> {
 		return retrieveRemoteVersion(url, timeout);
 	}
 

--- a/src/library/engine.ts
+++ b/src/library/engine.ts
@@ -1,4 +1,4 @@
-import { z } from "npm:zod";
+import { z } from "zod";
 import { Emitter } from "./emitter.ts";
 import { getIncrementalID } from "./getIncrementalID.ts";
 import WebSocket from "./WebSocket/deno.ts";

--- a/src/library/jsonify.ts
+++ b/src/library/jsonify.ts
@@ -1,9 +1,9 @@
-import { Decimal } from "./cbor/decimal.ts";
-import { Geometry } from "./cbor/geometry.ts";
-import { Duration } from "./cbor/index.ts";
-import { RecordId, StringRecordId } from "./cbor/recordid.ts";
-import { Table } from "./cbor/table.ts";
-import { UUID } from "./cbor/uuid.ts";
+import type { Decimal } from "./cbor/decimal.ts";
+import type { Geometry } from "./cbor/geometry.ts";
+import type { Duration } from "./cbor/index.ts";
+import type { RecordId, StringRecordId } from "./cbor/recordid.ts";
+import type { Table } from "./cbor/table.ts";
+import type { UUID } from "./cbor/uuid.ts";
 
 export type Jsonify<T extends unknown> = T extends
 	Date | UUID | Decimal | Duration | StringRecordId ? string

--- a/src/library/processAuthVars.ts
+++ b/src/library/processAuthVars.ts
@@ -1,5 +1,5 @@
 import { NoDatabaseSpecified, NoNamespaceSpecified } from "../errors.ts";
-import { AnyAuth } from "../types.ts";
+import type { AnyAuth } from "../types.ts";
 import { isNil } from "./isNil.ts";
 
 export function processAuthVars<T extends AnyAuth>(vars: T, fallback?: {

--- a/src/library/tagged-template.ts
+++ b/src/library/tagged-template.ts
@@ -1,9 +1,10 @@
 import { PreparedQuery } from "./PreparedQuery.ts";
+import type { ConvertMethod } from "./PreparedQuery.ts";
 
 export function surrealql(
 	query_raw: string[] | TemplateStringsArray,
 	...values: unknown[]
-) {
+): PreparedQuery<ConvertMethod<unknown>> {
 	const mapped_bindings = values.map((v, i) =>
 		[`__tagged_template_literal_binding__${i}`, v] as const
 	);

--- a/src/library/versionCheck.ts
+++ b/src/library/versionCheck.ts
@@ -1,9 +1,11 @@
-import semver from "semver";
+import type { SemVer } from "@std/semver";
+import { parse, parseRange } from "@std/semver";
+import { satisfies } from "@std/semver";
 import { UnsupportedVersion, VersionRetrievalFailure } from "../errors.ts";
 
-export const supportedSurrealDbVersionRange = ">= 1.4.2 < 2.0.0";
+export const supportedSurrealDbVersionRange = parseRange(">= 1.4.2 < 2.0.0");
 
-export function versionCheck(version: string): true {
+export function versionCheck(version: SemVer): true {
 	if (!isVersionSupported(version)) {
 		throw new UnsupportedVersion(version, supportedSurrealDbVersionRange);
 	}
@@ -11,14 +13,14 @@ export function versionCheck(version: string): true {
 	return true;
 }
 
-export function isVersionSupported(version: string) {
-	return semver.satisfies(version, supportedSurrealDbVersionRange);
+export function isVersionSupported(version: SemVer): boolean {
+	return satisfies(version, supportedSurrealDbVersionRange);
 }
 
 export async function retrieveRemoteVersion(
 	url: URL,
 	timeout: number,
-): Promise<string> {
+): Promise<SemVer> {
 	const mappedProtocols = {
 		"ws:": "http:",
 		"wss:": "https:",
@@ -50,7 +52,7 @@ export async function retrieveRemoteVersion(
 				clearTimeout(id);
 			});
 
-		return version;
+		return parse(version);
 	}
 
 	throw new VersionRetrievalFailure();

--- a/src/library/versionCheck.ts
+++ b/src/library/versionCheck.ts
@@ -1,4 +1,4 @@
-import semver from "npm:semver";
+import semver from "semver";
 import { UnsupportedVersion, VersionRetrievalFailure } from "../errors.ts";
 
 export const supportedSurrealDbVersionRange = ">= 1.4.2 < 2.0.0";

--- a/src/library/versionCheck.ts
+++ b/src/library/versionCheck.ts
@@ -15,7 +15,10 @@ export function isVersionSupported(version: string) {
 	return semver.satisfies(version, supportedSurrealDbVersionRange);
 }
 
-export async function retrieveRemoteVersion(url: URL, timeout: number) {
+export async function retrieveRemoteVersion(
+	url: URL,
+	timeout: number,
+): Promise<string> {
 	const mappedProtocols = {
 		"ws:": "http:",
 		"wss:": "https:",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { z } from "npm:zod";
+import { z } from "zod";
 import { RecordId } from "./library/cbor/recordid.ts";
 import { Surreal } from "./surreal.ts";
 import { UUID } from "./library/cbor/uuid.ts";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { RecordId } from "./library/cbor/recordid.ts";
-import { Surreal } from "./surreal.ts";
+import type { RecordId } from "./library/cbor/recordid.ts";
+import type { Surreal } from "./surreal.ts";
 import { UUID } from "./library/cbor/uuid.ts";
 
 export const UseOptions = z.object({

--- a/tests/integration/tests/auth.ts
+++ b/tests/integration/tests/auth.ts
@@ -1,4 +1,4 @@
-import { assertRejects, assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { createAuth } from "../surreal.ts";
 import { createSurreal } from "../surreal.ts";
 import { RecordId, ResponseError } from "../../../mod.ts";

--- a/tests/integration/tests/auth.ts
+++ b/tests/integration/tests/auth.ts
@@ -1,8 +1,6 @@
-import { assertRejects } from "https://deno.land/std@0.223.0/assert/assert_rejects.ts";
+import { assertRejects, assertEquals } from "@std/assert";
 import { createAuth } from "../surreal.ts";
 import { createSurreal } from "../surreal.ts";
-
-import { assertEquals } from "https://deno.land/std@0.223.0/assert/mod.ts";
 import { RecordId, ResponseError } from "../../../mod.ts";
 
 Deno.test("root signin", async () => {

--- a/tests/integration/tests/connection.ts
+++ b/tests/integration/tests/connection.ts
@@ -1,4 +1,4 @@
-import { assertInstanceOf, assertEquals, assertLess } from "@std/assert";
+import { assertEquals, assertInstanceOf, assertLess } from "@std/assert";
 import { createSurreal } from "../surreal.ts";
 import { VersionRetrievalFailure } from "../../../mod.ts";
 

--- a/tests/integration/tests/connection.ts
+++ b/tests/integration/tests/connection.ts
@@ -1,8 +1,6 @@
-import { assertInstanceOf } from "https://deno.land/std@0.223.0/assert/assert_instance_of.ts";
+import { assertInstanceOf, assertEquals, assertLess } from "@std/assert";
 import { createSurreal } from "../surreal.ts";
-import { assertEquals } from "https://deno.land/std@0.223.0/assert/mod.ts";
 import { VersionRetrievalFailure } from "../../../mod.ts";
-import { assertLess } from "https://deno.land/std@0.223.0/assert/assert_less.ts";
 
 Deno.test("check version", async () => {
 	const surreal = await createSurreal();

--- a/tests/integration/tests/live.ts
+++ b/tests/integration/tests/live.ts
@@ -6,7 +6,7 @@ import {
 	assertGreater,
 	assertNotEquals,
 	assertRejects,
-} from "https://deno.land/std@0.223.0/assert/mod.ts";
+} from "@std/assert";
 import { type Action, RecordId, UUID } from "../../../mod.ts";
 
 async function withTimeout(p: Promise<void>, ms: number): Promise<void> {

--- a/tests/integration/tests/querying.ts
+++ b/tests/integration/tests/querying.ts
@@ -1,6 +1,6 @@
 import { createSurreal } from "../surreal.ts";
 
-import { assertEquals } from "https://deno.land/std@0.223.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import {
 	Duration,
 	GeometryCollection,

--- a/tests/unit/isVersionSupported.ts
+++ b/tests/unit/isVersionSupported.ts
@@ -1,29 +1,30 @@
 import { assertEquals } from "@std/assert";
+import { parse } from "@std/semver";
 import { isVersionSupported } from "../../src/library/versionCheck.ts";
 
 Deno.test("isVersionSupported", () => {
 	assertEquals(
-		isVersionSupported("1.0.0"),
+		isVersionSupported(parse("1.0.0")),
 		false,
 		"1.0.0 should be unsupported",
 	);
 	assertEquals(
-		isVersionSupported("1.4.1"),
+		isVersionSupported(parse("1.4.1")),
 		false,
 		"1.4.1 should be unsupported",
 	);
 	assertEquals(
-		isVersionSupported("1.4.2"),
+		isVersionSupported(parse("1.4.2")),
 		true,
 		"1.4.2 should be supported",
 	);
 	assertEquals(
-		isVersionSupported("1.99.99"),
+		isVersionSupported(parse("1.99.99")),
 		true,
 		"1.99.99 should be supported",
 	);
 	assertEquals(
-		isVersionSupported("2.0.0"),
+		isVersionSupported(parse("2.0.0")),
 		false,
 		"2.0.0 should be unsupported",
 	);

--- a/tests/unit/isVersionSupported.ts
+++ b/tests/unit/isVersionSupported.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.223.0/assert/assert_equals.ts";
+import { assertEquals } from "@std/assert";
 import { isVersionSupported } from "../../src/library/versionCheck.ts";
 
 Deno.test("isVersionSupported", () => {

--- a/tests/unit/jsonify.ts
+++ b/tests/unit/jsonify.ts
@@ -1,4 +1,4 @@
-import { assertSnapshot } from "https://deno.land/std@0.224.0/testing/snapshot.ts";
+import { assertSnapshot } from "@std/testing/snapshot";
 import {
 	Decimal,
 	Duration,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The Deno team has launched [JSR](https://jsr.io/)
You can read about it here: https://deno.com/blog/jsr-is-not-another-package-manager
It would be great to have this package published there

## What does this change do?

This PR changes the following:

1. Updates `deno.json` to use the new fields: `name`, `version`, `description`, replacing `project.json`
2. Uses `deno.json`'s import map to specify package versions, using packages published to JSR where possible
3. Replace `semver` with Deno's `@std/semver`
4. Added as many return type annotations as I could, JSR want's all public return types to be explicitly typed. Right now I have left those returning Zed functions as they are very verbose.
5. Added vscode defaults for default formatter and format on save
6. Added export map to `deno.json` to export `mod.ts`
7. Updated a few CI action versions & added a JSR publish step
8. Add Pull Request CI workflow to check formatting and run tests

What's required if this PR is accepted is for a JSR [JSR](https://jsr.io/) account and namespace to be created, I have specified `@surrealdb` and to register the package name `surrealdb`. Then under the publish settings, specify this github repo to enable automatic provenance and publishing

Thanks.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
