### PR TITLE
Explicitly type undefined as valid select result

### DIFF
--- a/packages/sdk/src/surreal.ts
+++ b/packages/sdk/src/surreal.ts
@@ -401,11 +401,11 @@ export class Surreal implements EventPublisher<SurrealEvents> {
     }
 
     /**
-     * Select all fields from a specific record based on the provied Record ID
+     * Select the contents of a specific record based on the provied Record ID
      *
      * @param recordId The record ID to select
      */
-    select<T extends Doc>(recordId: RecordId): SelectPromise<RecordResult<T>, T>;
+    select<T extends Doc>(recordId: RecordId): SelectPromise<RecordResult<T> | undefined, T>;
 
     /**
      * Select all records based on the provided Record ID range


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `db.select(RecordId)` function currently always types the result as `T`, while it should be `T | undefined`.

## What does this change do?

Update the return type to a union of `T | undefined`.

## What is your testing strategy?

N/A

## Is this related to any issues?

Fixes #423

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
