### PR TITLE
number-looking like string should be escaped

### DIFF
--- a/src/library/cbor/recordid.ts
+++ b/src/library/cbor/recordid.ts
@@ -49,6 +49,11 @@ export class StringRecordId {
 }
 
 function escape_ident(str: string) {
+	// String which looks like a number should always be escaped, to prevent it from being parsed as a number
+	if (!isNaN(str) && !isNaN(parseFloat(str))) {
+		return `⟨${str}⟩`;
+	}
+
 	let code, i, len;
 
 	for (i = 0, len = str.length; i < len; i++) {

--- a/src/library/cbor/recordid.ts
+++ b/src/library/cbor/recordid.ts
@@ -50,7 +50,7 @@ export class StringRecordId {
 
 function escape_ident(str: string) {
 	// String which looks like a number should always be escaped, to prevent it from being parsed as a number
-	if (!isNaN(parseFloat(str))) {
+	if (isOnlyNumbers(str)) {
 		return `⟨${str}⟩`;
 	}
 
@@ -69,4 +69,9 @@ function escape_ident(str: string) {
 	}
 
 	return str;
+}
+
+function isOnlyNumbers(str: string) {
+	const parsed = parseInt(str);
+	return !isNaN(parsed) && parsed.toString() === str;
 }

--- a/src/library/cbor/recordid.ts
+++ b/src/library/cbor/recordid.ts
@@ -50,7 +50,7 @@ export class StringRecordId {
 
 function escape_ident(str: string) {
 	// String which looks like a number should always be escaped, to prevent it from being parsed as a number
-	if (!isNaN(str) && !isNaN(parseFloat(str))) {
+	if (!isNaN(parseFloat(str))) {
 		return `⟨${str}⟩`;
 	}
 

--- a/tests/unit/__snapshots__/jsonify.ts.snap
+++ b/tests/unit/__snapshots__/jsonify.ts.snap
@@ -71,6 +71,7 @@ snapshot[`jsonify matches snapshot 1`] = `
     ],
     type: "GeometryCollection",
   },
+  id_almost_a_number: "⟨some:thing⟩:1e23",
   id_is_a_number: "⟨some:thing⟩:123",
   id_looks_like_number: "⟨some:thing⟩:⟨123⟩",
   null: null,

--- a/tests/unit/__snapshots__/jsonify.ts.snap
+++ b/tests/unit/__snapshots__/jsonify.ts.snap
@@ -71,6 +71,8 @@ snapshot[`jsonify matches snapshot 1`] = `
     ],
     type: "GeometryCollection",
   },
+  id_is_a_number: "⟨some:thing⟩:123",
+  id_looks_like_number: "⟨some:thing⟩:⟨123⟩",
   null: null,
   num: 123,
   rid: "⟨some:thing⟩:under_score",

--- a/tests/unit/jsonify.ts
+++ b/tests/unit/jsonify.ts
@@ -18,6 +18,8 @@ Deno.test("jsonify matches snapshot", async function (t) {
 	const json = jsonify(
 		{
 			rid: new RecordId("some:thing", "under_score"),
+			id_looks_like_number: new RecordId("some:thing", "123"),
+			id_is_a_number: new RecordId("some:thing", 123),
 			str_rid: new StringRecordId("⟨some:thing⟩:under_score"),
 			dec: new Decimal("3.333333"),
 			dur: new Duration("1d2h"),

--- a/tests/unit/jsonify.ts
+++ b/tests/unit/jsonify.ts
@@ -19,6 +19,7 @@ Deno.test("jsonify matches snapshot", async function (t) {
 		{
 			rid: new RecordId("some:thing", "under_score"),
 			id_looks_like_number: new RecordId("some:thing", "123"),
+			id_almost_a_number: new RecordId("some:thing", "1e23"),
 			id_is_a_number: new RecordId("some:thing", 123),
 			str_rid: new StringRecordId("⟨some:thing⟩:under_score"),
 			dec: new Decimal("3.333333"),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

#281 

## What does this change do?

When the ident is a string, we will check if it can be parsed as an integer. If that is the case, it will be escaped

## What is your testing strategy?

Added a test

## Is this related to any issues?

Fixes #281 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
