### PR TITLE
Improve rpc method validation

### DIFF
--- a/src/engines/http.ts
+++ b/src/engines/http.ts
@@ -31,12 +31,12 @@ export class HttpEngine extends AbstractEngine {
 		token: string | undefined;
 		variables: Record<string, unknown>;
 	} = {
-			url: undefined,
-			namespace: undefined,
-			database: undefined,
-			token: undefined,
-			variables: {},
-		};
+		url: undefined,
+		namespace: undefined,
+		database: undefined,
+		token: undefined,
+		variables: {},
+	};
 
 	private setStatus<T extends ConnectionStatus>(
 		status: T,
@@ -83,7 +83,10 @@ export class HttpEngine extends AbstractEngine {
 			throw new ConnectionUnavailable();
 		}
 
-		if ((!this.connection.namespace || !this.connection.database) && !ALWAYS_ALLOW.has(request.method)) {
+		if (
+			(!this.connection.namespace || !this.connection.database) &&
+			!ALWAYS_ALLOW.has(request.method)
+		) {
 			throw new MissingNamespaceDatabase();
 		}
 
@@ -131,7 +134,7 @@ export class HttpEngine extends AbstractEngine {
 		const id = getIncrementalID();
 		const headers: Record<string, string> = {
 			"Content-Type": "application/cbor",
-			"Accept": "application/cbor",
+			Accept: "application/cbor",
 		};
 
 		if (this.connection.namespace) {

--- a/src/engines/http.ts
+++ b/src/engines/http.ts
@@ -21,6 +21,7 @@ const ALWAYS_ALLOW = new Set([
 	"use",
 	"let",
 	"unset",
+	"query",
 ]);
 
 export class HttpEngine extends AbstractEngine {

--- a/src/engines/http.ts
+++ b/src/engines/http.ts
@@ -146,7 +146,7 @@ export class HttpEngine extends AbstractEngine {
 		}
 
 		if (this.connection.token) {
-			headers["Authorization"] = `Bearer ${this.connection.token}`;
+			headers.Authorization = `Bearer ${this.connection.token}`;
 		}
 
 		const raw = await fetch(`${this.connection.url}`, {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-export class SurrealDbError extends Error {}
+export class SurrealDbError extends Error { }
 
 export class NoActiveSocket extends SurrealDbError {
 	name = "NoActiveSocket";
@@ -64,7 +64,7 @@ export class ConnectionUnavailable extends SurrealDbError {
 
 export class MissingNamespaceDatabase extends SurrealDbError {
 	name = "MissingNamespaceDatabase";
-	message = "There are no namespace and/or database configured.";
+	message = "There is no namespace and/or database selected.";
 }
 
 export class HttpConnectionError extends SurrealDbError {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-export class SurrealDbError extends Error { }
+export class SurrealDbError extends Error {}
 
 export class NoActiveSocket extends SurrealDbError {
 	name = "NoActiveSocket";

--- a/tests/integration/surreal.ts
+++ b/tests/integration/surreal.ts
@@ -38,6 +38,7 @@ type CreateSurrealOptions = {
 	protocol?: Protocol;
 	auth?: PremadeAuth;
 	reachable?: boolean;
+	unselected?: boolean;
 };
 
 export async function setupServer(): Promise<{
@@ -61,13 +62,14 @@ export async function setupServer(): Promise<{
 		protocol,
 		auth,
 		reachable,
+		unselected,
 	}: CreateSurrealOptions = {}) {
 		protocol = protocol ? protocol : PROTOCOL;
 		const surreal = new Surreal();
 		const port = reachable === false ? SURREAL_PORT_UNREACHABLE : SURREAL_PORT;
 		await surreal.connect(`${protocol}://127.0.0.1:${port}/rpc`, {
-			namespace: SURREAL_NS,
-			database: SURREAL_DB,
+			namespace: unselected ? undefined : SURREAL_NS,
+			database: unselected ? undefined : SURREAL_DB,
 			auth: createAuth(auth ?? "root"),
 		});
 

--- a/tests/integration/tests/connection.test.ts
+++ b/tests/integration/tests/connection.test.ts
@@ -30,7 +30,7 @@ describe("rpc", async () => {
 	test("allowed rpcs without namespace or database", async () => {
 		const surreal = await createSurreal({
 			unselected: true,
-			protocol: "http"
+			protocol: "http",
 		});
 
 		await surreal.version();
@@ -40,7 +40,7 @@ describe("rpc", async () => {
 	test("disallowed rpcs without namespace or database", async () => {
 		const surreal = await createSurreal({
 			unselected: true,
-			protocol: "http"
+			protocol: "http",
 		});
 
 		expect(async () => {

--- a/tests/integration/tests/connection.test.ts
+++ b/tests/integration/tests/connection.test.ts
@@ -25,3 +25,26 @@ describe("version check", async () => {
 		expect(diff).toBeLessThanOrEqual(defaultVersionCheckTimeout + 100); // 100ms margin
 	});
 });
+
+describe("rpc", async () => {
+	test("allowed rpcs without namespace or database", async () => {
+		const surreal = await createSurreal({
+			unselected: true,
+			protocol: "http"
+		});
+
+		await surreal.version();
+		await surreal.invalidate();
+	});
+
+	test("disallowed rpcs without namespace or database", async () => {
+		const surreal = await createSurreal({
+			unselected: true,
+			protocol: "http"
+		});
+
+		expect(async () => {
+			await surreal.query("SELECT * FROM test");
+		}).toThrow();
+	});
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently HTTP based RPC messages such as `signin` and `version` are disallowed from executing unless a namespace and database is defined, which is not necessary.

## What does this change do?

Improved the HTTP RPC validation logic to allow a manually defined list of RPC methods when no namespace or database is defined.

## What is your testing strategy?

Added tests

## Is this related to any issues?

- #303

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
