### PR TITLE
Allow partial use

### DIFF
--- a/src/engines/http.ts
+++ b/src/engines/http.ts
@@ -72,9 +72,13 @@ export class HttpEngine extends AbstractEngine {
 		}
 
 		if (request.method === "use") {
-			const [namespace, database] = request.params as [string, string];
-			if (namespace) this.connection.namespace = namespace;
-			if (database) this.connection.database = database;
+			const [ns, db] = request.params as [
+				string | undefined,
+				string | undefined,
+			];
+
+			if (ns) this.connection.namespace = ns;
+			if (db) this.connection.database = db;
 			return {
 				result: true as Result,
 			};

--- a/src/engines/ws.ts
+++ b/src/engines/ws.ts
@@ -145,9 +145,13 @@ export class WebsocketEngine extends AbstractEngine {
 		if ("result" in res) {
 			switch (request.method) {
 				case "use": {
-					const [ns, db] = request.params as [string, string];
-					this.connection.namespace = ns;
-					this.connection.database = db;
+					const [ns, db] = request.params as [
+						string | undefined,
+						string | undefined,
+					];
+
+					if (ns) this.connection.namespace = ns;
+					if (db) this.connection.database = db;
 					break;
 				}
 

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -107,10 +107,6 @@ export class Surreal {
 
 		// Process options
 		const { prepare, auth, namespace, database } = opts;
-		if (opts.namespace || opts.database) {
-			if (!opts.namespace) throw new NoNamespaceSpecified();
-			if (!opts.database) throw new NoDatabaseSpecified();
-		}
 
 		// Close any existing connections
 		await this.close();
@@ -216,19 +212,7 @@ export class Surreal {
 		database?: string;
 	}): Promise<true> {
 		if (!this.connection) throw new NoActiveSocket();
-
-		if (!namespace && !this.connection.connection.namespace) {
-			throw new NoNamespaceSpecified();
-		}
-		if (!database && !this.connection.connection.database) {
-			throw new NoDatabaseSpecified();
-		}
-
-		const { error } = await this.rpc("use", [
-			namespace ?? this.connection.connection.namespace,
-			database ?? this.connection.connection.database,
-		]);
-
+		const { error } = await this.rpc("use", [namespace, database]);
 		if (error) throw new ResponseError(error.message);
 		return true;
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Appearantly, the RPC protocol allows you to use only a namespace or database, as long as two values are passed in the argument array. Ommitted values can be represented as none

## What does this change do?

It allows you to partially use only a namespace

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
