### PR TITLE
Fix datetime compact format

### DIFF
--- a/demo/wasm/index.ts
+++ b/demo/wasm/index.ts
@@ -1,6 +1,6 @@
 import { createWasmEngines } from "@surrealdb/wasm";
 import * as surrealdb from "surrealdb";
-import { Surreal } from "surrealdb";
+import { createRemoteEngines, Surreal } from "surrealdb";
 
 declare global {
     interface Window {
@@ -13,7 +13,10 @@ if (typeof window !== "undefined") {
     Object.assign(window, surrealdb);
 
     window.surreal = new Surreal({
-        engines: createWasmEngines(),
+        engines: {
+            ...createWasmEngines(),
+            ...createRemoteEngines(),
+        },
     });
 
     window.initialize = async () => {

--- a/packages/sdk/src/value/datetime.ts
+++ b/packages/sdk/src/value/datetime.ts
@@ -8,7 +8,7 @@ const MICROSECOND = 1000n * NANOSECOND;
 const MILLISECOND = 1000n * MICROSECOND;
 const SECOND = 1000n * MILLISECOND;
 
-export type DateTimeTuple = [number | bigint, number | bigint] | [number | bigint] | [];
+export type DateTimeTuple = [number | bigint, number | bigint];
 
 /**
  * A SurrealQL datetime value with support for parsing, formatting, arithmetic, and nanosecond precision.
@@ -127,12 +127,8 @@ export class DateTime extends Value {
     /**
      * Converts the datetime to a tuple
      */
-    toCompact(): [bigint, bigint] | [bigint] | [] {
-        return this.#nanoseconds > 0n
-            ? [this.#seconds, this.#nanoseconds]
-            : this.#seconds > 0n
-              ? [this.#seconds]
-              : [];
+    toCompact(): [bigint, bigint] {
+        return [this.#seconds, this.#nanoseconds];
     }
 
     /**

--- a/packages/tests/unit/values/datetime.test.ts
+++ b/packages/tests/unit/values/datetime.test.ts
@@ -64,6 +64,12 @@ describe("DateTime", () => {
         expect(compact).toEqual([1703500200n, 123000000n]);
     });
 
+    test("toCompact method with zero", () => {
+        const dt = new DateTime(0);
+        const compact = dt.toCompact();
+        expect(compact.length).toEqual(2);
+    });
+
     test("equals method", () => {
         const dt1 = new DateTime("2023-12-25T10:30:00.123Z");
         const dt2 = new DateTime("2023-12-25T10:30:00.123Z");


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

DateTime compact format should always be a fixed length of 2

## What does this change do?

Ensure a length of 2

## What is your testing strategy?

Added test

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
