### PR TITLE
fix: fix json conversion of geometries

### DIFF
--- a/src/library/cbor/geometry.ts
+++ b/src/library/cbor/geometry.ts
@@ -12,7 +12,7 @@ export abstract class Geometry {
 		coordinates: unknown[];
 	} | {
 		type: "GeometryCollection";
-		geometries: Geometry[];
+		geometries: unknown[];
 	};
 }
 
@@ -195,6 +195,8 @@ export class GeometryCollection<T extends [Geometry, ...Geometry[]]>
 	}
 
 	get geometries() {
-		return this.collection as Geometry[];
+		return this.collection.map((g) => g.toJSON()) as {
+			[K in keyof T]: ReturnType<T[K]["toJSON"]>;
+		};
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I guess it was there for a reason.

## What does this change do?

Revert change on `geometries` property to properly handle JSON serialization.

## What is your testing strategy?

N/A

## Is this related to any issues?

Tested with Surrealist. The inner geometries are not converted into JSON objects.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
