### PR TITLE
Differentate access auth between system and record users

### DIFF
--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -19,7 +19,7 @@ import { processAuthVars } from "./util/processAuthVars.ts";
 import { versionCheck } from "./util/versionCheck.ts";
 
 import {
-	type AccessAuth,
+	type AccessRecordAuth,
 	type ActionResult,
 	type AnyAuth,
 	type LiveHandler,
@@ -243,7 +243,7 @@ export class Surreal {
 	 * @param vars - Variables used in a signup query.
 	 * @return The authentication token.
 	 */
-	async signup(vars: ScopeAuth | AccessAuth): Promise<Token> {
+	async signup(vars: ScopeAuth | AccessRecordAuth): Promise<Token> {
 		if (!this.connection) throw new NoActiveSocket();
 
 		const parsed = processAuthVars(vars, this.connection.connection);

--- a/src/util/processAuthVars.ts
+++ b/src/util/processAuthVars.ts
@@ -8,7 +8,10 @@ export function processAuthVars<T extends AnyAuth>(
 		database?: string;
 	},
 ): AnyAuth {
-	if ("scope" in vars || "access" in vars) {
+	if (
+		"scope" in vars ||
+		("access" in vars && "variables" in vars && vars.variables)
+	) {
 		if (!vars.namespace) {
 			if (!fallback?.namespace) throw new NoNamespaceSpecified();
 			vars.namespace = fallback.namespace;

--- a/tests/integration/tests/auth.test.ts
+++ b/tests/integration/tests/auth.test.ts
@@ -73,7 +73,7 @@ describe("record auth", async () => {
 	test("record signup", async () => {
 		const signup = await surreal.signup({
 			access: "user",
-			id: 123,
+			variables: { id: 123 },
 		});
 
 		expect(typeof signup).toBe("string");
@@ -82,7 +82,7 @@ describe("record auth", async () => {
 	test("record signin", async () => {
 		const signin = await surreal.signin({
 			access: "user",
-			id: 123,
+			variables: { id: 123 },
 		});
 
 		expect(typeof signin).toBe("string");

--- a/tests/unit/convertAuth.test.ts
+++ b/tests/unit/convertAuth.test.ts
@@ -57,6 +57,21 @@ test("valid", () => {
 		ns: "test",
 		db: "test",
 		ac: "user",
+		user: "root",
+		pass: "root",
+	});
+
+	expect(
+		convertAuth({
+			namespace: "test",
+			database: "test",
+			access: "user",
+			variables: { username: "root", password: "root" },
+		}),
+	).toStrictEqual({
+		ns: "test",
+		db: "test",
+		ac: "user",
 		username: "root",
 		password: "root",
 	});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

With the introduction of `TYPE BEARER` on `DEFINE ACCESS`, it will now be possible to also pass `username` and `password` properties for record access, but with the current implementation these won't be translated. Passing additional variables on the root of the object has never been clean, so we're changing this implementation.

## What does this change do?

To pass variables to record access, they will now need to be passed via the `variables` property. Nested in there, `ns`, `db` and `ac` cannot be passed, as they are used internally.

Additionally, we added in the `AccessSystemAuth` type.

## What is your testing strategy?

Updated tests

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
