### PR TITLE
Re-introduce BoundQuery tag literal append overload

### DIFF
--- a/packages/tests/unit/utilities/bound-query.test.ts
+++ b/packages/tests/unit/utilities/bound-query.test.ts
@@ -41,4 +41,13 @@ describe("BoundQuery", () => {
         expect(query.query).toBe("SELECT * FROM $id WHERE active = $value");
         expect(query.bindings).toMatchObject({ id: new RecordId("user", 123), value: true });
     });
+
+    test("append template literal", () => {
+        const query = new BoundQuery("SELECT * FROM $id", { id: new RecordId("user", 123) });
+
+        query.append` WHERE active = ${true}`;
+
+        expect(query.query).toBe("SELECT * FROM $id WHERE active = $bind__1");
+        expect(query.bindings).toMatchObject({ id: new RecordId("user", 123), bind__1: true });
+    });
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

This was an unnecessary breaking change

## What does this change do?

Re-introduces the old syntax alongside the new overloads

## What is your testing strategy?

Added test

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
