### PR TITLE
Add toleration for StringRecordId (#372)

### DIFF
--- a/src/data/types/recordid.ts
+++ b/src/data/types/recordid.ts
@@ -52,8 +52,7 @@ export class StringRecordId extends Value {
 
 		// In some cases the same method may be used with different data sources
 		// this can cause this method to be called with an already instanced StringRecordId.
-		if (rid instanceof StringRecordId)
-			this.rid = rid.rid;
+		if (rid instanceof StringRecordId) this.rid = rid.rid;
 
 		if (typeof rid !== "string")
 			throw new SurrealDbError("String Record ID must be a string");

--- a/src/data/types/recordid.ts
+++ b/src/data/types/recordid.ts
@@ -47,8 +47,14 @@ export class RecordId<Tb extends string = string> extends Value {
 export class StringRecordId extends Value {
 	public readonly rid: string;
 
-	constructor(rid: string) {
+	constructor(rid: string | StringRecordId) {
 		super();
+
+		// In some cases the same method may be used with different data sources
+		// this can cause this method to be called with an already instanced StringRecordId.
+		if (rid instanceof StringRecordId)
+			this.rid = rid.rid;
+
 		if (typeof rid !== "string")
 			throw new SurrealDbError("String Record ID must be a string");
 		this.rid = rid;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

PR #372.

## What does this change do?

Checks if the provided argument is already an instance of a StringRecordId.

## What is your testing strategy?

There is not already a test file for StringRecordId. My code change adds 2 lines and it's simple enough to know it's not going to implode.

## Is this related to any issues?

#372 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
