### PR TITLE
Add "using" event

### DIFF
--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -42,7 +42,7 @@ const DEFAULT_ENGINES: Engines = {
     https: (ctx) => new HttpEngine(ctx),
 };
 
-type ConnectionEvents = {
+export type ConnectionEvents = {
     connecting: [];
     connected: [];
     disconnected: [];
@@ -50,6 +50,7 @@ type ConnectionEvents = {
     error: [Error];
     authenticated: [Token];
     invalidated: [];
+    using: [NamespaceDatabase];
 };
 
 export class ConnectionController implements SurrealProtocol, EventPublisher<ConnectionEvents> {
@@ -209,6 +210,8 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
         if (db === null) this.#state.database = undefined;
         if (ns) this.#state.namespace = ns;
         if (db) this.#state.database = db;
+
+        this.#eventPublisher.publish("using", response);
 
         return response;
     }

--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -250,6 +250,10 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
         this.#state.database = undefined;
         this.#state.variables = {};
         this.handleAuthInvalidate();
+        this.#eventPublisher.publish("using", {
+            namespace: null,
+            database: null,
+        });
     }
 
     importSql(data: string): Promise<void> {

--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -42,7 +42,7 @@ const DEFAULT_ENGINES: Engines = {
     https: (ctx) => new HttpEngine(ctx),
 };
 
-export type ConnectionEvents = {
+type ConnectionEvents = {
     connecting: [];
     connected: [];
     disconnected: [];

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -258,3 +258,19 @@ export class ExpressionError extends SurrealError {
         super();
     }
 }
+
+/**
+ * Thrown when one or more subscribers throw an error
+ */
+export class PublishError extends SurrealError {
+    override name = "PublishError";
+    override message = "One or more subscribers threw an error:";
+
+    constructor(causes: unknown[]) {
+        super();
+
+        for (const cause of causes) {
+            this.message += `\n- ${cause instanceof Error ? cause.message : cause}`;
+        }
+    }
+}

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -265,12 +265,25 @@ export class ExpressionError extends SurrealError {
 export class PublishError extends SurrealError {
     override name = "PublishError";
     override message = "One or more subscribers threw an error:";
+    readonly causes: unknown[];
 
     constructor(causes: unknown[]) {
         super();
+        this.causes = causes;
+        this.message += PublishError.#appendCauses(causes, "");
+    }
+
+    static #appendCauses(causes: unknown[], msg: string): string {
+        let message = msg;
 
         for (const cause of causes) {
-            this.message += `\n- ${cause instanceof Error ? cause.message : cause}`;
+            if (cause instanceof PublishError) {
+                message = PublishError.#appendCauses(cause.causes, msg);
+            } else {
+                message += `\n  - ${cause instanceof Error ? cause.message : cause}`;
+            }
         }
+
+        return message;
     }
 }

--- a/packages/sdk/src/utils/publisher.ts
+++ b/packages/sdk/src/utils/publisher.ts
@@ -1,3 +1,4 @@
+import { PublishError } from "../errors";
 import type { EventPayload, EventPublisher } from "../types/publisher";
 
 export class Publisher<T extends EventPayload> implements EventPublisher<T> {
@@ -43,8 +44,18 @@ export class Publisher<T extends EventPayload> implements EventPublisher<T> {
             return;
         }
 
+        const failures: unknown[] = [];
+
         for (const subscription of subscriptions) {
-            subscription(...payload);
+            try {
+                subscription(...payload);
+            } catch (cause) {
+                failures.push(cause);
+            }
+        }
+
+        if (failures.length > 0) {
+            throw new PublishError(failures);
         }
     }
 }

--- a/packages/tests/integration/connection.test.ts
+++ b/packages/tests/integration/connection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { setupServer, VERSION_CHECK } from "./__helpers__";
 
 const { createSurreal, createIdleSurreal } = await setupServer();
@@ -74,5 +74,32 @@ describe("connection", async () => {
         await connect();
         await connect();
         await connect();
+    });
+
+    test("using event", async () => {
+        const { surreal, connect } = createIdleSurreal();
+        const handle = mock(() => {});
+
+        surreal.subscribe("using", handle);
+
+        await connect({
+            namespace: "foo",
+            database: "bar",
+        });
+
+        await surreal.use({
+            namespace: "hello",
+            database: null,
+        });
+
+        expect(handle).nthCalledWith(1, {
+            namespace: "foo",
+            database: "bar",
+        });
+
+        expect(handle).nthCalledWith(2, {
+            namespace: "hello",
+            database: null,
+        });
     });
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

It may be desirable in tooling and other advanced contexts to subscribe to namespace or database changes.

## What does this change do?

This PR introduces a `using` event on the Surreal class which is called each time a namespace or database is selected, including on connect. Additionally, it is also called when `reset` is invoked.

This PR also improves error handling of event publishers in order to combine subscriber errors together.

## What is your testing strategy?

Added test

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
