### PR TITLE
Improve tests spawn and kill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                surrealdb: ["v1.4.2", "v1.5.3", "v2.0.4", "v2.1.0"]
+                surrealdb: ["v1.4.2", "v1.5.3", "v2.0.5", "v2.1.5", "v2.2.2"]
                 engine: ["ws", "http"]
         steps:
             - name: Install SurrealDB ${{ matrix.surrealdb }} over ${{ matrix.engine }} engine

--- a/tests/integration/tests/connection.test.ts
+++ b/tests/integration/tests/connection.test.ts
@@ -3,7 +3,7 @@ import {
 	VersionRetrievalFailure,
 	defaultVersionCheckTimeout,
 } from "../../../src";
-import { setupServer, VERSION_CHECK } from "../surreal.ts";
+import { VERSION_CHECK, setupServer } from "../surreal.ts";
 
 const { createSurreal } = await setupServer();
 

--- a/tests/integration/tests/connection.test.ts
+++ b/tests/integration/tests/connection.test.ts
@@ -3,19 +3,19 @@ import {
 	VersionRetrievalFailure,
 	defaultVersionCheckTimeout,
 } from "../../../src";
-import { setupServer } from "../surreal.ts";
+import { setupServer, VERSION_CHECK } from "../surreal.ts";
 
 const { createSurreal } = await setupServer();
 
 describe("version check", async () => {
-	test("check version", async () => {
+	test.todoIf(!VERSION_CHECK)("check version", async () => {
 		const surreal = await createSurreal();
 
 		const res = await surreal.version();
 		expect(res.startsWith("surrealdb-")).toBe(true);
 	});
 
-	test("version check timeout", async () => {
+	test.skipIf(!VERSION_CHECK)("version check timeout", async () => {
 		const start = new Date();
 		const res = createSurreal({ reachable: false });
 		const end = new Date();

--- a/tests/integration/tests/live.test.ts
+++ b/tests/integration/tests/live.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { compareVersions } from "compare-versions";
 import {
 	type LiveHandlerArguments,
 	RecordId,
@@ -7,32 +6,22 @@ import {
 	type Surreal,
 	Uuid,
 } from "../../../src";
-import { fetchVersion } from "../helpers.ts";
 import { setupServer } from "../surreal.ts";
 
 const { createSurreal } = await setupServer();
 
 const isHttp = (surreal: Surreal) =>
-	surreal.connection?.connection.url?.protocol.startsWith("http");
+	!!surreal.connection?.connection.url?.protocol.startsWith("http");
 
-describe("Live Queries HTTP", async () => {
+describe("Live Queries", async () => {
 	const surreal = await createSurreal();
-	if (!isHttp(surreal)) return;
+	const http = isHttp(surreal);
 
-	test("not supported", () => {
+	test.skipIf(!http)("not supported on HTTP", () => {
 		expect(surreal.live("person")).rejects.toBeInstanceOf(ResponseError);
 	});
-});
 
-describe("Live Queries WS", async () => {
-	const surreal = await createSurreal();
-	const version = await fetchVersion(surreal);
-	if (isHttp(surreal)) return;
-
-	// temp - subscribe is broken is 2.1.0
-	if (compareVersions(version, "2.1.0") >= 0) return;
-
-	test("live", async () => {
+	test.skipIf(http)("live", async () => {
 		const events = new CollectablePromise<{
 			action: LiveHandlerArguments[0];
 			result: LiveHandlerArguments[1];
@@ -84,7 +73,7 @@ describe("Live Queries WS", async () => {
 		]);
 	});
 
-	test("unsubscribe", async () => {
+	test.skipIf(http)("unsubscribe", async () => {
 		// Prepare
 		let primaryCount = 0;
 		let secondaryCount = 0;
@@ -128,7 +117,7 @@ describe("Live Queries WS", async () => {
 		expect(primaryCount).toBeGreaterThan(secondaryCount);
 	});
 
-	test("kill", async () => {
+	test.skipIf(http)("kill", async () => {
 		// Prepare
 		let primaryCount = 0;
 		let secondaryCount = 0;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The spawn and kill currently rely on timeouts.

## What does this change do?

They now rely on stdout and actual promises. Also, this PR introduces an `SURREAL_VERSION_CHECK` envvar in the test suite which disables the version check when set to false. To be used in the surrealdb repo

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
