### PR TITLE
Use same type parameters for query method for consistency

### DIFF
--- a/packages/sdk/src/api/queryable.ts
+++ b/packages/sdk/src/api/queryable.ts
@@ -41,7 +41,10 @@ export abstract class SurrealQueryable {
      * @param bindings Assigns variables which can be used in the query
      * @returns A `Query` instance which can be used to execute or configure the query
      */
-    query(query: string, bindings?: Record<string, unknown>): Query;
+    query<R extends unknown[] = unknown[]>(
+        query: string,
+        bindings?: Record<string, unknown>,
+    ): Query<R>;
 
     /**
      * Runs a set of SurrealQL statements against the database.


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Having only one of the overloads support result typing is confusing.

## What does this change do?

Use same parameter for both query functions in a `SurrealQueryable` instance

## What is your testing strategy?

No testable changes. So no testing needed.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
