### PR TITLE
Fix empty ident escaping

### DIFF
--- a/src/util/escape.ts
+++ b/src/util/escape.ts
@@ -11,6 +11,11 @@ export function escapeIdent(str: string): string {
 		return `⟨${str}⟩`;
 	}
 
+	// Empty string should always be escaped
+	if (str === "") {
+		return "⟨⟩";
+	}
+
 	let code: number;
 	let i: number;
 	let len: number;

--- a/tests/unit/idents.test.ts
+++ b/tests/unit/idents.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { escapeIdent } from "../../src";
+
+describe("idents", () => {
+	test("escape empty", () => {
+		expect(escapeIdent("")).toBe("⟨⟩");
+	});
+
+	test("escape numeric", () => {
+		expect(escapeIdent("123")).toBe("⟨123⟩");
+	});
+
+	test("escape underscore", () => {
+		expect(escapeIdent("hello_world")).toBe("hello_world");
+	});
+
+	test("escape hyphen", () => {
+		expect(escapeIdent("hello-world")).toBe("⟨hello-world⟩");
+	});
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Empty string idents currently are not escaped, which is invalid SurrealQL

## What does this change do?

Empty strings will always be escaped

## What is your testing strategy?

Unit tests

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
