### PR TITLE
fix: fix GeometryCollection class

### DIFF
--- a/src/library/cbor/geometry.ts
+++ b/src/library/cbor/geometry.ts
@@ -2,12 +2,13 @@ import { Decimal } from "npm:decimal.js@^10.4.3";
 
 export abstract class Geometry {
 	abstract toJSON(): {
-		type: string;
+		type: "Point" | "LineString" | "Polygon" | "MultiPoint" | "MultiLineString" | "MultiPolygon";
 		coordinates: unknown[];
+	} | {
+		type: "GeometryCollection";
+		geometries: Geometry[];
 	};
-
-	abstract coordinates: unknown[];
-}
+ }
 
 export class GeometryPoint extends Geometry {
 	readonly point: [Decimal, Decimal];
@@ -184,13 +185,11 @@ export class GeometryCollection<T extends [Geometry, ...Geometry[]]>
 	toJSON() {
 		return {
 			type: "GeometryCollection" as const,
-			coordinates: this.coordinates,
+			geometries: this.geometries,
 		};
 	}
 
-	get coordinates() {
-		return this.collection.map((g) => g.toJSON()) as {
-			[K in keyof T]: ReturnType<T[K]["toJSON"]>;
-		};
+	get geometries() {
+		return this.collection as Geometry[];
 	}
 }

--- a/tests/unit/__snapshots__/jsonify.ts.snap
+++ b/tests/unit/__snapshots__/jsonify.ts.snap
@@ -8,7 +8,7 @@ snapshot[`jsonify matches snapshot 1`] = `
   false: false,
   float: 123.456,
   geo: {
-    coordinates: [
+    geometries: [
       {
         coordinates: [
           "1",


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Fix `GeometryCollection` class as it takes/returns a `geometries` prop instead of a `coordinates` props.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
