### PR TITLE
Fix errors

### DIFF
--- a/src/data/types/duration.ts
+++ b/src/data/types/duration.ts
@@ -1,3 +1,5 @@
+import { SurrealDbError } from "../../errors";
+
 const millisecond = 1;
 const microsecond = millisecond / 1000;
 const nanosecond = microsecond / 1000;
@@ -85,14 +87,14 @@ export class Duration {
 				const amount = Number.parseInt(match[1]);
 				const factor = units.get(match[2]);
 				if (factor === undefined)
-					throw new Error(`Invalid duration unit: ${match[2]}`);
+					throw new SurrealDbError(`Invalid duration unit: ${match[2]}`);
 
 				ms += amount * factor;
 				left = left.slice(match[0].length);
 				continue;
 			}
 
-			throw new Error("Could not match a next duration part");
+			throw new SurrealDbError("Could not match a next duration part");
 		}
 
 		return ms;

--- a/src/data/types/recordid.ts
+++ b/src/data/types/recordid.ts
@@ -1,3 +1,5 @@
+import { SurrealDbError } from "../../errors";
+
 const MAX_i64 = 9223372036854775807n;
 export type RecordIdValue =
 	| string
@@ -11,8 +13,9 @@ export class RecordId<Tb extends string = string> {
 	public readonly id: RecordIdValue;
 
 	constructor(tb: Tb, id: RecordIdValue) {
-		if (typeof tb !== "string") throw new Error("TB part is not valid");
-		if (!isValidIsPart(id)) throw new Error("ID part is not valid");
+		if (typeof tb !== "string")
+			throw new SurrealDbError("TB part is not valid");
+		if (!isValidIsPart(id)) throw new SurrealDbError("ID part is not valid");
 
 		this.tb = tb;
 		this.id = id;
@@ -39,7 +42,7 @@ export class StringRecordId {
 
 	constructor(rid: string) {
 		if (typeof rid !== "string")
-			throw new Error("String Record ID must be a string");
+			throw new SurrealDbError("String Record ID must be a string");
 
 		this.rid = rid;
 	}

--- a/src/data/types/table.ts
+++ b/src/data/types/table.ts
@@ -1,8 +1,11 @@
+import { SurrealDbError } from "../../errors";
+
 export class Table<Tb extends string = string> {
 	public readonly tb: Tb;
 
 	constructor(tb: Tb) {
-		if (typeof tb !== "string") throw new Error("Table must be a string");
+		if (typeof tb !== "string")
+			throw new SurrealDbError("Table must be a string");
 		this.tb = tb;
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,9 @@ export function convertAuth(params: AnyAuth): Record<string, unknown> {
 			cloned[b] = `${cloned[a]}`;
 			delete cloned[a];
 		} else if (optional !== true) {
-			throw new Error(`Key ${a} is missing from the authentication parameters`);
+			throw new SurrealDbError(
+				`Key ${a} is missing from the authentication parameters`,
+			);
 		}
 	};
 
@@ -38,7 +40,7 @@ export function convertAuth(params: AnyAuth): Record<string, unknown> {
 		convertString("namespace", "ns");
 		convertString("database", "db");
 	} else {
-		convertString("database", "db", !("namespace" in params));
+		convertString("database", "db", true);
 		convertString("namespace", "ns", !("database" in params));
 		convertString("username", "user");
 		convertString("password", "pass");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { Encoded, Fill } from "./cbor";
 import { type RecordId, Uuid } from "./data";
+import { SurrealDbError } from "./errors";
 import type { PreparedQuery } from "./util/PreparedQuery";
 
 export type ActionResult<T extends Record<string, unknown>> = Prettify<

--- a/tests/unit/convertAuth.test.ts
+++ b/tests/unit/convertAuth.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { type AnyAuth, convertAuth } from "../../src";
+
+test("valid", () => {
+	expect(convertAuth({ username: "root", password: "root" })).toStrictEqual({
+		user: "root",
+		pass: "root",
+	});
+
+	expect(
+		convertAuth({ namespace: "test", username: "root", password: "root" }),
+	).toStrictEqual({
+		ns: "test",
+		user: "root",
+		pass: "root",
+	});
+
+	expect(
+		convertAuth({
+			namespace: "test",
+			database: "test",
+			username: "root",
+			password: "root",
+		}),
+	).toStrictEqual({
+		ns: "test",
+		db: "test",
+		user: "root",
+		pass: "root",
+	});
+
+	expect(
+		convertAuth({
+			namespace: "test",
+			database: "test",
+			scope: "user",
+			username: "root",
+			password: "root",
+		}),
+	).toStrictEqual({
+		ns: "test",
+		db: "test",
+		sc: "user",
+		username: "root",
+		password: "root",
+	});
+
+	expect(
+		convertAuth({
+			namespace: "test",
+			database: "test",
+			access: "user",
+			username: "root",
+			password: "root",
+		}),
+	).toStrictEqual({
+		ns: "test",
+		db: "test",
+		ac: "user",
+		username: "root",
+		password: "root",
+	});
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`convertAuth` threw an error if a namespace was specified, while database was omitted.

## What does this change do?

It makes `database` optional, and additionally some generic `Error` instances are now converted to `SurrealDbError`

## What is your testing strategy?

Added a test for `convertAuth`

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
