### PR TITLE
Ensure PreparedQuery has replacer context

### DIFF
--- a/src/cbor/decoder.ts
+++ b/src/cbor/decoder.ts
@@ -4,7 +4,7 @@ import { Reader } from "./reader";
 import { Tagged } from "./tagged";
 import { infiniteBytes } from "./util";
 
-interface DecodeOptions {
+export interface DecodeOptions {
 	map?: "object" | "map";
 	replacer?: Replacer;
 }

--- a/src/cbor/encoder.ts
+++ b/src/cbor/encoder.ts
@@ -6,7 +6,7 @@ import { PartiallyEncoded } from "./partial";
 import { Tagged } from "./tagged";
 import { Writer } from "./writer";
 
-interface EncoderOptions<Partial extends boolean> {
+export interface EncoderOptions<Partial extends boolean> {
 	replacer?: Replacer;
 	writer?: Writer;
 	partial?: Partial;

--- a/src/cbor/partial.ts
+++ b/src/cbor/partial.ts
@@ -1,5 +1,5 @@
 import type { Replacer } from "./constants";
-import { encode } from "./encoder";
+import { type EncoderOptions, encode } from "./encoder";
 import { CborFillMissing } from "./error";
 import type { Fill, Gap } from "./gap";
 import { Writer } from "./writer";
@@ -41,12 +41,12 @@ export class PartiallyEncoded {
 
 export function partiallyEncodeObject(
 	object: Record<string, unknown>,
-	fills?: Fill[],
+	options?: EncoderOptions<true>,
 ): Record<string, PartiallyEncoded> {
 	return Object.fromEntries(
 		Object.entries(object).map(([k, v]) => [
 			k,
-			encode(v, { fills, partial: true }),
+			encode(v, { ...options, partial: true }),
 		]),
 	);
 }

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -34,6 +34,7 @@ import {
 } from "./types.ts";
 
 import { type Fill, partiallyEncodeObject } from "./cbor";
+import { replacer } from "./data/cbor.ts";
 import { HttpEngine } from "./engines/http.ts";
 import { WebsocketEngine } from "./engines/ws.ts";
 import {
@@ -432,7 +433,13 @@ export class Surreal {
 	): Promise<Prettify<MapQueryResult<T>>> {
 		const params =
 			q instanceof PreparedQuery
-				? [q.query, partiallyEncodeObject(q.bindings, b as Fill[])]
+				? [
+						q.query,
+						partiallyEncodeObject(q.bindings, {
+							fills: b as Fill[],
+							replacer: replacer.encode,
+						}),
+					]
 				: [q, b];
 
 		await this.ready;

--- a/src/util/PreparedQuery.ts
+++ b/src/util/PreparedQuery.ts
@@ -5,6 +5,7 @@ import {
 	encode,
 	partiallyEncodeObject,
 } from "../cbor";
+import { replacer } from "../data/cbor";
 
 export type ConvertMethod<T = unknown> = (result: unknown[]) => T;
 export class PreparedQuery<
@@ -15,7 +16,9 @@ export class PreparedQuery<
 
 	constructor(query: string, bindings?: Record<string, unknown>, convert?: C) {
 		this.query = new Encoded(encode(query));
-		this.bindings = partiallyEncodeObject(bindings ?? {});
+		this.bindings = partiallyEncodeObject(bindings ?? {}, {
+			replacer: replacer.encode,
+		});
 	}
 
 	build(gaps?: Fill[]): ArrayBuffer {

--- a/tests/integration/tests/querying.test.ts
+++ b/tests/integration/tests/querying.test.ts
@@ -381,6 +381,13 @@ describe("template literal", async () => {
 		const res = await surreal.query(query, [gap.fill(789)]);
 		expect(res).toStrictEqual([[123, 456, 789]]);
 	});
+
+	test("has replacer context", async () => {
+		const id = new RecordId("test", 123);
+		const query = surql`RETURN ${id}`;
+		const res = await surreal.query(query);
+		expect(res).toStrictEqual([id]);
+	});
 });
 
 test("query", async () => {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

In an oversight, `PreparedQuery` used just a bare minimal CBOR encoder, leaving custom tags such as record ids not properly encoded.

## What does this change do?

Alters the `partiallyEncodeObject` method to accept all encode options, allowing the `PreparedQuery` class to pass a replacer to the CBOR encode method.

## What is your testing strategy?

Added a test to ensure that prepared queries have replacer context.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
