### PR TITLE
Fix JS SDK tests for SurrealDB 3.0

### DIFF
--- a/packages/tests/integration/__snapshots__/export.test.ts.snap
+++ b/packages/tests/integration/__snapshots__/export.test.ts.snap
@@ -1,6 +1,52 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`export basic 1`] = `
+exports[`export basic 2.x 1`] = `
+"-- ------------------------------
+-- OPTION
+-- ------------------------------
+
+OPTION IMPORT;
+
+-- ------------------------------
+-- FUNCTIONS
+-- ------------------------------
+
+DEFINE FUNCTION fn::foo() { RETURN 'bar'; } PERMISSIONS FULL;
+
+-- ------------------------------
+-- TABLE: bar
+-- ------------------------------
+
+DEFINE TABLE bar TYPE ANY SCHEMALESS PERMISSIONS NONE;
+
+
+
+
+-- ------------------------------
+-- TABLE DATA: bar
+-- ------------------------------
+
+INSERT [ { hello: 'world', id: bar:1 } ];
+
+-- ------------------------------
+-- TABLE: foo
+-- ------------------------------
+
+DEFINE TABLE foo TYPE ANY SCHEMALESS PERMISSIONS NONE;
+
+
+
+
+-- ------------------------------
+-- TABLE DATA: foo
+-- ------------------------------
+
+INSERT [ { hello: 'world', id: foo:1 } ];
+
+"
+`;
+
+exports[`export basic 3.x 1`] = `
 "-- ------------------------------
 -- OPTION
 -- ------------------------------
@@ -46,7 +92,38 @@ INSERT [ { hello: 'world', id: foo:1 } ];
 "
 `;
 
-exports[`export filter tables 1`] = `
+exports[`export filter tables 2.x 1`] = `
+"-- ------------------------------
+-- OPTION
+-- ------------------------------
+
+OPTION IMPORT;
+
+-- ------------------------------
+-- FUNCTIONS
+-- ------------------------------
+
+DEFINE FUNCTION fn::foo() { RETURN 'bar'; } PERMISSIONS FULL;
+
+-- ------------------------------
+-- TABLE: foo
+-- ------------------------------
+
+DEFINE TABLE foo TYPE ANY SCHEMALESS PERMISSIONS NONE;
+
+
+
+
+-- ------------------------------
+-- TABLE DATA: foo
+-- ------------------------------
+
+INSERT [ { hello: 'world', id: foo:1 } ];
+
+"
+`;
+
+exports[`export filter tables 3.x 1`] = `
 "-- ------------------------------
 -- OPTION
 -- ------------------------------
@@ -77,7 +154,23 @@ INSERT [ { hello: 'world', id: foo:1 } ];
 "
 `;
 
-exports[`export filter functions 1`] = `
+exports[`export filter functions 2.x 1`] = `
+"-- ------------------------------
+-- OPTION
+-- ------------------------------
+
+OPTION IMPORT;
+
+-- ------------------------------
+-- FUNCTIONS
+-- ------------------------------
+
+DEFINE FUNCTION fn::foo() { RETURN 'bar'; } PERMISSIONS FULL;
+
+"
+`;
+
+exports[`export filter functions 3.x 1`] = `
 "-- ------------------------------
 -- OPTION
 -- ------------------------------

--- a/packages/tests/integration/__snapshots__/export.test.ts.snap
+++ b/packages/tests/integration/__snapshots__/export.test.ts.snap
@@ -11,7 +11,7 @@ OPTION IMPORT;
 -- FUNCTIONS
 -- ------------------------------
 
-DEFINE FUNCTION fn::foo() { RETURN 'bar'; } PERMISSIONS FULL;
+DEFINE FUNCTION fn::foo() { RETURN 'bar' } PERMISSIONS FULL;
 
 -- ------------------------------
 -- TABLE: bar
@@ -57,7 +57,7 @@ OPTION IMPORT;
 -- FUNCTIONS
 -- ------------------------------
 
-DEFINE FUNCTION fn::foo() { RETURN 'bar'; } PERMISSIONS FULL;
+DEFINE FUNCTION fn::foo() { RETURN 'bar' } PERMISSIONS FULL;
 
 -- ------------------------------
 -- TABLE: foo
