### PR TITLE
RecordId stringification fixes

### DIFF
--- a/src/data/types/recordid.ts
+++ b/src/data/types/recordid.ts
@@ -76,7 +76,7 @@ export function escape_ident(str: string): string {
 			!(code > 96 && code < 123) && // lower alpha (a-z)
 			!(code === 95) // underscore (_)
 		) {
-			return `⟨${str.replaceAll("⟩", "⟩")}⟩`;
+			return `⟨${str.replaceAll("⟩", "\\⟩")}⟩`;
 		}
 	}
 
@@ -84,8 +84,9 @@ export function escape_ident(str: string): string {
 }
 
 export function isOnlyNumbers(str: string): boolean {
-	const parsed = Number.parseInt(str);
-	return !Number.isNaN(parsed) && parsed.toString() === str;
+	const stripped = str.replace("_", "");
+	const parsed = Number.parseInt(stripped);
+	return !Number.isNaN(parsed) && parsed.toString() === stripped;
 }
 
 export function isValidIdPart(v: unknown): v is RecordIdValue {
@@ -105,7 +106,7 @@ export function isValidIdPart(v: unknown): v is RecordIdValue {
 
 export function escape_id_part(id: RecordIdValue): string {
 	return id instanceof Uuid
-		? `d"${id}"`
+		? `u"${id}"`
 		: typeof id === "string"
 			? escape_ident(id)
 			: typeof id === "bigint" || typeof id === "number"

--- a/tests/unit/recordid.test.ts
+++ b/tests/unit/recordid.test.ts
@@ -1,17 +1,27 @@
 import { describe, expect, test } from "bun:test";
-import { RecordId } from "../../src";
+import { RecordId, Uuid } from "../../src";
 
 describe("record ids", () => {
 	test("toString()", () => {
 		expect(new RecordId("table", 123).toString()).toBe("table:123");
 		expect(new RecordId("table", "123").toString()).toBe("table:⟨123⟩");
+		expect(new RecordId("table", "123_456").toString()).toBe("table:⟨123_456⟩");
 		expect(new RecordId("table", "test").toString()).toBe("table:test");
 		expect(new RecordId("table", "complex-ident").toString()).toBe(
 			"table:⟨complex-ident⟩",
 		);
+		expect(new RecordId("table", "⟩").toString()).toBe("table:⟨\\⟩⟩");
 		expect(new RecordId("complex-table", "complex-ident").toString()).toBe(
 			"⟨complex-table⟩:⟨complex-ident⟩",
 		);
+
+		// UUID
+		expect(
+			new RecordId(
+				"table",
+				new Uuid("d2f72714-a387-487a-8eae-451330796ff4"),
+			).toString(),
+		).toBe('table:u"d2f72714-a387-487a-8eae-451330796ff4"');
 
 		// Bigint
 		expect(new RecordId("table", 9223372036854775807n).toString()).toBe(


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

As noticed on @XKonti's Live Stream this weekend, we found some issues in RecordId stringification.

## What does this change do?

- Fixes `⟩` not being escaped properly
- Fixes `_` being stripped from numbers during validation
- Fixes the UUID prefix to be `u` instead of `d`

## What is your testing strategy?

Added tests

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
