### PR TITLE
publish npm package with latest only for non beta releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - uses: actions/checkout@v3
       - run: deno task build
-      - run: cd ./npm && npm publish
+      # Publish with latest only versions that match the semver pattern, otherwise publish with beta tag
+      # This is to avoid publishing beta versions with the latest tag (if no dist tag is provided, npm will use latest)
+      - run: cd ./npm && npm publish --dist-tag $(npm pkg get version | tr -d '"' | grep -qoE "^\d+\.\d+\.\d+$" && echo 'latest' || echo 'beta')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What is the motivation?

To avoid installing beta when I run `npm i surrealdb.js` in new projects

## What does this change do?
mark `latest` only versions that match the semver standard, and the rest with `beta` 

## What is your testing strategy?

Manually tested it

## Is this related to any issues?

Not existing ones

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
