### PR TITLE
Fix namespace/database tracking getting out of sync

### DIFF
--- a/packages/sdk/src/engine/diagnostics.ts
+++ b/packages/sdk/src/engine/diagnostics.ts
@@ -10,6 +10,7 @@ import type {
     LiveMessage,
     MlExportOptions,
     NamespaceDatabase,
+    Nullable,
     QueryChunk,
     SqlExportOptions,
     SurrealEngine,
@@ -73,6 +74,14 @@ export class DiagnosticsEngine implements SurrealEngine {
         );
     }
 
+    async use(what: Nullable<NamespaceDatabase>): Promise<void> {
+        return this.#diagnose(
+            "use",
+            () => this.#delegate.use(what),
+            () => ({ requested: what }),
+        );
+    }
+
     async signup(auth: AccessRecordAuth): Promise<AuthResponse> {
         return this.#diagnose(
             "signup",
@@ -104,14 +113,6 @@ export class DiagnosticsEngine implements SurrealEngine {
             "authenticate",
             () => this.#delegate.authenticate(token),
             () => ({ variant: "token" }),
-        );
-    }
-
-    async use(what: Partial<NamespaceDatabase>): Promise<NamespaceDatabase> {
-        return this.#diagnose(
-            "use",
-            () => this.#delegate.use(what),
-            (response) => ({ requested: what, corrected: response }),
         );
     }
 

