### PR TITLE
Reusable gaps

### DIFF
--- a/src/util/prepared-query.ts
+++ b/src/util/prepared-query.ts
@@ -48,18 +48,21 @@ export class PreparedQuery {
 	): PreparedQuery {
 		const base = this.length;
 		this.length += values.length;
+
+		let reused = 0;
 		const gaps = new Map<Gap, number>();
 		const mapped_bindings = values.map((v, i) => {
 			if (v instanceof Gap) {
 				const index = gaps.get(v);
 				if (index !== undefined) {
+					reused++;
 					return [`bind___${index}`, v] as const;
 				}
 
-				gaps.set(v, i);
+				gaps.set(v, i - reused);
 			}
 
-			return [`bind___${base + i}`, v] as const;
+			return [`bind___${base + i - reused}`, v] as const;
 		});
 
 		for (const [k, v] of mapped_bindings) {

--- a/src/util/tagged-template.ts
+++ b/src/util/tagged-template.ts
@@ -5,18 +5,20 @@ export function surrealql(
 	query_raw: string[] | TemplateStringsArray,
 	...values: unknown[]
 ): PreparedQuery {
+	let reused = 0;
 	const gaps = new Map<Gap, number>();
 	const mapped_bindings = values.map((v, i) => {
 		if (v instanceof Gap) {
 			const index = gaps.get(v);
 			if (index !== undefined) {
+				reused++;
 				return [`bind___${index}`, v] as const;
 			}
 
-			gaps.set(v, i);
+			gaps.set(v, i - reused);
 		}
 
-		return [`bind___${i}`, v] as const;
+		return [`bind___${i - reused}`, v] as const;
 	});
 
 	const bindings = mapped_bindings.reduce<Record<`bind___${number}`, unknown>>(

--- a/src/util/tagged-template.ts
+++ b/src/util/tagged-template.ts
@@ -1,10 +1,24 @@
+import { Gap } from "../cbor/gap.ts";
 import { PreparedQuery } from "./prepared-query.ts";
 
 export function surrealql(
 	query_raw: string[] | TemplateStringsArray,
 	...values: unknown[]
 ): PreparedQuery {
-	const mapped_bindings = values.map((v, i) => [`bind___${i}`, v] as const);
+	const gaps = new Map<Gap, number>();
+	const mapped_bindings = values.map((v, i) => {
+		if (v instanceof Gap) {
+			const index = gaps.get(v);
+			if (index !== undefined) {
+				return [`bind___${index}`, v] as const;
+			}
+
+			gaps.set(v, i);
+		}
+
+		return [`bind___${i}`, v] as const;
+	});
+
 	const bindings = mapped_bindings.reduce<Record<`bind___${number}`, unknown>>(
 		(prev, [k, v]) => {
 			prev[k] = v;

--- a/tests/integration/tests/querying.test.ts
+++ b/tests/integration/tests/querying.test.ts
@@ -449,10 +449,26 @@ describe("template literal", async () => {
 			"bind___3",
 		]);
 
+		// Ensure appended segments also re-use
+		query.append`; RETURN [${foo}, ${bar}, ${1}, ${foo}, ${bar}, ${2}]`;
+		expect(Object.keys(query.bindings)).toStrictEqual([
+			"bind___0",
+			"bind___1",
+			"bind___2",
+			"bind___3",
+			"bind___4",
+			"bind___5",
+			"bind___6",
+			"bind___7",
+		]);
+
 		// Check result
 		const res = await surreal.query(query, [foo.fill("a"), bar.fill("b")]);
 
-		expect(res).toStrictEqual(["a", "b", 1, "a", "b", 2]);
+		expect(res).toStrictEqual([
+			["a", "b", 1, "a", "b", 2],
+			["a", "b", 1, "a", "b", 2],
+		]);
 	});
 });
 

--- a/tests/integration/tests/querying.test.ts
+++ b/tests/integration/tests/querying.test.ts
@@ -437,6 +437,23 @@ describe("template literal", async () => {
 			},
 		]);
 	});
+
+	test("reused gap", async () => {
+		const foo = new Gap();
+		const bar = new Gap();
+		const query = surql`RETURN [${foo}, ${bar}, ${1}, ${foo}, ${bar}, ${2}]`;
+		expect(Object.keys(query.bindings)).toStrictEqual([
+			"bind___0",
+			"bind___1",
+			"bind___2",
+			"bind___3",
+		]);
+
+		// Check result
+		const res = await surreal.query(query, [foo.fill("a"), bar.fill("b")]);
+
+		expect(res).toStrictEqual(["a", "b", 1, "a", "b", 2]);
+	});
 });
 
 test("query", async () => {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

For every run of the tagged-template method, we can re-use a binding for gaps, so that the value will be transferred just once.

## What does this change do?

Updated the logic to re-use bindings where possible.

## What is your testing strategy?

Added a test.

## Is this related to any issues?

- No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
