### PR TITLE
LiveResource also accepts RecordId, RecordIdRange and StringRecordId

### DIFF
--- a/packages/sdk/src/types/live.ts
+++ b/packages/sdk/src/types/live.ts
@@ -1,8 +1,8 @@
-import type { RecordId, Table, Uuid } from "../value";
+import type { RecordId, RecordIdRange, StringRecordId, Table, Uuid } from "../value";
 
 export const LIVE_ACTIONS = ["CREATE", "UPDATE", "DELETE", "KILLED"] as const;
 
-export type LiveResource = Table;
+export type LiveResource = RecordId | RecordIdRange | StringRecordId | Table;
 export type LiveAction = (typeof LIVE_ACTIONS)[number];
 export type LiveMessage = {
     queryId: Uuid;

--- a/packages/tests/integration/query/live.test.ts
+++ b/packages/tests/integration/query/live.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, mock, test } from "bun:test";
-import { eq, type LiveMessage, RecordId, type Uuid } from "surrealdb";
+import {
+    BoundIncluded,
+    eq,
+    type LiveMessage,
+    RecordId,
+    RecordIdRange,
+    StringRecordId,
+    type Uuid,
+} from "surrealdb";
 import {
     createSurreal,
     insertMockRecords,
@@ -27,6 +35,152 @@ describe.if(SURREAL_PROTOCOL === "ws")("live() / liveOf()", async () => {
         await subscription.kill();
 
         expect(subscription.isAlive).toBeFalse();
+    });
+
+    test.todo("RecordId", async () => {
+        const surreal = await createSurreal({
+            reconnect: {
+                enabled: true,
+            },
+        });
+        await insertMockRecords(surreal);
+        const subscription = await surreal.live(new RecordId("person", 3));
+        const { promise, resolve } = Promise.withResolvers();
+        const mockHandler = mock(() => resolve());
+
+        subscription.subscribe(mockHandler);
+
+        await surreal.create(new RecordId("person", 3)).content({
+            firstname: "John",
+            lastname: "Doe",
+        });
+
+        await promise;
+
+        expect(mockHandler).toBeCalledTimes(1);
+        expect(mockHandler).toBeCalledWith({
+            action: "CREATE",
+            queryId: subscription.id,
+            recordId: new RecordId("person", 3),
+            value: {
+                id: new RecordId("person", 3),
+                firstname: "John",
+                lastname: "Doe",
+            },
+        });
+
+        await subscription.kill();
+    });
+
+    test.todo("RecordIdRange", async () => {
+        const surreal = await createSurreal({
+            reconnect: {
+                enabled: true,
+            },
+        });
+        await insertMockRecords(surreal);
+        const subscription = await surreal.live(
+            new RecordIdRange(
+                personTable,
+                new BoundIncluded("person:3"),
+                new BoundIncluded("person:3"),
+            ),
+        );
+        const { promise, resolve } = Promise.withResolvers();
+        const mockHandler = mock(() => resolve());
+
+        subscription.subscribe(mockHandler);
+
+        await surreal.create(new RecordId("person", 3)).content({
+            firstname: "John",
+            lastname: "Doe",
+        });
+
+        await promise;
+
+        expect(mockHandler).toBeCalledTimes(1);
+        expect(mockHandler).toBeCalledWith({
+            action: "CREATE",
+            queryId: subscription.id,
+            recordId: new RecordId("person", 3),
+            value: {
+                id: new RecordId("person", 3),
+                firstname: "John",
+                lastname: "Doe",
+            },
+        });
+
+        await subscription.kill();
+    });
+
+    test.todo("StringRecordId", async () => {
+        const surreal = await createSurreal({
+            reconnect: {
+                enabled: true,
+            },
+        });
+        await insertMockRecords(surreal);
+        const subscription = await surreal.live(new StringRecordId("person:3"));
+        const { promise, resolve } = Promise.withResolvers();
+        const mockHandler = mock(() => resolve());
+
+        subscription.subscribe(mockHandler);
+
+        await surreal.create(new RecordId("person", 3)).content({
+            firstname: "John",
+            lastname: "Doe",
+        });
+
+        await promise;
+
+        expect(mockHandler).toBeCalledTimes(1);
+        expect(mockHandler).toBeCalledWith({
+            action: "CREATE",
+            queryId: subscription.id,
+            recordId: new RecordId("person", 3),
+            value: {
+                id: new RecordId("person", 3),
+                firstname: "John",
+                lastname: "Doe",
+            },
+        });
+
+        await subscription.kill();
+    });
+
+    test.todo("Table", async () => {
+        const surreal = await createSurreal({
+            reconnect: {
+                enabled: true,
+            },
+        });
+        await insertMockRecords(surreal);
+        const subscription = await surreal.live(personTable);
+        const { promise, resolve } = Promise.withResolvers();
+        const mockHandler = mock(() => resolve());
+
+        subscription.subscribe(mockHandler);
+
+        await surreal.create(new RecordId("person", 3)).content({
+            firstname: "John",
+            lastname: "Doe",
+        });
+
+        await promise;
+
+        expect(mockHandler).toBeCalledTimes(1);
+        expect(mockHandler).toBeCalledWith({
+            action: "CREATE",
+            queryId: subscription.id,
+            recordId: new RecordId("person", 3),
+            value: {
+                id: new RecordId("person", 3),
+                firstname: "John",
+                lastname: "Doe",
+            },
+        });
+
+        await subscription.kill();
     });
 
     test.todo("create action", async () => {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`db.live` is documented to accept `RecordId` and `RecordIdRange`, but only accepts `Table`
## What does this change do?

Provide a description of what this pull request does.

## What is your testing strategy?

I ran `bun i` (which created `bun.lockb`, totally ignoring `bun.lock`, despite me installing exact `bun` version from the `package.json`) and `bun run test`, but I faced the following issue:
```
dmitriibaranov@Dmitriis-MacBook-Pro surrealdb.js % bun run test
$ bun run build:sdk && cd packages/tests && bun test --preload ./global.ts
$ turbo build --filter=surrealdb
turbo 2.6.1

• Packages in scope: surrealdb
• Running build in 1 packages
• Remote caching disabled
surrealdb:build: cache miss, executing 0decbd762f5efae0
surrealdb:build: 
surrealdb:build: $ bun run build.ts
surrealdb:build: 382 |  nativeBinding = require_webcontainer_fallback();
surrealdb:build: 383 | } catch (err) {
surrealdb:build: 384 |  loadErrors.push(err);
surrealdb:build: 385 | }
surrealdb:build: 386 | if (!nativeBinding) {
surrealdb:build: 387 |  if (loadErrors.length > 0) throw new Error("Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.", { cause: loadErrors });
surrealdb:build:                                         ^
surrealdb:build: error: Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
surrealdb:build:  cause: [
surrealdb:build:   {
surrealdb:build:     "name": "ResolveMessage",
surrealdb:build:     "position": null,
surrealdb:build:     "message": "Cannot find module \"../rolldown-binding.darwin-universal.node\" from \"/Users/dmitriibaranov/Projects/surrealdb.js/node_modules/rolldown/dist/shared/parse-ast-index-B-b57oWx.mjs\"",
surrealdb:build:     "level": "error",
surrealdb:build:     "specifier": "../rolldown-binding.darwin-universal.node",
surrealdb:build:     "importKind": "require-call",
surrealdb:build:     "referrer": "/Users/dmitriibaranov/Projects/surrealdb.js/node_modules/rolldown/dist/shared/parse-ast-index-B-b57oWx.mjs"
surrealdb:build:   },
surrealdb:build:   {
surrealdb:build:     "name": "ResolveMessage",
surrealdb:build:     "position": null,
surrealdb:build:     "message": "Cannot find module \"@rolldown/binding-darwin-universal\" from \"/Users/dmitriibaranov/Projects/surrealdb.js/node_modules/rolldown/dist/shared/parse-ast-index-B-b57oWx.mjs\"",
surrealdb:build:     "level": "error",
surrealdb:build:     "specifier": "@rolldown/binding-darwin-universal",
surrealdb:build:     "importKind": "require-call",
surrealdb:build:     "referrer": "/Users/dmitriibaranov/Projects/surrealdb.js/node_modules/rolldown/dist/shared/parse-ast-index-B-b57oWx.mjs"
surrealdb:build:   },
surrealdb:build:   {
surrealdb:build:     "name": "ResolveMessage",
surrealdb:build:     "position": null,
surrealdb:build:     "message": "Cannot find module \"../rolldown-binding.darwin-arm64.node\" from \"/Users/dmitriibaranov/Projects/surrealdb.js/node_modules/rolldown/dist/shared/parse-ast-index-B-b57oWx.mjs\"",
surrealdb:build:     "level": "error",
surrealdb:build:     "specifier": "../rolldown-binding.darwin-arm64.node",
surrealdb:build:     "importKind": "require-call",
surrealdb:build:     "referrer": "/Users/dmitriibaranov/Projects/surrealdb.js/node_modules/rolldown/dist/shared/parse-ast-index-B-b57oWx.mjs"
surrealdb:build:   },
surrealdb:build:   {
surrealdb:build:     "code": "ObjectExpected"
surrealdb:build:   }
surrealdb:build: ]
surrealdb:build: 
surrealdb:build:       at /Users/dmitriibaranov/Projects/surrealdb.js/node_modules/rolldown/dist/shared/parse-ast-index-B-b57oWx.mjs:387:35
surrealdb:build: 
surrealdb:build: Bun v1.1.17 (macOS arm64)
surrealdb:build: error: script "build" exited with code 1
surrealdb:build: ERROR: command finished with error: command (/Users/dmitriibaranov/Projects/surrealdb.js/packages/sdk) /opt/homebrew/bin/bun run build exited (1)
surrealdb#build: command (/Users/dmitriibaranov/Projects/surrealdb.js/packages/sdk) /opt/homebrew/bin/bun run build exited (1)

 Tasks:    0 successful, 1 total
Cached:    0 cached, 1 total
  Time:    827ms 
Failed:    surrealdb#build

 ERROR  run failed: command  exited (1)
error: script "build:sdk" exited with code 1
error: script "test" exited with code 1
```

Didn't find a way to fix this. So I ended up going through the code and adding some tests. I hope they pass :)

## Is this related to any issues?

https://github.com/surrealdb/surrealdb.js/issues/501

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
