### PR TITLE
Detect surreal executable for tests before falling back

### DIFF
--- a/packages/tests/integration/__helpers__/env.ts
+++ b/packages/tests/integration/__helpers__/env.ts
@@ -5,7 +5,7 @@ const port = await getPort();
 if (typeof port !== "number") throw new Error("Could not claim port");
 
 export const SURREAL_EXECUTABLE_PATH: string =
-    process.env.SURREAL_EXECUTABLE_PATH || "/usr/local/bin/surreal";
+    process.env.SURREAL_EXECUTABLE_PATH || Bun.which("surreal") || "/usr/local/bin/surreal";
 export const SURREAL_PROTOCOL: Protocol =
     import.meta.env.SURREAL_PROTOCOL === "http" ? "http" : "ws";
 export const SURREAL_PORT: string = port.toString();


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Got an error trying tk run tests, noticed tests assumed fixed installation path

## What does this change do?

Updates the tests env file to detect surreal installation path before trying the fallback

## What is your testing strategy?

Just run tests while surreal is in a different location while still in the $PATH. They should succeed instead of erroring because surreal binarybwasnt found.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