--- a/packages/sdk/src/engine/rpc.ts
+++ b/packages/sdk/src/engine/rpc.ts
@@ -10,6 +10,7 @@ import type {
     LiveMessage,
     MlExportOptions,
     NamespaceDatabase,
+    Nullable,
     QueryChunk,
     RpcQueryResult,
     RpcRequest,
@@ -43,6 +44,13 @@ export abstract class RpcEngine implements SurrealProtocol {
         return {
             version,
         };
+    }
+
+    async use(what: Nullable<NamespaceDatabase>): Promise<void> {
+        await this.send({
+            method: "use",
+            params: [what.namespace, what.database],
+        });
     }
 
     async signup(auth: AccessRecordAuth): Promise<AuthResponse> {
@@ -80,18 +88,6 @@ export abstract class RpcEngine implements SurrealProtocol {
             method: "authenticate",
             params: [token],
         });
-    }
-
-    async use(what: Partial<NamespaceDatabase>): Promise<NamespaceDatabase> {
-        await this.send({
-            method: "use",
-            params: [what.namespace, what.database],
-        });
-
-        return {
-            namespace: what.namespace ?? null,
-            database: what.database ?? null,
-        };
     }
 
     async set(name: string, value: unknown): Promise<void> {

--- a/packages/sdk/src/surreal.ts
+++ b/packages/sdk/src/surreal.ts
@@ -30,6 +30,7 @@ import type {
     EventPublisher,
     LiveResource,
     NamespaceDatabase,
+    Nullable,
     RecordResult,
     SqlExportOptions,
     Token,
@@ -211,6 +212,26 @@ export class Surreal implements EventPublisher<SurrealEvents> {
     // =========================================================== //
 
     /**
+     * Switch to the specified {@link https://surrealdb.com/docs/surrealdb/introduction/concepts/namespace|namespace}
+     * and {@link https://surrealdb.com/docs/surrealdb/introduction/concepts/database|database}
+     *
+     * Leaving the namespace or database undefined will leave the current namespace or database unchanged,
+     * while passing null will unset the selected namespace or database.
+     *
+     * @param database Switches to a specific namespace
+     * @param db Switches to a specific database
+     * @returns The newly selected namespace and database
+     */
+    async use(what: Nullable<NamespaceDatabase>): Promise<NamespaceDatabase> {
+        await this.#connection.use(what);
+
+        return {
+            namespace: this.namespace,
+            database: this.database,
+        };
+    }
+
+    /**
      * Sign up to the SurrealDB instance as a new
      * {@link https://surrealdb.com/docs/surrealdb/security/authentication#record-users|record user}.
      *
@@ -238,17 +259,6 @@ export class Surreal implements EventPublisher<SurrealEvents> {
      */
     authenticate(token: Token): Promise<void> {
         return this.#connection.authenticate(token);
-    }
-
-    /**
-     * Switch to the specified {@link https://surrealdb.com/docs/surrealdb/introduction/concepts/namespace|namespace}
-     * and {@link https://surrealdb.com/docs/surrealdb/introduction/concepts/database|database}
-     *
-     * @param database Switches to a specific namespace
-     * @param db Switches to a specific database
-     */
-    use(what: Partial<NamespaceDatabase>): Promise<NamespaceDatabase> {
-        return this.#connection.use(what);
     }
 
     /**

--- a/packages/sdk/src/types/diagnostics.ts
+++ b/packages/sdk/src/types/diagnostics.ts
@@ -1,10 +1,11 @@
 import type { Duration, Uuid } from "../value";
+import type { Nullable } from "./helpers";
 import type { LiveMessage } from "./live";
 import type { NamespaceDatabase, QueryChunk, VersionInfo } from "./surreal";
 
 type AuthVariant = "system_user" | "token" | "record_access" | "bearer_access";
 type AuthInfo = { variant: AuthVariant };
-type UseInfo = { requested: Partial<NamespaceDatabase>; corrected: NamespaceDatabase };
+type UseInfo = { requested: Nullable<NamespaceDatabase> };
 type SetInfo = { name: string; value: unknown };
 type UnsetInfo = { name: string };
 type LiveQueryInfo = { id: Uuid; message?: LiveMessage };

--- a/packages/sdk/src/types/helpers.ts
+++ b/packages/sdk/src/types/helpers.ts
@@ -6,7 +6,6 @@ export type Doc = Prettify<Record<string, unknown>>;
 export type Values<T> = Partial<T> & Doc;
 export type Output = "none" | "null" | "diff" | "before" | "after";
 export type Mutation = "content" | "merge" | "replace" | "patch";
+export type Nullable<T> = { [K in keyof T]: T[K] | null };
 
 export type AnyRecordId<Tb extends string = string> = RecordId<Tb> | StringRecordId;
-
-export type Nullish<T> = T | null | undefined;

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -9,6 +9,7 @@ import type {
     AuthResponse,
     Token,
 } from "./auth";
+import type { Nullable } from "./helpers";
 import type { Prettify } from "./internal";
 import type { LiveMessage } from "./live";
 import type { EventPublisher } from "./publisher";
@@ -34,10 +35,10 @@ export interface SurrealProtocol {
     version(): Promise<VersionInfo>;
 
     // Session operations
+    use(what: Nullable<NamespaceDatabase>): Promise<void>;
     signup(auth: AccessRecordAuth): Promise<AuthResponse>;
     signin(auth: AnyAuth): Promise<AuthResponse>;
     authenticate(token: Token): Promise<void>;
-    use(what: Partial<NamespaceDatabase>): Promise<NamespaceDatabase>;
     set(name: string, value: unknown): Promise<void>;
     unset(name: string): Promise<void>;
     invalidate(): Promise<void>;
@@ -208,8 +209,8 @@ export interface VersionInfo {
  * A combination of namespace and database
  */
 export interface NamespaceDatabase {
-    namespace: string | null;
-    database: string | null;
+    namespace?: string;
+    database?: string;
 }
 
 /**

--- a/packages/tests/integration/__snapshots__/diagnostics.test.ts.snap
+++ b/packages/tests/integration/__snapshots__/diagnostics.test.ts.snap
@@ -30,10 +30,6 @@ exports[`diagnostics diagnostic events 1`] = `
     "key": Uuid {},
     "phase": "after",
     "result": {
-      "corrected": {
-        "database": "test",
-        "namespace": "test",
-      },
       "requested": {
         "database": "test",
         "namespace": "test",

--- a/packages/tests/integration/connection.test.ts
+++ b/packages/tests/integration/connection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
+import { RecordId } from "surrealdb";
 import { setupServer, VERSION_CHECK } from "./__helpers__";
 
 const { createSurreal, createIdleSurreal } = await setupServer();
@@ -110,7 +111,39 @@ describe("connection", async () => {
 
         expect(handle).nthCalledWith(2, {
             namespace: "hello",
-            database: null,
+            database: undefined,
         });
+    });
+
+    test("use seperately", async () => {
+        const surreal = await createSurreal();
+
+        await surreal.use({
+            namespace: "foo",
+        });
+
+        await surreal.use({
+            database: "bar",
+        });
+
+        expect(surreal.namespace).toBe("foo");
+        expect(surreal.database).toBe("bar");
+
+        await surreal.select(new RecordId("person", 1));
+    });
+
+    test("use correction", async () => {
+        const surreal = await createSurreal();
+
+        await surreal.use({
+            namespace: "foo",
+        });
+
+        const current = await surreal.use({
+            database: "bar",
+        });
+
+        expect(current.namespace).toBe("foo");
+        expect(current.database).toBe("bar");
     });
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When selecting a database after selecting a namespace the connection state becomes out of sync with the remote database.

## What does this change do?

Always rely on local state and user-specified requests for NS/DB tracking

## What is your testing strategy?

Added tests and corrected existing tests

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