@@ -88,7 +88,7 @@ OPTION IMPORT;
 -- FUNCTIONS
 -- ------------------------------
 
-DEFINE FUNCTION fn::foo() { RETURN 'bar'; } PERMISSIONS FULL;
+DEFINE FUNCTION fn::foo() { RETURN 'bar' } PERMISSIONS FULL;
 
 "
 `;

--- a/packages/tests/integration/export.test.ts
+++ b/packages/tests/integration/export.test.ts
@@ -17,15 +17,22 @@ beforeAll(async () => {
 describe("export", async () => {
     const surreal = await createSurreal();
     const version = await fetchVersion(surreal);
-    const hasPostExport = compareVersions(version, "2.1.0") >= 0;
+    const is2x = compareVersions(version, "2.1.0") >= 0 && compareVersions(version, "3.0.0") < 0;
+    const is3x = compareVersions(version, "3.0.0") >= 0;
 
-    test.if(hasPostExport)("basic", async () => {
+    test.if(is2x)("basic 2.x", async () => {
         const res = await surreal.export();
 
         expect(res).toMatchSnapshot();
     });
 
-    test.if(hasPostExport)("filter tables", async () => {
+    test.if(is3x)("basic 3.x", async () => {
+        const res = await surreal.export();
+
+        expect(res).toMatchSnapshot();
+    });
+
+    test.if(is2x)("filter tables 2.x", async () => {
         const res = await surreal.export({
             tables: ["foo"],
         });
@@ -33,7 +40,24 @@ describe("export", async () => {
         expect(res).toMatchSnapshot();
     });
 
-    test.if(hasPostExport)("filter functions", async () => {
+    test.if(is3x)("filter tables 3.x", async () => {
+        const res = await surreal.export({
+            tables: ["foo"],
+        });
+
+        expect(res).toMatchSnapshot();
+    });
+
+    test.if(is2x)("filter functions 2.x", async () => {
+        const res = await surreal.export({
+            functions: true,
+            tables: false,
+        });
+
+        expect(res).toMatchSnapshot();
+    });
+
+    test.if(is3x)("filter functions 3.x", async () => {
         const res = await surreal.export({
             functions: true,
             tables: false,

--- a/packages/tests/integration/query/query.test.ts
+++ b/packages/tests/integration/query/query.test.ts
@@ -57,7 +57,9 @@ describe("query()", async () => {
             }
         }
 
-        expect(valueCount).toEqual(100);
+        // In 2.x ranges are inclusive, in 3.x they are exclusive.
+        expect(valueCount).toBeGreaterThanOrEqual(99);
+        expect(valueCount).toBeLessThanOrEqual(100);
         expect(doneCount).toEqual(1);
         expect(errorCount).toEqual(0);
     });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The SDK tests that run in SurrealDB have been failing ever since we began the 3.x changes.

## What does this change do?

This change attempts to fixup the tests so they work when run against 3.0.

## What is your testing strategy?

Ran against 3.0 locally:
```
$ SURREAL_EXECUTABLE_PATH=/Users/stu/dev/worktrees/surrealdb.wt2/target/debug/surreal bun test
bun test v1.2.9 (9a329c04)

packages/tests/unit/cbor.test.ts:
✓ cbor > infinity > valid bytes [0.85ms]
✓ cbor > infinity > invalid bytes, nested infinite bytes [0.73ms]
✓ cbor > infinity > invalid bytes, no break [0.04ms]
✓ cbor > infinity > invalid bytes, invalid major [0.02ms]
✓ cbor > infinity > valid text [0.04ms]
✓ cbor > infinity > valid array [0.04ms]
✓ cbor > infinity > valid map [0.01ms]
✓ cbor > partial > Succeeds if configured correctly > with gaps filled [0.03ms]
✓ cbor > partial > Succeeds if configured correctly > with defaults overwritten [0.29ms]
✓ cbor > partial > Fails if not enabled [0.07ms]
✓ cbor > partial > Fails to build if fill for gap is missing [0.05ms]
✓ cbor > encode basic types [0.58ms]
✓ cbor > encode/decode [0.82ms]

