### PR TITLE
CBOR performance improvements

### DIFF
--- a/src/cbor/reader.ts
+++ b/src/cbor/reader.ts
@@ -14,10 +14,6 @@ export class Reader {
 		this._byte.set(new Uint8Array(buffer));
 	}
 
-	get left(): Uint8Array {
-		return this._byte.slice(this._pos);
-	}
-
 	private read<T>(amount: number, res: T): T {
 		this._pos += amount;
 		return res;
@@ -96,8 +92,8 @@ export class Reader {
 	}
 
 	readBytes(amount: number): Uint8Array {
-		const available = this.left.length;
-		if (amount > available)
+		const available = this._byte.length - this._pos;
+		if (available < amount)
 			throw new CborRangeError(
 				`The argument must be between 0 and ${available}`,
 			);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

As reported in [Discord](https://discord.com/channels/902568124350599239/1013527402674139268/1260922437479170128), our custom CBOR implementation had some serious performance implications

## What does this change do?

Made some improvements to the encoder, decoder, writer and reader, making the CBOR implementation even faster than the original library that we used.

## What is your testing strategy?

GitHub CI. Benchmark tests to be added soon to prevent this sort of performance decline from happening in the future.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
