### PR TITLE
Do not minify identifiers

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -9,7 +9,8 @@ await Promise.all([
 		plugins: [tscPlugin({ force: true })],
 		external: ["uuidv7", "isows"],
 		format: "esm",
-		minify: true,
+		minifyWhitespace: true,
+		minifySyntax: true,
 	}),
 	esbuild.build({
 		entryPoints: ["src/index.ts"],
@@ -18,7 +19,8 @@ await Promise.all([
 		plugins: [tscPlugin({ force: true })],
 		external: ["uuidv7", "isows"],
 		format: "cjs",
-		minify: true,
+		minifyWhitespace: true,
+		minifySyntax: true,
 	}),
 	esbuild.build({
 		entryPoints: ["src/index.ts"],
@@ -26,7 +28,8 @@ await Promise.all([
 		outfile: "dist/esm.bundled.js",
 		plugins: [tscPlugin({ force: true })],
 		format: "esm",
-		minify: true,
+		minifyWhitespace: true,
+		minifySyntax: true,
 	}),
 ]);
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Minifying identifiers make them difficult to read in for example browsers when logging classes.

## What does this change do?

Changes minification to only affect syntax and whitespace, excluding identifiers

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
