### PR TITLE
Use getter for Symbol.toStringTag

### DIFF
--- a/packages/sdk/src/internal/dispatched-promise.ts
+++ b/packages/sdk/src/internal/dispatched-promise.ts
@@ -52,9 +52,11 @@ export abstract class DispatchedPromise<T> extends Promise<T> {
         return super.finally(onfinally);
     }
 
-    static get [Symbol.species](): PromiseConstructor {
+    static override get [Symbol.species](): PromiseConstructor {
         return Promise;
     }
 
-    [Symbol.toStringTag] = "DispatchedPromise";
+    override get [Symbol.toStringTag]() {
+        return "DispatchedPromise";
+    }
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

#460

## What does this change do?

Use a getter to return the string tag

## What is your testing strategy?

N/A

## Is this related to any issues?

Fixes #460

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
