### PR TITLE
Fix emitter leak

### DIFF
--- a/src/util/emitter.ts
+++ b/src/util/emitter.ts
@@ -75,8 +75,11 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 	): void {
 		if (this.listeners[event]) {
 			const index = this.listeners[event]?.findIndex((v) => v === listener);
-			if (index) {
+			if (typeof index === "number") {
 				this.listeners[event]?.splice(index, 1);
+				if (this.listeners[event]?.length === 0) {
+					delete this.listeners[event];
+				}
 			}
 		}
 	}

--- a/src/util/emitter.ts
+++ b/src/util/emitter.ts
@@ -43,7 +43,7 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 
 			if (historic && this.collectable[event]) {
 				const buffer = this.collectable[event];
-				this.collectable[event] = [];
+				delete this.collectable[event];
 				for (const args of buffer) {
 					listener(...args);
 				}
@@ -51,10 +51,19 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 		}
 	}
 
-	subscribeOnce<Event extends keyof Events>(
+	async subscribeOnce<Event extends keyof Events>(
 		event: Event,
 		historic = false,
 	): Promise<Events[Event]> {
+		if (historic && this.collectable[event]) {
+			const args = this.collectable[event]?.shift();
+			if (this.collectable[event]?.length === 0) {
+				delete this.collectable[event];
+			}
+
+			if (args) return args;
+		}
+
 		return new Promise<Events[Event]>((resolve) => {
 			let resolved = false;
 			const listener = (...args: Events[Event]) => {
@@ -65,7 +74,7 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 				}
 			};
 
-			this.subscribe(event, listener, historic);
+			this.subscribe(event, listener, false);
 		});
 	}
 
@@ -99,7 +108,10 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 		const interceptor = this.interceptors[event];
 		const computedArgs = interceptor ? await interceptor(...args) : args;
 
-		if (this.listeners[event]?.length === 0 && collectable) {
+		if (
+			(collectable && !this.listeners[event]) ||
+			this.listeners[event]?.length === 0
+		) {
 			if (!this.collectable[event]) {
 				this.collectable[event] = [];
 			}

--- a/src/util/emitter.ts
+++ b/src/util/emitter.ts
@@ -75,7 +75,7 @@ export class Emitter<Events extends UnknownEvents = UnknownEvents> {
 	): void {
 		if (this.listeners[event]) {
 			const index = this.listeners[event]?.findIndex((v) => v === listener);
-			if (typeof index === "number") {
+			if (index >= 0) {
 				this.listeners[event]?.splice(index, 1);
 				if (this.listeners[event]?.length === 0) {
 					delete this.listeners[event];

--- a/tests/unit/emitter.test.ts
+++ b/tests/unit/emitter.test.ts
@@ -62,11 +62,15 @@ describe("emitter", () => {
 	test("collectable", async () => {
 		const emitter = new Emitter<{ test: [number] }>();
 
-		emitter.emit("test", [1], true);
+		await emitter.emit("test", [1], true);
+		await emitter.emit("test", [2], true);
 		expect(emitter.scanListeners().length).toBe(0);
 
-		const p1 = await emitter.subscribeOnce("test");
+		const p1 = await emitter.subscribeOnce("test", true);
 		expect(p1).toEqual([1]);
+
+		const p2 = await emitter.subscribeOnce("test", true);
+		expect(p2).toEqual([2]);
 
 		expect(emitter.scanListeners().length).toBe(0);
 	});

--- a/tests/unit/emitter.test.ts
+++ b/tests/unit/emitter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { Emitter } from "../../src";
+
+describe("emitter", () => {
+	test("scan", () => {
+		const emitter = new Emitter<{ test: []; other: [] }>();
+		expect(emitter.scanListeners().length).toBe(0);
+
+		const listener = () => {};
+		emitter.subscribe("test", listener);
+		expect(emitter.scanListeners().length).toBe(1);
+
+		const listener2 = () => {};
+		emitter.subscribe("other", listener2);
+		expect(emitter.scanListeners((k) => k === "other").length).toBe(1);
+
+		expect(emitter.scanListeners().length).toBe(2);
+
+		emitter.unSubscribe("test", listener);
+		expect(emitter.scanListeners().length).toBe(1);
+		emitter.unSubscribe("other", listener2);
+		expect(emitter.scanListeners().length).toBe(0);
+	});
+
+	test("listeners are properly cleared out", () => {
+		const emitter = new Emitter<{ test: [] }>();
+		const listener = () => {};
+		const listener2 = () => {};
+
+		emitter.subscribe("test", listener);
+		expect(emitter.scanListeners().length).toBe(1);
+
+		emitter.unSubscribe("test", listener);
+		expect(emitter.scanListeners().length).toBe(0);
+	});
+
+	test("isSubscribed", () => {
+		const emitter = new Emitter<{ test: [] }>();
+		const listener = () => {};
+		const listener2 = () => {};
+
+		emitter.subscribe("test", listener);
+		expect(emitter.isSubscribed("test", listener)).toBe(true);
+		expect(emitter.isSubscribed("test", listener2)).toBe(false);
+	});
+
+	test("interceptors", async () => {
+		const emitter = new Emitter<{ test: [number] }>({
+			interceptors: {
+				test: async (v) => [v + 1],
+			},
+		});
+
+		const listener = (v: number) => v;
+		emitter.subscribe("test", listener);
+
+		const p = emitter.subscribeOnce("test");
+		emitter.emit("test", [1]);
+		expect(p).resolves.toEqual([2]);
+	});
+
+	test("collectable", async () => {
+		const emitter = new Emitter<{ test: [number] }>();
+
+		emitter.emit("test", [1], true);
+		expect(emitter.scanListeners().length).toBe(0);
+
+		const p1 = await emitter.subscribeOnce("test");
+		expect(p1).toEqual([1]);
+
+		expect(emitter.scanListeners().length).toBe(0);
+	});
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #395

## What does this change do?

It fixes two issues in the emitter's unsubscribe logic:
- If the index of the listener in it's group was `0`, the check if we found an index would fail, causing the listener not to be removed.
- If the group for a certain event was empty, it would not be cleared out.

## What is your testing strategy?

Added a test

## Is this related to any issues?

- Fixes #395

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
