### PR TITLE
Fix CommonJS target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "surrealdb.js",
-	"version": "1.0.0-beta.11",
+	"version": "1.0.0-beta.12",
 	"type": "module",
 	"license": "Apache-2.0",
 	"repository": {
@@ -39,15 +39,15 @@
 	"engines": {
 		"node": ">=18.0.0"
 	},
-	"browser": "./dist/esm.bundled.js",
-	"types": "./dist/types.d.ts",
-	"main": "./dist/esm.js",
+	"browser": "./dist/index.bundled.mjs",
+	"types": "./dist/index.d.ts",
+	"main": "./dist/index.mjs",
 	"exports": {
 		".": {
-			"require": "./dist/cjs.js",
-			"import": "./dist/esm.js",
-			"types": "./dist/types.d.ts",
-			"browser": "./dist/esm.bundled.js"
+			"require": "./dist/index.cjs",
+			"import": "./dist/index.mjs",
+			"types": "./dist/index.d.ts",
+			"browser": "./dist/index.bundled.mjs"
 		}
 	},
 	"files": ["dist", "README.md", "LICENCE", "SECURITY.md"]

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -5,7 +5,7 @@ await Promise.all([
 	esbuild.build({
 		entryPoints: ["src/index.ts"],
 		bundle: true,
-		outfile: "dist/esm.js",
+		outfile: "dist/index.mjs",
 		plugins: [tscPlugin({ force: true })],
 		external: ["uuidv7", "isows"],
 		format: "esm",
@@ -15,7 +15,7 @@ await Promise.all([
 	esbuild.build({
 		entryPoints: ["src/index.ts"],
 		bundle: true,
-		outfile: "dist/cjs.js",
+		outfile: "dist/index.cjs",
 		plugins: [tscPlugin({ force: true })],
 		external: ["uuidv7", "isows"],
 		format: "cjs",
@@ -25,7 +25,7 @@ await Promise.all([
 	esbuild.build({
 		entryPoints: ["src/index.ts"],
 		bundle: true,
-		outfile: "dist/esm.bundled.js",
+		outfile: "dist/index.bundled.mjs",
 		plugins: [tscPlugin({ force: true })],
 		format: "esm",
 		minifyWhitespace: true,
@@ -37,7 +37,7 @@ Bun.spawn([
 	"bunx",
 	"dts-bundle-generator",
 	"-o",
-	"dist/types.d.ts",
+	"dist/index.d.ts",
 	"src/index.ts",
 	"--no-check",
 	"--export-referenced-types",


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Because the cjs output did not have a cjs extension, it could not be required as such.

## What does this change do?

It changes all outputted bundled to have either a cjs or mjs extension

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
