### PR TITLE
Stabilize 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "surrealdb",
-	"version": "1.0.0-beta.21",
+	"version": "1.0.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"repository": {
@@ -46,10 +46,5 @@
 			"browser": "./dist/index.bundled.mjs"
 		}
 	},
-	"files": [
-		"dist",
-		"README.md",
-		"LICENCE",
-		"SECURITY.md"
-	]
+	"files": ["dist", "README.md", "LICENCE", "SECURITY.md"]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from "./types.ts";
 export * from "./util/jsonify.ts";
 export * from "./util/versionCheck.ts";
 export * from "./util/getIncrementalID.ts";
+export * from "./util/string-prefixes.ts";
 export {
 	ConnectionStatus,
 	AbstractEngine,

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -1,8 +1,8 @@
 import {
 	type StringRecordId,
+	Table,
 	type Uuid,
 	type RecordId as _RecordId,
-	Table,
 	decodeCbor,
 	encodeCbor,
 } from "./data";

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -442,8 +442,8 @@ export class Surreal {
 	 * Selects all records in a table, or a specific record, from the database.
 	 * @param thing - The table name or a record ID to select.
 	 */
-	async select<T extends R>(thing: Table | string): Promise<ActionResult<T>[]>;
 	async select<T extends R>(thing: RecordId): Promise<ActionResult<T>>;
+	async select<T extends R>(thing: Table | string): Promise<ActionResult<T>[]>;
 	async select<T extends R>(thing: RecordId | Table | string) {
 		await this.ready;
 		const res = await this.rpc<ActionResult<T>>("select", [thing]);
@@ -457,13 +457,13 @@ export class Surreal {
 	 * @param data - The document / record data to insert.
 	 */
 	async create<T extends R, U extends R = T>(
-		thing: Table | string,
-		data?: U,
-	): Promise<ActionResult<T>[]>;
-	async create<T extends R, U extends R = T>(
 		thing: RecordId,
 		data?: U,
 	): Promise<ActionResult<T>>;
+	async create<T extends R, U extends R = T>(
+		thing: Table | string,
+		data?: U,
+	): Promise<ActionResult<T>[]>;
 	async create<T extends R, U extends R = T>(
 		thing: RecordId | Table | string,
 		data?: U,
@@ -480,13 +480,13 @@ export class Surreal {
 	 * @param data - The document(s) / record(s) to insert.
 	 */
 	async insert<T extends R, U extends R = T>(
-		thing: Table | string,
-		data?: U | U[],
-	): Promise<ActionResult<T>[]>;
-	async insert<T extends R, U extends R = T>(
 		thing: RecordId,
 		data?: U,
 	): Promise<ActionResult<T>>;
+	async insert<T extends R, U extends R = T>(
+		thing: Table | string,
+		data?: U | U[],
+	): Promise<ActionResult<T>[]>;
 	async insert<T extends R, U extends R = T>(
 		thing: RecordId | Table | string,
 		data?: U | U[],
@@ -505,13 +505,13 @@ export class Surreal {
 	 * @param data - The document / record data to insert.
 	 */
 	async update<T extends R, U extends R = T>(
-		thing: Table | string,
-		data?: U,
-	): Promise<ActionResult<T>[]>;
-	async update<T extends R, U extends R = T>(
 		thing: RecordId,
 		data?: U,
 	): Promise<ActionResult<T>>;
+	async update<T extends R, U extends R = T>(
+		thing: Table | string,
+		data?: U,
+	): Promise<ActionResult<T>[]>;
 	async update<T extends R, U extends R = T>(
 		thing: RecordId | Table | string,
 		data?: U,
@@ -530,13 +530,13 @@ export class Surreal {
 	 * @param data - The document / record data to insert.
 	 */
 	async upsert<T extends R, U extends R = T>(
-		thing: Table | string,
-		data?: U,
-	): Promise<ActionResult<T>[]>;
-	async upsert<T extends R, U extends R = T>(
 		thing: RecordId,
 		data?: U,
 	): Promise<ActionResult<T>>;
+	async upsert<T extends R, U extends R = T>(
+		thing: Table | string,
+		data?: U,
+	): Promise<ActionResult<T>[]>;
 	async upsert<T extends R, U extends R = T>(
 		thing: RecordId | Table | string,
 		data?: U,
@@ -555,13 +555,13 @@ export class Surreal {
 	 * @param data - The document / record data to insert.
 	 */
 	async merge<T extends R, U extends R = Partial<T>>(
-		thing: Table | string,
-		data?: U,
-	): Promise<ActionResult<T>[]>;
-	async merge<T extends R, U extends R = Partial<T>>(
 		thing: RecordId,
 		data?: U,
 	): Promise<ActionResult<T>>;
+	async merge<T extends R, U extends R = Partial<T>>(
+		thing: Table | string,
+		data?: U,
+	): Promise<ActionResult<T>[]>;
 	async merge<T extends R, U extends R = Partial<T>>(
 		thing: RecordId | Table | string,
 		data?: U,
@@ -617,8 +617,8 @@ export class Surreal {
 	 * Deletes all records in a table, or a specific record, from the database.
 	 * @param thing - The table name or a record ID to select.
 	 */
-	async delete<T extends R>(thing: Table | string): Promise<ActionResult<T>[]>;
 	async delete<T extends R>(thing: RecordId): Promise<ActionResult<T>>;
+	async delete<T extends R>(thing: Table | string): Promise<ActionResult<T>[]>;
 	async delete<T extends R>(thing: RecordId | Table | string) {
 		await this.ready;
 		const res = await this.rpc<ActionResult<T>>("delete", [thing]);
@@ -669,16 +669,16 @@ export class Surreal {
 	 */
 	async relate<T extends R, U extends R = T>(
 		from: string | RecordId | RecordId[],
-		thing: string,
-		to: string | RecordId | RecordId[],
-		data?: U,
-	): Promise<T[]>;
-	async relate<T extends R, U extends R = T>(
-		from: string | RecordId | RecordId[],
 		thing: RecordId,
 		to: string | RecordId | RecordId[],
 		data?: U,
 	): Promise<T>;
+	async relate<T extends R, U extends R = T>(
+		from: string | RecordId | RecordId[],
+		thing: string,
+		to: string | RecordId | RecordId[],
+		data?: U,
+	): Promise<T[]>;
 	async relate<T extends R, U extends R = T>(
 		from: string | RecordId | RecordId[],
 		thing: string | RecordId,

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -480,18 +480,11 @@ export class Surreal {
 	 * @param data - The document(s) / record(s) to insert.
 	 */
 	async insert<T extends R, U extends R = T>(
-		data?: U,
-	): Promise<ActionResult<T>>;
-	async insert<T extends R, U extends R = T>(
-		data?: U[],
+		data?: U | U[],
 	): Promise<ActionResult<T>[]>;
 	async insert<T extends R, U extends R = T>(
 		table: Table | string,
-		data?: U,
-	): Promise<ActionResult<T>>;
-	async insert<T extends R, U extends R = T>(
-		table: Table | string,
-		data?: U[],
+		data?: U | U[],
 	): Promise<ActionResult<T>[]>;
 	async insert<T extends R, U extends R = T>(
 		arg1: Table | string | U | U[],
@@ -513,18 +506,11 @@ export class Surreal {
 	 * @param data - The document(s) / record(s) to insert.
 	 */
 	async insert_relation<T extends R, U extends R = T>(
-		data?: U,
-	): Promise<ActionResult<T>>;
-	async insert_relation<T extends R, U extends R = T>(
-		data?: U[],
+		data?: U | U[],
 	): Promise<ActionResult<T>[]>;
 	async insert_relation<T extends R, U extends R = T>(
 		table: Table | string,
-		data?: U,
-	): Promise<ActionResult<T>>;
-	async insert_relation<T extends R, U extends R = T>(
-		table: Table | string,
-		data?: U[],
+		data?: U | U[],
 	): Promise<ActionResult<T>[]>;
 	async insert_relation<T extends R, U extends R = T>(
 		arg1: Table | string | U | U[],

--- a/src/util/string-prefixes.ts
+++ b/src/util/string-prefixes.ts
@@ -1,0 +1,32 @@
+import { StringRecordId, Uuid } from "../data";
+
+export function s(
+	string: string[] | TemplateStringsArray,
+	...values: unknown[]
+): string {
+	return string.reduce(
+		(prev, curr, i) => `${prev}${curr}${values[i] ?? ""}`,
+		"",
+	);
+}
+
+export function d(
+	string: string[] | TemplateStringsArray,
+	...values: unknown[]
+): Date {
+	return new Date(s(string, values));
+}
+
+export function r(
+	string: string[] | TemplateStringsArray,
+	...values: unknown[]
+): StringRecordId {
+	return new StringRecordId(s(string, values));
+}
+
+export function u(
+	string: string[] | TemplateStringsArray,
+	...values: unknown[]
+): Uuid {
+	return new Uuid(s(string, values));
+}

--- a/tests/unit/string-prefixes.test.ts
+++ b/tests/unit/string-prefixes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { s, d, r, u, StringRecordId, Uuid } from "../../src";
+import { StringRecordId, Uuid, d, r, s, u } from "../../src";
 
 describe("string prefixes", () => {
 	test("s", () => {

--- a/tests/unit/string-prefixes.test.ts
+++ b/tests/unit/string-prefixes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { s, d, r, u, StringRecordId, Uuid } from "../../src";
+
+describe("string prefixes", () => {
+	test("s", () => {
+		expect(s`Hello World!`).toBe("Hello World!");
+		expect(s`Hello ${"World"}!`).toBe("Hello World!");
+		expect(s`Hello ${"World"}! ${123}`).toBe("Hello World! 123");
+	});
+
+	test("d", () => {
+		expect(d`2024-09-18T13:27:42.050Z`).toMatchObject(
+			new Date("2024-09-18T13:27:42.050Z"),
+		);
+	});
+
+	test("r", () => {
+		expect(r`person:123`).toMatchObject(new StringRecordId("person:123"));
+	});
+
+	test("u", () => {
+		expect(u`3c467084-4ac4-4938-b26a-13cadf3ab7e9`).toMatchObject(
+			new Uuid("3c467084-4ac4-4938-b26a-13cadf3ab7e9"),
+		);
+	});
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

With SurrealDB 2.0.0 launched, we're now ready to stabilize the 1.0.0 release of the SurrealDB JavaScript SDK!

## What does this change do?

Bumps version to 1.0.0, and fixes a couple last typescript issues. Additionally adds a missing RPC method.

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
