### PR TITLE
Add support for query type

### DIFF
--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -88,10 +88,9 @@ export class UnexpectedConnectionError extends SurrealError {
  */
 export class UnsupportedEngine extends SurrealError {
     override name = "UnsupportedEngine";
-    override message = "The engine you are trying to connect to is not supported or configured";
 
-    constructor(public readonly engine: string) {
-        super();
+    constructor(engine: string) {
+        super(`The engine "${engine}" is not supported or configured`);
     }
 }
 

--- a/packages/sdk/src/query/query.ts
+++ b/packages/sdk/src/query/query.ts
@@ -145,7 +145,7 @@ export class Query<
                     maybeJsonify(chunk.result?.[0] as T, json as J),
                     true,
                 );
-                yield new DoneFrame<T, J>(chunk.query, chunk.stats);
+                yield new DoneFrame<T, J>(chunk.query, chunk.stats, chunk.type ?? "other");
                 continue;
             }
 
@@ -156,7 +156,7 @@ export class Query<
             }
 
             if (chunk.kind === "batched-final") {
-                yield new DoneFrame<T, J>(chunk.query, chunk.stats);
+                yield new DoneFrame<T, J>(chunk.query, chunk.stats, chunk.type ?? "other");
             }
         }
     }

--- a/packages/sdk/src/types/rpc.ts
+++ b/packages/sdk/src/types/rpc.ts
@@ -1,8 +1,11 @@
+import type { QueryType } from "./surreal";
+
 export type RpcQueryResult<T = unknown> = RpcQueryResultOk<T> | RpcQueryResultErr;
 export type RpcQueryResultOk<T> = {
     status: "OK";
     time: string;
     result: T;
+    type: QueryType;
 };
 
 export type RpcQueryResultErr = {

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -21,6 +21,7 @@ export type Engines = Record<string, EngineFactory>;
 export type CodecFactory = (options: CodecOptions) => ValueCodec;
 export type Codecs = Partial<Record<CodecType, CodecFactory>>;
 export type CodecRegistry = Record<CodecType, ValueCodec>;
+export type QueryType = "live" | "kill" | "other";
 
 /**
  * The communication contract between the SDK and a SurrealDB datastore.
@@ -249,6 +250,7 @@ export interface QueryChunk<T> {
     kind: QueryResponseKind;
     stats?: QueryStats;
     result?: T[];
+    type?: QueryType;
     error?: {
         code: number;
         message: string;

--- a/packages/sdk/src/utils/frame.ts
+++ b/packages/sdk/src/utils/frame.ts
@@ -1,12 +1,12 @@
 import { ResponseError } from "../errors";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
-import type { QueryStats } from "../types";
+import type { QueryStats, QueryType } from "../types";
 
 /**
  * Represents a single query result frame frame
  */
 export class Frame<T, J extends boolean> {
-    query: number;
+    readonly query: number;
 
     constructor(query: number) {
         this.query = query;
@@ -67,7 +67,7 @@ export class Frame<T, J extends boolean> {
  * and no further values will be returned for that specific statement.
  */
 export class ValueFrame<T, J extends boolean> extends Frame<T, J> {
-    value: MaybeJsonify<T, J>;
+    readonly value: MaybeJsonify<T, J>;
     readonly isSingle: boolean;
 
     constructor(query: number, value: MaybeJsonify<T, J>, isSingle: boolean) {
@@ -85,8 +85,8 @@ export class ValueFrame<T, J extends boolean> extends Frame<T, J> {
  * Represents an error frame in a query result
  */
 export class ErrorFrame<T, J extends boolean> extends Frame<T, J> {
-    stats: QueryStats | undefined;
-    error: {
+    readonly stats: QueryStats | undefined;
+    readonly error: {
         code: number;
         message: string;
     };
@@ -117,11 +117,13 @@ export class ErrorFrame<T, J extends boolean> extends Frame<T, J> {
  * Represents a done frame in a query result
  */
 export class DoneFrame<T, J extends boolean> extends Frame<T, J> {
-    stats: QueryStats | undefined;
+    readonly stats: QueryStats | undefined;
+    readonly type: QueryType;
 
-    constructor(query: number, stats: QueryStats | undefined) {
+    constructor(query: number, stats: QueryStats | undefined, type: QueryType) {
         super(query);
         this.stats = stats;
+        this.type = type;
     }
 
     override isOf<V = T>(query: number): this is DoneFrame<V, J> {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

It is currently not possible to infer live query creation or killing from responses alone

## What does this change do?

Exposes the new `type` property on `DoneFrame` to detect query type

## What is your testing strategy?

Tested in demo

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