packages/tests/integration/connection.test.ts:
✓ connection > check version [234.55ms]
✓ connection > allowed rpcs without namespace or database [231.07ms]
✓ connection > disallowed rpcs without namespace or database [229.93ms]
✓ connection > access selected namespace and database [231.64ms]
✓ connection > connection status [230.53ms]
✓ connection > access token [238.49ms]
✓ connection > sequential connects [1167.53ms]
2025-09-16T10:42:37.579475Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/import.test.ts:
✓ import > basic [7.08ms]
2025-09-16T10:42:39.254322Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/export.test.ts:
» export > basic 2.x
✓ export > basic 3.x [4.24ms]
» export > filter tables 2.x
✓ export > filter tables 3.x [2.39ms]
» export > filter functions 2.x
✓ export > filter functions 3.x [1.48ms]
2025-09-16T10:42:41.157086Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/authentication.test.ts:
✓ system auth > root signin [228.41ms]
✓ system auth > invalid credentials [0.73ms]
✓ record auth > record signup [2.45ms]
✓ record auth > record signin [1.95ms]
✓ record auth > info [1.28ms]
✓ record auth > invalidate [0.43ms]
✓ session renewal > disabled [1504.89ms]
✓ session renewal > provider [1514.82ms]
✓ session renewal > custom [1514.21ms]
2025-09-16T10:42:48.096776Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/unit/values/record-id.test.ts:
✓ record ids > toString() [2.55ms]

packages/tests/unit/values/file.test.ts:
✓ File > formatting [0.17ms]

packages/tests/unit/values/duration.test.ts:
✓ Duration > fuzzing > add identity [4.10ms]
✓ Duration > fuzzing > sub self equals zero [0.93ms]
✓ Duration > fuzzing > multiply by one [0.78ms]
✓ Duration > fuzzing > div by self is one (only if exact) [0.64ms]
✓ Duration > fuzzing > mod by self is zero (only if exact) [0.62ms]
✓ Duration > fuzzing > division and remainder reconstruct original (only if clean) [0.95ms]
✓ Duration > string equality [0.25ms]
✓ Duration > component getters and constructors [0.48ms]
✓ Duration > bigint duration [0.05ms]
✓ Duration > compact and fromCompact [0.05ms]
✓ Duration > equality [0.05ms]
✓ Duration > add [0.04ms]
✓ Duration > sub [0.04ms]
✓ Duration > mul [0.06ms]
✓ Duration > div [0.03ms]
✓ Duration > mod [0.02ms]
✓ Duration > normalization
✓ Duration > measure [51.00ms]

packages/tests/unit/values/decimal.test.ts:
✓ Decimal > fuzzing > add identity [1.86ms]
✓ Decimal > fuzzing > sub self is zero [1.07ms]
✓ Decimal > fuzzing > mul by one [0.86ms]
✓ Decimal > fuzzing > div by self is one (nonzero) [1.03ms]
✓ Decimal > fuzzing > mul commutativity [1.58ms]
✓ Decimal > fuzzing > add associativity (approx) [1.93ms]
✓ Decimal > fuzzing > mul by zero is zero [0.79ms]
✓ Decimal > parses and returns high-precision values [0.06ms]
✓ Decimal > basic arithmetic [0.06ms]
✓ Decimal > additional arithmetic scenarios [0.05ms]
✓ Decimal > modulo returns remainder
✓ Decimal > handles very small values [0.03ms]
✓ Decimal > zero
✓ Decimal > serialization to JSON [0.04ms]
✓ Decimal > abs and neg [0.03ms]
✓ Decimal > isZero and isNegative [0.02ms]
✓ Decimal > compare [0.04ms]
✓ Decimal > round [0.03ms]
✓ Decimal > toFixed [0.02ms]
✓ Decimal > toFloat, toBigInt, toParts [0.04ms]
✓ Decimal > toScientific [0.14ms]
✓ Decimal > fromScientificNotation parses correctly [0.06ms]

