### PR TITLE
Add `.export()`

### DIFF
--- a/src/engines/abstract.ts
+++ b/src/engines/abstract.ts
@@ -1,5 +1,10 @@
 import type { EngineDisconnected } from "../errors";
-import type { LiveHandlerArguments, RpcRequest, RpcResponse } from "../types";
+import type {
+	ExportOptions,
+	LiveHandlerArguments,
+	RpcRequest,
+	RpcResponse,
+} from "../types";
 import type { Emitter } from "../util/emitter";
 
 export type Engine = new (context: EngineContext) => AbstractEngine;
@@ -85,4 +90,5 @@ export abstract class AbstractEngine {
 	>(request: RpcRequest<Method, Params>): Promise<RpcResponse<Result>>;
 
 	abstract version(url: URL, timeout?: number): Promise<string>;
+	abstract export(options?: ExportOptions): Promise<string>;
 }

--- a/src/engines/ws.ts
+++ b/src/engines/ws.ts
@@ -2,11 +2,17 @@ import { WebSocket } from "isows";
 import {
 	ConnectionUnavailable,
 	EngineDisconnected,
+	FeatureUnavailableForEngine,
 	ResponseError,
 	UnexpectedConnectionError,
 	UnexpectedServerResponse,
 } from "../errors";
-import { type RpcRequest, type RpcResponse, isLiveResult } from "../types";
+import {
+	type ExportOptions,
+	type RpcRequest,
+	type RpcResponse,
+	isLiveResult,
+} from "../types";
 import { getIncrementalID } from "../util/get-incremental-id";
 import { retrieveRemoteVersion } from "../util/version-check";
 import {
@@ -200,6 +206,10 @@ export class WebsocketEngine extends AbstractEngine {
 
 	get connected(): boolean {
 		return !!this.socket;
+	}
+
+	async export(options?: ExportOptions): Promise<string> {
+		throw new FeatureUnavailableForEngine();
 	}
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -57,6 +57,12 @@ export class UnsupportedEngine extends SurrealDbError {
 	}
 }
 
+export class FeatureUnavailableForEngine extends SurrealDbError {
+	name = "FeatureUnavailableForEngine";
+	message =
+		"The feature you are trying to use is not available on this engine.";
+}
+
 export class ConnectionUnavailable extends SurrealDbError {
 	name = "ConnectionUnavailable";
 	message = "There is no connection available at this moment.";

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,3 +238,18 @@ export function isLiveResult(v: unknown): v is LiveResult {
 
 	return true;
 }
+
+/////////////////////////////////////
+/////////   EXPORT TYPES   //////////
+/////////////////////////////////////
+
+export type ExportOptions = {
+	users: boolean;
+	accesses: boolean;
+	params: boolean;
+	functions: boolean;
+	analyzers: boolean;
+	versions: boolean;
+	tables: boolean | string[];
+	records: boolean;
+};


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The upcoming 2.1.0 release of surrealdb will add support for configurable exports

## What does this change do?

Adds a `.export()` method

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
