### PR TITLE
Value deep equality function

### DIFF
--- a/src/data/types/decimal.ts
+++ b/src/data/types/decimal.ts
@@ -1,8 +1,16 @@
-export class Decimal {
+import { Value } from "../value";
+
+export class Decimal extends Value {
 	readonly decimal: string;
 
 	constructor(decimal: string | number | Decimal) {
+		super();
 		this.decimal = decimal.toString();
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof Decimal)) return false;
+		return this.decimal === other.decimal;
 	}
 
 	toString(): string {

--- a/src/data/types/duration.ts
+++ b/src/data/types/duration.ts
@@ -1,4 +1,5 @@
 import { SurrealDbError } from "../../errors";
+import { Value } from "../value";
 
 const millisecond = 1;
 const microsecond = millisecond / 1000;
@@ -31,10 +32,12 @@ const durationPartRegex = new RegExp(
 	`^(\\d+)(${Array.from(units.keys()).join("|")})`,
 );
 
-export class Duration {
+export class Duration extends Value {
 	readonly _milliseconds: number;
 
 	constructor(input: Duration | number | string) {
+		super();
+
 		if (input instanceof Duration) {
 			this._milliseconds = input._milliseconds;
 		} else if (typeof input === "string") {
@@ -49,6 +52,11 @@ export class Duration {
 		ns = ns ?? 0;
 		const ms = s * 1000 + ns / 1000000;
 		return new Duration(ms);
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof Duration)) return false;
+		return this._milliseconds === other._milliseconds;
 	}
 
 	toCompact(): [number, number] | [number] | [] {

--- a/src/data/types/future.ts
+++ b/src/data/types/future.ts
@@ -7,7 +7,6 @@ export class Future extends Value {
 
 	equals(other: unknown): boolean {
 		if (!(other instanceof Future)) return false;
-		// TODO ignore whitespace
 		return this.inner === other.inner;
 	}
 

--- a/src/data/types/future.ts
+++ b/src/data/types/future.ts
@@ -1,5 +1,15 @@
-export class Future {
-	constructor(readonly inner: string) {}
+import { Value } from "../value";
+
+export class Future extends Value {
+	constructor(readonly inner: string) {
+		super();
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof Future)) return false;
+		// TODO ignore whitespace
+		return this.inner === other.inner;
+	}
 
 	toJSON(): string {
 		return this.toString();

--- a/src/data/types/geometry.ts
+++ b/src/data/types/geometry.ts
@@ -10,6 +10,10 @@ export abstract class Geometry extends Value {
 		if (!(other instanceof Geometry)) return false;
 		return this.is(other);
 	}
+
+	toString(): string {
+		return JSON.stringify(this.toJSON());
+	}
 }
 
 function f(num: number | Decimal) {

--- a/src/data/types/geometry.ts
+++ b/src/data/types/geometry.ts
@@ -1,9 +1,15 @@
+import { Value } from "../value.ts";
 import { Decimal } from "./decimal.ts";
 
-export abstract class Geometry {
+export abstract class Geometry extends Value {
 	abstract toJSON(): GeoJson;
 	abstract is(geometry: Geometry): boolean;
 	abstract clone(): Geometry;
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof Geometry)) return false;
+		return this.is(other);
+	}
 }
 
 function f(num: number | Decimal) {

--- a/src/data/types/range.ts
+++ b/src/data/types/range.ts
@@ -1,5 +1,6 @@
 import { Tagged } from "../../cbor";
 import { SurrealDbError } from "../../errors";
+import { equals } from "../../util/equals";
 import { toSurrealqlString } from "../../util/to-surrealql-string";
 import { TAG_BOUND_EXCLUDED, TAG_BOUND_INCLUDED } from "../cbor";
 import { Value } from "../value";
@@ -23,8 +24,8 @@ export class Range<Beg, End> extends Value {
 		if (this.beg?.constructor !== other.beg?.constructor) return false;
 		if (this.end?.constructor !== other.end?.constructor) return false;
 		return (
-			this.beg?.value === other.beg?.value &&
-			this.end?.value === other.end?.value
+			equals(this.beg?.value, other.beg?.value) &&
+			equals(this.end?.value, other.end?.value)
 		);
 	}
 
@@ -48,16 +49,28 @@ export class BoundExcluded<T> {
 	constructor(readonly value: T) {}
 }
 
-export class RecordIdRange<Tb extends string = string> {
+export class RecordIdRange<Tb extends string = string> extends Value {
 	constructor(
 		public readonly tb: Tb,
 		public readonly beg: Bound<RecordIdValue>,
 		public readonly end: Bound<RecordIdValue>,
 	) {
+		super();
 		if (typeof tb !== "string")
 			throw new SurrealDbError("TB part is not valid");
 		if (!isValidIdBound(beg)) throw new SurrealDbError("Beg part is not valid");
 		if (!isValidIdBound(end)) throw new SurrealDbError("End part is not valid");
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof RecordIdRange)) return false;
+		if (this.beg?.constructor !== other.beg?.constructor) return false;
+		if (this.end?.constructor !== other.end?.constructor) return false;
+		return (
+			this.tb === other.tb &&
+			equals(this.beg?.value, other.beg?.value) &&
+			equals(this.end?.value, other.end?.value)
+		);
 	}
 
 	toJSON(): string {

--- a/src/data/types/range.ts
+++ b/src/data/types/range.ts
@@ -2,6 +2,7 @@ import { Tagged } from "../../cbor";
 import { SurrealDbError } from "../../errors";
 import { toSurrealqlString } from "../../util/to-surrealql-string";
 import { TAG_BOUND_EXCLUDED, TAG_BOUND_INCLUDED } from "../cbor";
+import { Value } from "../value";
 import {
 	type RecordIdValue,
 	escape_id_part,
@@ -9,11 +10,23 @@ import {
 	isValidIdPart,
 } from "./recordid";
 
-export class Range<Beg, End> {
+export class Range<Beg, End> extends Value {
 	constructor(
 		readonly beg: Bound<Beg>,
 		readonly end: Bound<End>,
-	) {}
+	) {
+		super();
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof Range)) return false;
+		if (this.beg?.constructor !== other.beg?.constructor) return false;
+		if (this.end?.constructor !== other.end?.constructor) return false;
+		return (
+			this.beg?.value === other.beg?.value &&
+			this.end?.value === other.end?.value
+		);
+	}
 
 	toJSON(): string {
 		return this.toString();

--- a/src/data/types/recordid.ts
+++ b/src/data/types/recordid.ts
@@ -1,5 +1,7 @@
 import { SurrealDbError } from "../../errors";
+import { equals } from "../../util/equals";
 import { toSurrealqlString } from "../../util/to-surrealql-string";
+import { Value } from "../value";
 import { Uuid } from "./uuid";
 
 const MAX_i64 = 9223372036854775807n;
@@ -11,17 +13,24 @@ export type RecordIdValue =
 	| unknown[]
 	| Record<string, unknown>;
 
-export class RecordId<Tb extends string = string> {
+export class RecordId<Tb extends string = string> extends Value {
 	public readonly tb: Tb;
 	public readonly id: RecordIdValue;
 
 	constructor(tb: Tb, id: RecordIdValue) {
+		super();
+
 		if (typeof tb !== "string")
 			throw new SurrealDbError("TB part is not valid");
 		if (!isValidIdPart(id)) throw new SurrealDbError("ID part is not valid");
 
 		this.tb = tb;
 		this.id = id;
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof RecordId)) return false;
+		return this.tb === other.tb && equals(this.id, other.id);
 	}
 
 	toJSON(): string {
@@ -35,14 +44,19 @@ export class RecordId<Tb extends string = string> {
 	}
 }
 
-export class StringRecordId {
+export class StringRecordId extends Value {
 	public readonly rid: string;
 
 	constructor(rid: string) {
+		super();
 		if (typeof rid !== "string")
 			throw new SurrealDbError("String Record ID must be a string");
-
 		this.rid = rid;
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof StringRecordId)) return false;
+		return this.rid === other.rid;
 	}
 
 	toJSON(): string {

--- a/src/data/types/table.ts
+++ b/src/data/types/table.ts
@@ -1,12 +1,19 @@
 import { SurrealDbError } from "../../errors";
+import { Value } from "../value";
 
-export class Table<Tb extends string = string> {
+export class Table<Tb extends string = string> extends Value {
 	public readonly tb: Tb;
 
 	constructor(tb: Tb) {
+		super();
 		if (typeof tb !== "string")
 			throw new SurrealDbError("Table must be a string");
 		this.tb = tb;
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof Table)) return false;
+		return this.tb === other.tb;
 	}
 
 	toJSON(): string {

--- a/src/data/types/uuid.ts
+++ b/src/data/types/uuid.ts
@@ -1,9 +1,12 @@
 import { UUID, uuidv4obj, uuidv7obj } from "uuidv7";
+import { Value } from "../value";
 
-export class Uuid {
+export class Uuid extends Value {
 	private readonly inner: UUID;
 
 	constructor(uuid: string | ArrayBuffer | Uint8Array | Uuid | UUID) {
+		super();
+
 		if (uuid instanceof ArrayBuffer) {
 			this.inner = UUID.ofInner(new Uint8Array(uuid));
 		} else if (uuid instanceof Uint8Array) {
@@ -15,6 +18,11 @@ export class Uuid {
 		} else {
 			this.inner = UUID.parse(uuid);
 		}
+	}
+
+	equals(other: unknown): boolean {
+		if (!(other instanceof Uuid)) return false;
+		return this.inner.equals(other.inner);
 	}
 
 	toString(): string {

--- a/src/data/value.ts
+++ b/src/data/value.ts
@@ -8,4 +8,9 @@ export abstract class Value {
 	 * Convert this value to a serializable string
 	 */
 	abstract toJSON(): unknown;
+
+	/**
+	 * Convert this value to a string representation
+	 */
+	abstract toString(): string;
 }

--- a/src/data/value.ts
+++ b/src/data/value.ts
@@ -1,0 +1,11 @@
+export abstract class Value {
+	/**
+	 * Compare equality with another value.
+	 */
+	abstract equals(other: unknown): boolean;
+
+	/**
+	 * Convert this value to a serializable string
+	 */
+	abstract toJSON(): unknown;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from "./cbor/error";
 export * from "./data";
 export * from "./errors.ts";
 export * from "./types.ts";
+export * from "./util/equals.ts";
 export * from "./util/jsonify.ts";
 export * from "./util/version-check.ts";
 export * from "./util/get-incremental-id.ts";

--- a/src/util/equals.ts
+++ b/src/util/equals.ts
@@ -1,0 +1,38 @@
+import { Value } from "../data/value";
+
+/**
+ * Compares two values for deep equality, including arrays, objects,
+ * and SurrealQL value types.
+ *
+ * @param x The first value to compare
+ * @param y The second value to compare
+ * @returns Whether the two values are recursively equal
+ */
+export function equals(x: unknown, y: unknown): boolean {
+	if (Object.is(x, y)) return true;
+	if (x instanceof Date && y instanceof Date) {
+		return x.getTime() === y.getTime();
+	}
+	if (x instanceof RegExp && y instanceof RegExp) {
+		return x.toString() === y.toString();
+	}
+	if (x instanceof Value && y instanceof Value) {
+		return x.equals(y);
+	}
+	if (
+		typeof x !== "object" ||
+		x === null ||
+		typeof y !== "object" ||
+		y === null
+	) {
+		return false;
+	}
+	const keysX = Reflect.ownKeys(x as unknown as object) as (keyof typeof x)[];
+	const keysY = Reflect.ownKeys(y as unknown as object);
+	if (keysX.length !== keysY.length) return false;
+	for (let i = 0; i < keysX.length; i++) {
+		if (!Reflect.has(y as unknown as object, keysX[i])) return false;
+		if (!equals(x[keysX[i]], y[keysX[i]])) return false;
+	}
+	return true;
+}

--- a/tests/unit/__helpers.ts
+++ b/tests/unit/__helpers.ts
@@ -1,0 +1,75 @@
+import {
+	BoundExcluded,
+	BoundIncluded,
+	Decimal,
+	Duration,
+	GeometryCollection,
+	GeometryLine,
+	GeometryMultiPolygon,
+	GeometryPoint,
+	GeometryPolygon,
+	Range,
+	RecordId,
+	RecordIdRange,
+	StringRecordId,
+	Table,
+	Uuid,
+} from "../../src";
+
+export function createMockValue(): object {
+	return {
+		rid: new RecordId("some:thing", "under_score"),
+		id_looks_like_number: new RecordId("some:thing", "123"),
+		id_almost_a_number: new RecordId("some:thing", "1e23"),
+		id_is_a_number: new RecordId("some:thing", 123),
+		str_rid: new StringRecordId("⟨some:thing⟩:under_score"),
+		rng_rid: new RecordIdRange(
+			"bla",
+			new BoundIncluded("a"),
+			new BoundExcluded("z"),
+		),
+		range: new Range(
+			new BoundIncluded(new RecordId("bla", "a")),
+			new BoundExcluded("z"),
+		),
+		range_unbounded: new Range(undefined, new BoundExcluded("z")),
+		dec: new Decimal("3.333333"),
+		dur: new Duration("1d2h"),
+		geo: new GeometryCollection([
+			new GeometryPoint([1, 2]),
+			new GeometryMultiPolygon([
+				new GeometryPolygon([
+					new GeometryLine([
+						new GeometryPoint([1, 2]),
+						new GeometryPoint([3, 4]),
+					]),
+					new GeometryLine([
+						new GeometryPoint([5, 6]),
+						new GeometryPoint([7, 8]),
+					]),
+				]),
+			]),
+			new GeometryPolygon([
+				new GeometryLine([
+					new GeometryPoint([1, 2]),
+					new GeometryPoint([3, 4]),
+				]),
+				new GeometryLine([
+					new GeometryPoint([5, 6]),
+					new GeometryPoint([7, 8]),
+				]),
+			]),
+		]),
+
+		tb: new Table("some super _ cool table"),
+		uuid: new Uuid("92b84bde-39c8-4b4b-92f7-626096d6c4d9"),
+		date: new Date("2024-05-06T17:44:57.085Z"),
+		undef: undefined,
+		null: null,
+		num: 123,
+		float: 123.456,
+		true: true,
+		false: false,
+		string: "I am a string",
+	};
+}

--- a/tests/unit/equals.test.ts
+++ b/tests/unit/equals.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+import { createMockValue } from "./__helpers";
+import { equals } from "../../src";
+
+test("value deep equality", () => {
+	const first = createMockValue();
+	const second = createMockValue();
+
+	expect(equals(first, second)).toBeTrue();
+});

--- a/tests/unit/equals.test.ts
+++ b/tests/unit/equals.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { createMockValue } from "./__helpers";
 import { equals } from "../../src";
+import { createMockValue } from "./__helpers";
 
 test("value deep equality", () => {
 	const first = createMockValue();

--- a/tests/unit/jsonify.test.ts
+++ b/tests/unit/jsonify.test.ts
@@ -1,79 +1,9 @@
 import { expect, test } from "bun:test";
-import {
-	BoundExcluded,
-	BoundIncluded,
-	Decimal,
-	Duration,
-	GeometryCollection,
-	GeometryLine,
-	GeometryMultiPolygon,
-	GeometryPoint,
-	GeometryPolygon,
-	Range,
-	RecordId,
-	RecordIdRange,
-	StringRecordId,
-	Table,
-	Uuid,
-	jsonify,
-} from "../../src";
+import { jsonify } from "../../src";
+import { createMockValue } from "./__helpers";
 
 test("jsonify matches snapshot", () => {
-	const json = jsonify({
-		rid: new RecordId("some:thing", "under_score"),
-		id_looks_like_number: new RecordId("some:thing", "123"),
-		id_almost_a_number: new RecordId("some:thing", "1e23"),
-		id_is_a_number: new RecordId("some:thing", 123),
-		str_rid: new StringRecordId("⟨some:thing⟩:under_score"),
-		rng_rid: new RecordIdRange(
-			"bla",
-			new BoundIncluded("a"),
-			new BoundExcluded("z"),
-		),
-		range: new Range(
-			new BoundIncluded(new RecordId("bla", "a")),
-			new BoundExcluded("z"),
-		),
-		range_unbounded: new Range(undefined, new BoundExcluded("z")),
-		dec: new Decimal("3.333333"),
-		dur: new Duration("1d2h"),
-		geo: new GeometryCollection([
-			new GeometryPoint([1, 2]),
-			new GeometryMultiPolygon([
-				new GeometryPolygon([
-					new GeometryLine([
-						new GeometryPoint([1, 2]),
-						new GeometryPoint([3, 4]),
-					]),
-					new GeometryLine([
-						new GeometryPoint([5, 6]),
-						new GeometryPoint([7, 8]),
-					]),
-				]),
-			]),
-			new GeometryPolygon([
-				new GeometryLine([
-					new GeometryPoint([1, 2]),
-					new GeometryPoint([3, 4]),
-				]),
-				new GeometryLine([
-					new GeometryPoint([5, 6]),
-					new GeometryPoint([7, 8]),
-				]),
-			]),
-		]),
-
-		tb: new Table("some super _ cool table"),
-		uuid: new Uuid("92b84bde-39c8-4b4b-92f7-626096d6c4d9"),
-		date: new Date("2024-05-06T17:44:57.085Z"),
-		undef: undefined,
-		null: null,
-		num: 123,
-		float: 123.456,
-		true: true,
-		false: false,
-		string: "I am a string",
-	});
+	const json = jsonify(createMockValue());
 
 	expect(json).toMatchSnapshot();
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There is currently no convenient way to compare SurrealQL values, such as UUIDs or record ids.

## What does this change do?

Adds a new `equals` function to each SurrealQL value type, as well as an exported `equals` function which performs deep equality on two values.

## What is your testing strategy?

Added a unit test

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