packages/tests/unit/values/datetime.test.ts:
✓ DateTime > constructor with no arguments (current time) [0.94ms]
✓ DateTime > constructor with Date object [0.08ms]
✓ DateTime > constructor with ISO string [0.11ms]
✓ DateTime > constructor with seconds [0.02ms]
✓ DateTime > constructor with bigint seconds
✓ DateTime > constructor with milliseconds [0.03ms]
✓ DateTime > constructor with nanoseconds [0.01ms]
✓ DateTime > constructor with tuple notation [0.02ms]
✓ DateTime > epoch static method
✓ DateTime > toDate method [0.02ms]
✓ DateTime > toCompact method [0.03ms]
✓ DateTime > equals method [0.02ms]
✓ DateTime > add duration [0.04ms]
✓ DateTime > sub duration [0.02ms]
✓ DateTime > diff between datetimes [0.04ms]
✓ DateTime > nanoseconds getter [0.01ms]
✓ DateTime > microseconds getter [0.01ms]
✓ DateTime > milliseconds getter
✓ DateTime > seconds getter [0.03ms]
✓ DateTime > nanosecondsPart from toCompact
✓ DateTime > toJSON method [0.02ms]
✓ DateTime > toString method [0.01ms]
✓ DateTime > parseString with invalid format [0.03ms]

packages/tests/unit/utilities/jsonify.test.ts:
✓ jsonify() > match snapshot [1.66ms]

packages/tests/unit/utilities/version.test.ts:
✓ isVersionSupported() > 1.0.0 should be unsupported
✓ isVersionSupported() > 1.5.6 should be unsupported
✓ isVersionSupported() > 2.0.0 should be supported [0.03ms]
✓ isVersionSupported() > 3.0.0 should be supported [0.02ms]
✓ isVersionSupported() > 3.99.99 should be supported [0.02ms]
✓ isVersionSupported() > 4.0.0 should be unsupported [0.01ms]

packages/tests/unit/utilities/tagged-template.test.ts:
✓ Tagged template > empty string [0.26ms]
✓ Tagged template > query with interpolation [0.19ms]
✓ Tagged template > query with expression [0.05ms]
✓ Tagged template > query with raw insertion [0.03ms]

packages/tests/unit/utilities/bound-query.test.ts:
✓ BoundQuery > empty instance [0.10ms]
✓ BoundQuery > query only
✓ BoundQuery > query and bindings [0.01ms]
✓ BoundQuery > cloning [0.02ms]
✓ BoundQuery > appending [0.07ms]

packages/tests/unit/utilities/string-prefixes.test.ts:
✓ string prefixes > s [0.18ms]
✓ string prefixes > d [0.05ms]
✓ string prefixes > r [0.02ms]
✓ string prefixes > u [0.03ms]

packages/tests/unit/utilities/to-surql-string.test.ts:
✓ toSurqlString() > match snapshot [0.74ms]

packages/tests/unit/utilities/escape.test.ts:
✓ escape functions > empty ident [0.01ms]
✓ escape functions > numeric ident
✓ escape functions > nderscore ident
✓ escape functions > hyphenated ident
✓ escape functions > bigint number

packages/tests/unit/utilities/expression.test.ts:
✓ expression > empty [0.03ms]
✓ expression > equality [0.22ms]
✓ expression > and [0.04ms]
✓ expression > or [0.03ms]
✓ expression > not [0.03ms]
✓ expression > conditional [0.01ms]
✓ expression > raw [0.01ms]
✓ expression > complex [0.05ms]

packages/tests/unit/utilities/equals.test.ts:
✓ equals() > record ids [0.45ms]
✓ equals() > record id ranges [0.04ms]
✓ equals() > deep equality [0.24ms]

