### PR TITLE
Expose import function

### DIFF
--- a/src/engines/abstract.ts
+++ b/src/engines/abstract.ts
@@ -91,6 +91,7 @@ export abstract class AbstractEngine {
 
 	abstract version(url: URL, timeout?: number): Promise<string>;
 	abstract export(options?: Partial<ExportOptions>): Promise<string>;
+	abstract import(data: string): Promise<void>;
 
 	protected async req_post(
 		body: unknown,

--- a/src/engines/http.ts
+++ b/src/engines/http.ts
@@ -176,4 +176,17 @@ export class HttpEngine extends AbstractEngine {
 		const dec = new TextDecoder("utf-8");
 		return dec.decode(buffer);
 	}
+
+	async import(data: string): Promise<void> {
+		if (!this.connection.url) {
+			throw new ConnectionUnavailable();
+		}
+		const url = new URL(this.connection.url);
+		const basepath = url.pathname.slice(0, -4);
+		url.pathname = `${basepath}/import`;
+
+		await this.req_post(data, url, {
+			Accept: "application/json",
+		});
+	}
 }

--- a/src/engines/ws.ts
+++ b/src/engines/ws.ts
@@ -229,6 +229,20 @@ export class WebsocketEngine extends AbstractEngine {
 		const dec = new TextDecoder("utf-8");
 		return dec.decode(buffer);
 	}
+
+	async import(data: string): Promise<void> {
+		if (!this.connection.url) {
+			throw new ConnectionUnavailable();
+		}
+		const url = new URL(this.connection.url);
+		const basepath = url.pathname.slice(0, -4);
+		url.protocol = url.protocol.replace("ws", "http");
+		url.pathname = `${basepath}/import`;
+
+		await this.req_post(data, url, {
+			Accept: "application/json",
+		});
+	}
 }
 
 export class Pinger {

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -789,6 +789,16 @@ export class Surreal {
 		if (!this.connection) throw new NoActiveSocket();
 		return this.connection.export(options);
 	}
+
+	/**
+	 * Import an existing export into the database
+	 * @param input - The data to import
+	 */
+	public async import(input: string): Promise<void> {
+		await this.ready;
+		if (!this.connection) throw new NoActiveSocket();
+		return this.connection.import(input);
+	}
 }
 
 type Output<T, S> = S extends RecordId ? T : T[];

--- a/tests/integration/tests/__snapshots__/import.test.ts.snap
+++ b/tests/integration/tests/__snapshots__/import.test.ts.snap
@@ -1,0 +1,15 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`import basic 1`] = `
+[
+  [
+    {
+      "hello": "world",
+      "id": RecordId {
+        "id": 1,
+        "tb": "foo",
+      },
+    },
+  ],
+]
+`;

--- a/tests/integration/tests/import.test.ts
+++ b/tests/integration/tests/import.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import { setupServer } from "../surreal.ts";
+import { fetchVersion } from "../helpers.ts";
+import { compareVersions } from "compare-versions";
 
 const { createSurreal } = await setupServer();
 
 describe("import", async () => {
 	const surreal = await createSurreal();
+	const version = await fetchVersion(surreal);
+	const runTest = compareVersions(version, "2.0.0") >= 0;
 
-	test("basic", async () => {
+	test.if(runTest)("basic", async () => {
 		await surreal.import(/* surql */ `
 			CREATE foo:1 CONTENT { hello: "world" };
 		`);

--- a/tests/integration/tests/import.test.ts
+++ b/tests/integration/tests/import.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { setupServer } from "../surreal.ts";
-import { fetchVersion } from "../helpers.ts";
 import { compareVersions } from "compare-versions";
+import { fetchVersion } from "../helpers.ts";
+import { setupServer } from "../surreal.ts";
 
 const { createSurreal } = await setupServer();
 

--- a/tests/integration/tests/import.test.ts
+++ b/tests/integration/tests/import.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { setupServer } from "../surreal.ts";
+
+const { createSurreal } = await setupServer();
+
+describe("import", async () => {
+	const surreal = await createSurreal();
+
+	test("basic", async () => {
+		await surreal.import(/* surql */ `
+			CREATE foo:1 CONTENT { hello: "world" };
+		`);
+
+		const res = await surreal.query(/* surql */ `
+			SELECT * FROM foo;
+		`);
+
+		expect(res).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Unlike `export`, there is not currently a dedicated `import` function

## What does this change do?

Exposes an `import` function which executes a POST `/import` request, and can also be implemented separately for surrealdb.wasm

## What is your testing strategy?

Unit test

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
