### PR TITLE
Bump version to 1.3.1, add missing exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "surrealdb",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "The official SurrealDB SDK for JavaScript.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,4 @@ export {
 	type EngineEvents,
 } from "./engines/abstract.ts";
 export { Surreal, Surreal as default } from "./surreal.ts";
+export { EngineAuth, AuthController } from "./auth.ts";


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Some exports were missing, so we're doing a quick patch

## What does this change do?

Adds the missing exports, bumps version to 1.3.1

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
