### PR TITLE
Add support for RecordId (#372)

### DIFF
--- a/src/data/types/recordid.ts
+++ b/src/data/types/recordid.ts
@@ -55,7 +55,7 @@ export class StringRecordId extends Value {
 		if (rid instanceof StringRecordId) {
 			this.rid = rid.rid;
 		} else if (rid instanceof RecordId) {
-			this.rid = `${rid.tb}⟨${rid.id}⟩`;
+			this.rid = rid.toString();
 		} else if (typeof rid === "string") {
 			this.rid = rid;
 		} else {

--- a/src/data/types/recordid.ts
+++ b/src/data/types/recordid.ts
@@ -47,16 +47,20 @@ export class RecordId<Tb extends string = string> extends Value {
 export class StringRecordId extends Value {
 	public readonly rid: string;
 
-	constructor(rid: string | StringRecordId) {
+	constructor(rid: string | StringRecordId | RecordId) {
 		super();
 
 		// In some cases the same method may be used with different data sources
-		// this can cause this method to be called with an already instanced StringRecordId.
-		if (rid instanceof StringRecordId) this.rid = rid.rid;
-
-		if (typeof rid !== "string")
+		// this can cause this method to be called with an already instanced class object.
+		if (rid instanceof StringRecordId) {
+			this.rid = rid.rid;
+		} else if (rid instanceof RecordId) {
+			this.rid = `${rid.tb}⟨${rid.id}⟩`;
+		} else if (typeof rid === "string") {
+			this.rid = rid;
+		} else {
 			throw new SurrealDbError("String Record ID must be a string");
-		this.rid = rid;
+		}
 	}
 
 	equals(other: unknown): boolean {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Having support for initializing StringRecordId in cases where the input may already be a RecordId or a StringRecordId and not just a plain string.

## What does this change do?

Adds support for initialing a `StringRecordId` object with a provided `RecordId` object.

## What is your testing strategy?

This class doesn't have any tests yet, and my changes were trivial.

## Is this related to any issues?

#372 #373 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
