### PR TITLE
Fix range value decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
               run: bun install
 
             - name: Checking Code Quality
-              run: bun run quality:check
+              run: bun run qc
 
     test:
         name: Test

--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ For Deno, no build is needed. For all other environments run
 
 ### Code Quality Fixes
 
-`bun quality:apply`
+`bun qa`
 
 ### Code Quality unsafe fixes
 
-`bun quality:apply:unsafe`
+`bun qau`
 
 ### Run tests for WS
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
 	},
 	"scripts": {
 		"ts": "tsc --watch --noEmit true --emitDeclarationOnly false",
-		"quality:check": "biome check .",
-		"quality:apply": "biome check . --write",
-		"quality:apply:unsafe": "biome check . --write --unsafe",
+		"qc": "biome check .",
+		"qa": "biome check . --write",
+		"qau": "biome check . --write --unsafe",
 		"build": "bun run scripts/build.ts",
 		"jsr": "bun run scripts/jsr.ts"
 	},

--- a/src/data/cbor.ts
+++ b/src/data/cbor.ts
@@ -16,6 +16,8 @@ import {
 	GeometryPolygon,
 } from "./types/geometry.ts";
 import {
+	BoundExcluded,
+	BoundIncluded,
 	Range,
 	RecordIdRange,
 	cborToRange,
@@ -134,6 +136,10 @@ export const replacer = {
 				return new Future(v.value);
 			case TAG_RANGE:
 				return new Range(...cborToRange(v.value));
+			case TAG_BOUND_INCLUDED:
+				return new BoundIncluded(v.value);
+			case TAG_BOUND_EXCLUDED:
+				return new BoundExcluded(v.value);
 			case TAG_RECORDID: {
 				if (v.value[1] instanceof Range) {
 					return new RecordIdRange(v.value[0], v.value[1].beg, v.value[1].end);

--- a/tests/integration/tests/querying.test.ts
+++ b/tests/integration/tests/querying.test.ts
@@ -549,21 +549,18 @@ describe("value encoding/decoding", async () => {
 		"Range",
 		new Range(new BoundIncluded(1), new BoundExcluded(5)),
 		version.startsWith("surrealdb-2"),
-		true,
 	);
 
 	testValue(
 		"Range Unbounded",
 		new Range(new BoundIncluded(1), undefined),
 		version.startsWith("surrealdb-2"),
-		true,
 	);
 
 	testValue(
 		"Record ID Range",
 		new RecordIdRange("test", new BoundIncluded(1), new BoundExcluded(5)),
 		version.startsWith("surrealdb-2"),
-		true,
 	);
 });
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Decoding ranges was broken, because inner bounds are decoded at an earlier stage

## What does this change do?

Fixes decoding of bounds.

## What is your testing strategy?

Tests which tested bounds are now no longer marked as todo.

## Is this related to any issues?

Not that I'm aware

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
