### PR TITLE
Publish to latest for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,9 @@ jobs:
               run: bun run build
 
             - name: Publish to NPM
-              run: npm publish --tag $(npm pkg get version | tr -d '"' | grep -qoE "^\d+\.\d+\.\d+$" && echo 'latest' || echo 'beta')
+              # TODO temporary, enable beta tags again asap
+              # run: npm publish --tag $(npm pkg get version | tr -d '"' | grep -qoE "^\d+\.\d+\.\d+$" && echo 'latest' || echo 'beta')
+              run: npm publish
               env:
                 NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     jsr:


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The recent versions on the `surrealdb` package have been tagged with beta, while latest is 2 years out of date.

## What does this change do?

For now published to latest

## What is your testing strategy?

GitHub Actions

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
