### PR TITLE
Prevent prepare from locking

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -89,9 +89,12 @@ export class EngineAuth extends AuthController {
 	): Promise<RpcResponse<Result>> {
 		if (!this.connection) throw new NoActiveSocket();
 
-		return this.connection.rpc<typeof method, typeof params, Result>({
-			method,
-			params,
-		});
+		return this.connection.rpc<typeof method, typeof params, Result>(
+			{
+				method,
+				params,
+			},
+			true,
+		);
 	}
 }

--- a/src/engines/abstract.ts
+++ b/src/engines/abstract.ts
@@ -102,7 +102,10 @@ export abstract class AbstractEngine {
 		Method extends string,
 		Params extends unknown[] | undefined,
 		Result,
-	>(request: RpcRequest<Method, Params>): Promise<RpcResponse<Result>>;
+	>(
+		request: RpcRequest<Method, Params>,
+		force?: boolean,
+	): Promise<RpcResponse<Result>>;
 
 	abstract version(url: URL, timeout?: number): Promise<string>;
 	abstract export(options?: Partial<ExportOptions>): Promise<string>;

--- a/src/engines/http.ts
+++ b/src/engines/http.ts
@@ -72,12 +72,12 @@ export class HttpEngine extends AbstractRemoteEngine {
 		Method extends string,
 		Params extends unknown[] | undefined,
 		Result,
-	>(request: RpcRequest<Method, Params>): Promise<RpcResponse<Result>> {
-		await this.ready;
-
-		if (!this.connection.url) {
-			throw new ConnectionUnavailable();
-		}
+	>(
+		request: RpcRequest<Method, Params>,
+		force?: boolean,
+	): Promise<RpcResponse<Result>> {
+		if (!force) await this.ready;
+		if (!this.connection.url) throw new ConnectionUnavailable();
 
 		if (
 			(!this.connection.namespace || !this.connection.database) &&

--- a/tests/integration/tests/connection.test.ts
+++ b/tests/integration/tests/connection.test.ts
@@ -50,9 +50,24 @@ describe("rpc", async () => {
 });
 
 describe("prepare", async () => {
-	test("authentication with prepare", async () => {
+	test("authentication with prepare over ws", async () => {
 		const surreal = await createSurreal({
 			protocol: "ws",
+			auth: "none",
+			prepare: async (auth) => {
+				await auth.signin({
+					username: "root",
+					password: "root",
+				});
+			},
+		});
+
+		await surreal.query("CREATE example");
+	});
+
+	test("authentication with prepare over http", async () => {
+		const surreal = await createSurreal({
+			protocol: "http",
 			auth: "none",
 			prepare: async (auth) => {
 				await auth.signin({

--- a/tests/integration/tests/connection.test.ts
+++ b/tests/integration/tests/connection.test.ts
@@ -48,3 +48,20 @@ describe("rpc", async () => {
 		}).toThrow();
 	});
 });
+
+describe("prepare", async () => {
+	test("authentication with prepare", async () => {
+		const surreal = await createSurreal({
+			protocol: "ws",
+			auth: "none",
+			prepare: async (auth) => {
+				await auth.signin({
+					username: "root",
+					password: "root",
+				});
+			},
+		});
+
+		await surreal.query("CREATE example");
+	});
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Authentication calls in `prepare` currently lock the underlying engine

## What does this change do?

Change the order of operations and abstract the force flag to allow RPC invocations during prepare

## What is your testing strategy?

Added an auth prepare test

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