packages/tests/integration/protocol/http.test.ts:
✓ HTTP protocol > basic connection [230.12ms]
✓ HTTP protocol > execute query [231.95ms]
✓ HTTP protocol > status events [229.48ms]
✓ HTTP protocol > connection unavailable [0.61ms]
2025-09-16T10:42:50.350402Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/protocol/websocket.test.ts:
✓ WebSocket protocol > basic connection [241.08ms]
✓ WebSocket protocol > execute query [234.64ms]
✓ WebSocket protocol > status events [231.71ms]
✓ WebSocket protocol > connection unavailable [0.14ms]
2025-09-16T10:42:52.721690Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.
2025-09-16T10:42:53.837997Z  WARN surrealdb::core::kvs::ds: crates/core/src/kvs/ds.rs:654: Credentials were provided, but existing root users were found. The root user 'root' will not be created
2025-09-16T10:42:53.838008Z  WARN surrealdb::core::kvs::ds: crates/core/src/kvs/ds.rs:655: Consider removing the --user and --pass arguments from the server start command
✓ WebSocket protocol > reconnect on disconnect [2498.67ms]
2025-09-16T10:42:54.988758Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/select.test.ts:
✓ select() > single [1.51ms]
✓ select() > multiple [0.90ms]
✓ select() > range [0.84ms]
✓ select() > compile [0.96ms]
2025-09-16T10:42:56.658211Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/query.test.ts:
✓ query() > direct query [2.02ms]
✓ query() > collect query results [0.92ms]
✓ query() > collect specific query results [0.70ms]
✓ query() > stream query results [4.91ms]
✓ query() > bound query [0.59ms]
✓ query() > inner query [0.50ms]
✓ query() > pre compiled [2.11ms]
2025-09-16T10:42:58.703710Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/upsert.test.ts:
✓ upsert() > single [3.02ms]
✓ upsert() > content [1.28ms]
✓ upsert() > merge [0.97ms]
✓ upsert() > replace [0.98ms]
✓ upsert() > compile [0.48ms]
2025-09-16T10:43:00.380336Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/create.test.ts:
✓ create() > single [2.92ms]
✓ create() > multiple [0.94ms]
✓ create() > compile [0.37ms]
2025-09-16T10:43:02.159168Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/insert.test.ts:
✓ insert() > single [2.93ms]
✓ insert() > multiple [1.29ms]
✓ insert() > compile [0.97ms]
2025-09-16T10:43:04.137875Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/run.test.ts:
✓ run() > run [3.06ms]
✓ run() > compile [0.31ms]
2025-09-16T10:43:05.801642Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/update.test.ts:
✓ update() > single [1.38ms]
✓ update() > content [0.96ms]
✓ update() > merge [0.89ms]
✓ update() > replace [0.87ms]
✓ update() > compile [0.88ms]
2025-09-16T10:43:07.477712Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/params.test.ts:
✓ let() / unset() > define param [1.87ms]
✓ let() / unset() > unset param [1.18ms]
✓ let() / unset() > retrieve state [0.40ms]
2025-09-16T10:43:09.150900Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/delete.test.ts:
✓ delete() > single [1.86ms]
✓ delete() > multiple [1.23ms]
✓ delete() > compile [0.94ms]
2025-09-16T10:43:11.125807Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/relate.test.ts:
✓ relate() > single with id [3.42ms]
✓ relate() > single with table [1.19ms]
✓ relate() > multiple [1.68ms]
✓ relate() > compile [0.92ms]
2025-09-16T10:43:12.804707Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

packages/tests/integration/query/live.test.ts:
✓ live() / liveOf() > subscription properties [0.87ms]
✎ live() / liveOf() > create action
✎ live() / liveOf() > update action
✎ live() / liveOf() > delete action
✎ live() / liveOf() > reconnect and resume
✎ live() / liveOf() > unmanaged subscription properties
✎ live() / liveOf() > unmanaged create action
✎ live() / liveOf() > iterable
✎ live() / liveOf() > iterable survives reconnect
✓ live() / liveOf() > compile [0.86ms]
2025-09-16T10:43:14.474429Z  WARN surrealdb::net: src/net/signals.rs:27: SIGTERM received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.

3 tests skipped:
» export > basic 2.x
» export > filter tables 2.x
» export > filter functions 2.x


8 tests todo:
✎ live() / liveOf() > create action
✎ live() / liveOf() > update action
✎ live() / liveOf() > delete action
✎ live() / liveOf() > reconnect and resume
✎ live() / liveOf() > unmanaged subscription properties
✎ live() / liveOf() > unmanaged create action
✎ live() / liveOf() > iterable
✎ live() / liveOf() > iterable survives reconnect

 185 pass
 3 skip
 8 todo
 0 fail
 61 snapshots, 457 expect() calls
Ran 196 tests across 32 files. [41.01s]
```

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
