### PR TITLE
Engine should handle closing the connection

### DIFF
--- a/compile.ts
+++ b/compile.ts
@@ -54,7 +54,7 @@ await build({
 		"./src/library/WebSocket/deno.ts": "./src/library/WebSocket/node.ts",
 	},
 	compilerOptions: {
-		lib: ["dom", "es2021.string"],
+		lib: ["dom", "es2021"],
 		sourceMap: true,
 	},
 });

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -57,8 +57,8 @@ export class Surreal {
 		engines?: Engines;
 	} = {}) {
 		this.emitter = new Emitter();
-		this.emitter.subscribe("disconnected", () => this.clean());
-		this.emitter.subscribe("error", () => this.close());
+		this.emitter.subscribe(ConnectionStatus.Disconnected, () => this.clean());
+		this.emitter.subscribe(ConnectionStatus.Error, () => this.close());
 
 		if (engines) {
 			this.engines = {
@@ -137,16 +137,7 @@ export class Surreal {
 	 */
 	async close() {
 		this.clean();
-		const queue: Promise<unknown>[] = [];
-		if (this.connection) {
-			if (this.connection.status != ConnectionStatus.Disconnected) {
-				queue.push(this.emitter.subscribeOnce("disconnected"));
-			}
-
-			queue.push(this.connection?.disconnect());
-		}
-
-		await Promise.all(queue);
+		await this.connection?.disconnect();
 	}
 
 	private clean() {

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -57,7 +57,10 @@ export class Surreal {
 		engines?: Engines;
 	} = {}) {
 		this.emitter = new Emitter();
-		this.emitter.subscribe(ConnectionStatus.Disconnected, () => this.clean());
+		this.emitter.subscribe(
+			ConnectionStatus.Disconnected,
+			() => this.clean(),
+		);
 		this.emitter.subscribe(ConnectionStatus.Error, () => this.close());
 
 		if (engines) {

--- a/tests/integration/tests/querying.ts
+++ b/tests/integration/tests/querying.ts
@@ -390,7 +390,7 @@ Deno.test("table", async () => {
 		/* surql */ `RETURN type::table($table)`,
 		{
 			table: "person",
-		}
+		},
 	);
 
 	assertEquals(output.tb, "person");


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The close method does not work nicely with embedded databases, because the wasm library does not emit disconnect events onto the event emitter. The engine should handle closing the connection instead

## What does this change do?

The engine now awaits the disconnected message and will resolve the promise

## What is your testing strategy?

CI

## Is this related to any issues?

Yes, though no issue on GitHub was previously created.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
