### PR TITLE
fix: update GeometryPolygon type

### DIFF
--- a/src/library/cbor/geometry.ts
+++ b/src/library/cbor/geometry.ts
@@ -66,11 +66,11 @@ export class GeometryLine extends Geometry {
 }
 
 export class GeometryPolygon extends Geometry {
-	readonly polygon: [GeometryLine, GeometryLine, ...GeometryLine[]];
+	readonly polygon: [GeometryLine, ...GeometryLine[]];
 
 	constructor(
 		polygon:
-			| [GeometryLine, GeometryLine, ...GeometryLine[]]
+			| [GeometryLine, ...GeometryLine[]]
 			| GeometryPolygon,
 	) {
 		super();
@@ -78,7 +78,6 @@ export class GeometryPolygon extends Geometry {
 			? polygon.polygon
 			: polygon;
 		this.polygon = polygon.map((line) => new GeometryLine(line)) as [
-			GeometryLine,
 			GeometryLine,
 			...GeometryLine[],
 		];


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Missing this type in a previous change. `GeometryPolygon` can have 1 exterior ring, then >= 0 exterior rings.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
