### PR TITLE
fix: RecordId's toJSON returns object, not string

### DIFF
--- a/src/data/types/recordid.ts
+++ b/src/data/types/recordid.ts
@@ -33,8 +33,11 @@ export class RecordId<Tb extends string = string> extends Value {
 		return this.tb === other.tb && equals(this.id, other.id);
 	}
 
-	toJSON(): string {
-		return this.toString();
+	toJSON(): { tb: string; id: RecordIdValue } {
+		return {
+			tb: escape_ident(this.tb),
+			id: this.id,
+		};
 	}
 
 	toString(): string {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When passing data from a backend to frontend, `toJSON()` is typically called and is expected to return an object, but instead it returns `${tb}:${id}`. This is not expected from a `toJSON()` function.

## What does this change do?

`toJSON()` now returns `{ tb: string, id: RecordIdValue }`

## What is your testing strategy?

We tested this in production :^)

## Is this related to any issues?

#301 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
