### PR TITLE
Improve query collecting

### DIFF
--- a/packages/sdk/src/query/query.ts
+++ b/packages/sdk/src/query/query.ts
@@ -8,249 +8,249 @@ import { DoneFrame, ErrorFrame, type Frame, ValueFrame } from "../utils/frame";
 import type { Uuid } from "../value";
 
 interface QueryOptions {
-	query: BoundQuery;
-	transaction: Uuid | undefined;
-	session: Session;
-	json: boolean;
+    query: BoundQuery;
+    transaction: Uuid | undefined;
+    session: Session;
+    json: boolean;
 }
 
 type Collect<T extends unknown[], J extends boolean> = T extends []
-	? unknown[]
-	: { [K in keyof T]: MaybeJsonify<T[K], J> };
+    ? unknown[]
+    : { [K in keyof T]: MaybeJsonify<T[K], J> };
 
 type Responses<T extends unknown[], J extends boolean> = T extends []
-	? QueryResponse[]
-	: { [K in keyof T]: QueryResponse<MaybeJsonify<T[K], J>> };
+    ? QueryResponse[]
+    : { [K in keyof T]: QueryResponse<MaybeJsonify<T[K], J>> };
 
 /**
  * A configurable query sent to a SurrealDB instance.
  */
 export class Query<
-	R extends unknown[] = unknown[],
-	J extends boolean = false,
+    R extends unknown[] = unknown[],
+    J extends boolean = false,
 > extends DispatchedPromise<Collect<R, J>> {
-	#connection: ConnectionController;
-	#options: QueryOptions;
+    #connection: ConnectionController;
+    #options: QueryOptions;
 
-	constructor(connection: ConnectionController, options: QueryOptions) {
-		super();
-		this.#connection = connection;
-		this.#options = options;
-	}
+    constructor(connection: ConnectionController, options: QueryOptions) {
+        super();
+        this.#connection = connection;
+        this.#options = options;
+    }
 
-	/**
-	 * Retrieve the inner query that will be sent to the database.
-	 */
-	get inner(): BoundQuery {
-		return this.#options.query;
-	}
+    /**
+     * Retrieve the inner query that will be sent to the database.
+     */
+    get inner(): BoundQuery {
+        return this.#options.query;
+    }
 
-	/**
-	 * Configure the query to return the result of each response as a
-	 * JSON-compatible structure.
-	 *
-	 * This is useful when query results need to be serialized. Keep in mind
-	 * that your responses will lose SurrealDB type information.
-	 */
-	json(): Query<R, true> {
-		return new Query(this.#connection, {
-			...this.#options,
-			json: true,
-		});
-	}
+    /**
+     * Configure the query to return the result of each response as a
+     * JSON-compatible structure.
+     *
+     * This is useful when query results need to be serialized. Keep in mind
+     * that your responses will lose SurrealDB type information.
+     */
+    json(): Query<R, true> {
+        return new Query(this.#connection, {
+            ...this.#options,
+            json: true,
+        });
+    }
 
-	/**
-	 * Collect and return the results of all queries at once. If any of the queries fail, the promise
-	 * will reject.
-	 *
-	 * You can optionally pass a list of query indexes to collect only the results of specific queries.
-	 * 
-	 * This is the same as awaiting the query directly, but allows specifying which queries to collect.
-	 *
-	 * @example
-	 * ```ts
-	 * const [people] = await this.query("SELECT * FROM person").collect<[Person[]]>();
-	 * ```
-	 *
-	 * @param queries The queries to collect. If no queries are provided, all queries will be collected.
-	 * @returns A promise that resolves to the results of all queries at once.
-	 */
-	async collect<T extends unknown[] = R>(...queries: number[]): Promise<Collect<T, J>> {
-		await this.#connection.ready();
+    /**
+     * Collect and return the results of all queries at once. If any of the queries fail, the promise
+     * will reject.
+     *
+     * You can optionally pass a list of query indexes to collect only the results of specific queries.
+     *
+     * This is the same as awaiting the query directly, but allows specifying which queries to collect.
+     *
+     * @example
+     * ```ts
+     * const [people] = await this.query("SELECT * FROM person").collect<[Person[]]>();
+     * ```
+     *
+     * @param queries The queries to collect. If no queries are provided, all queries will be collected.
+     * @returns A promise that resolves to the results of all queries at once.
+     */
+    async collect<T extends unknown[] = R>(...queries: number[]): Promise<Collect<T, J>> {
+        await this.#connection.ready();
 
-		const { query, transaction, session, json } = this.#options;
-		const chunks = this.#connection.query(query, session, transaction);
-		const responses: unknown[] = [];
-		const queryIndexes =
-			queries.length > 0 ? new Map(queries.map((idx, i) => [idx, i])) : undefined;
+        const { query, transaction, session, json } = this.#options;
+        const chunks = this.#connection.query(query, session, transaction);
+        const responses: unknown[] = [];
+        const queryIndexes =
+            queries.length > 0 ? new Map(queries.map((idx, i) => [idx, i])) : undefined;
 
-		for await (const chunk of chunks) {
-			if (chunk.error) {
-				throw new ResponseError(chunk.error);
-			}
+        for await (const chunk of chunks) {
+            if (chunk.error) {
+                throw new ResponseError(chunk.error);
+            }
 
-			if (queryIndexes?.has(chunk.query) === false) {
-				continue;
-			}
+            if (queryIndexes?.has(chunk.query) === false) {
+                continue;
+            }
 
-			const index = queryIndexes?.get(chunk.query) ?? chunk.query;
+            const index = queryIndexes?.get(chunk.query) ?? chunk.query;
 
-			if (chunk.kind === "single") {
-				responses[index] = maybeJsonify(chunk.result?.[0], json);
-				continue;
-			}
+            if (chunk.kind === "single") {
+                responses[index] = maybeJsonify(chunk.result?.[0], json);
+                continue;
+            }
 
-			const additions = maybeJsonify(chunk.result ?? [], json);
-			let records = responses[index] as unknown[];
+            const additions = maybeJsonify(chunk.result ?? [], json);
+            let records = responses[index] as unknown[];
 
-			if (!records) {
-				records = additions;
-				responses[index] = records;
-			} else {
-				records.push(...additions);
-			}
-		}
+            if (!records) {
+                records = additions;
+                responses[index] = records;
+            } else {
+                records.push(...additions);
+            }
+        }
 
-		return responses as Collect<T, J>;
-	}
+        return responses as Collect<T, J>;
+    }
 
-	/**
-	 * Stream the response frames of the query as they are received as an AsyncIterable.
-	 *
-	 * Each iteration yields a **value**, **error**, or **done** frame. The provided
-	 * `isValue`, `isError`, and `isDone` methods can be used to check the type of frame.
-	 * You can pass a query index to these functions to check if the frame is associated with a
-	 * specific query.
-	 *
-	 * @example
-	 * ```ts
-	 * const stream = this.query("SELECT * FROM person").stream();
-	 *
-	 * for await (const frame of stream) {
-	 *     if (frame.isValue<Person>(0)) {
-	 *         // use frame.value
-	 *     }
-	 * }
-	 * ```
-	 *
-	 * @returns An async iterable of query frames.
-	 */
-	async *stream<T = unknown>(): AsyncIterable<Frame<T, J>> {
-		await this.#connection.ready();
+    /**
+     * Stream the response frames of the query as they are received as an AsyncIterable.
+     *
+     * Each iteration yields a **value**, **error**, or **done** frame. The provided
+     * `isValue`, `isError`, and `isDone` methods can be used to check the type of frame.
+     * You can pass a query index to these functions to check if the frame is associated with a
+     * specific query.
+     *
+     * @example
+     * ```ts
+     * const stream = this.query("SELECT * FROM person").stream();
+     *
+     * for await (const frame of stream) {
+     *     if (frame.isValue<Person>(0)) {
+     *         // use frame.value
+     *     }
+     * }
+     * ```
+     *
+     * @returns An async iterable of query frames.
+     */
+    async *stream<T = unknown>(): AsyncIterable<Frame<T, J>> {
+        await this.#connection.ready();
 
-		const { query, transaction, session, json } = this.#options;
-		const chunks = this.#connection.query(query, session, transaction);
+        const { query, transaction, session, json } = this.#options;
+        const chunks = this.#connection.query(query, session, transaction);
 
-		for await (const chunk of chunks) {
-			if (chunk.error) {
-				yield new ErrorFrame<T, J>(chunk.query, chunk.stats, chunk.error);
-				continue;
-			}
+        for await (const chunk of chunks) {
+            if (chunk.error) {
+                yield new ErrorFrame<T, J>(chunk.query, chunk.stats, chunk.error);
+                continue;
+            }
 
-			if (chunk.kind === "single") {
-				yield new ValueFrame<T, J>(
-					chunk.query,
-					maybeJsonify(chunk.result?.[0] as T, json as J),
-					true,
-				);
-				yield new DoneFrame<T, J>(chunk.query, chunk.stats, chunk.type ?? "other");
-				continue;
-			}
+            if (chunk.kind === "single") {
+                yield new ValueFrame<T, J>(
+                    chunk.query,
+                    maybeJsonify(chunk.result?.[0] as T, json as J),
+                    true,
+                );
+                yield new DoneFrame<T, J>(chunk.query, chunk.stats, chunk.type ?? "other");
+                continue;
+            }
 
-			const values = chunk.result as unknown[];
+            const values = chunk.result as unknown[];
 
-			for (const value of values) {
-				yield new ValueFrame<T, J>(chunk.query, maybeJsonify(value as T, json as J), false);
-			}
+            for (const value of values) {
+                yield new ValueFrame<T, J>(chunk.query, maybeJsonify(value as T, json as J), false);
+            }
 
-			if (chunk.kind === "batched-final") {
-				yield new DoneFrame<T, J>(chunk.query, chunk.stats, chunk.type ?? "other");
-			}
-		}
-	}
+            if (chunk.kind === "batched-final") {
+                yield new DoneFrame<T, J>(chunk.query, chunk.stats, chunk.type ?? "other");
+            }
+        }
+    }
 
-	/**
-	 * Collect and return the responses of all queries at once. Failed queries will be returned
-	 * with `success: false` and the associated error, while successful queries will have
-	 * `success: true` and their result.
-	 * 
-	 * You can optionally pass a list of query indexes to collect only the results of specific responses.
-	 * 
-	 * @example
-	 * ```ts
-	 * const [people] = await this.query("SELECT * FROM person").responses<[Person[]]>();
-	 * 
-	 * people.success; // true
-	 * people.result; // Person[]
-	 * ```
-	 * 
-	 * @param queries The queries to collect. If no queries are provided, all queries will be collected.
-	 * @returns A promise that resolves to the responses of all queries at once.
-	 */
-	async responses<T extends unknown[] = R>(...queries: number[]): Promise<Responses<T, J>> {
-		await this.#connection.ready();
+    /**
+     * Collect and return the responses of all queries at once. Failed queries will be returned
+     * with `success: false` and the associated error, while successful queries will have
+     * `success: true` and their result.
+     *
+     * You can optionally pass a list of query indexes to collect only the results of specific responses.
+     *
+     * @example
+     * ```ts
+     * const [people] = await this.query("SELECT * FROM person").responses<[Person[]]>();
+     *
+     * people.success; // true
+     * people.result; // Person[]
+     * ```
+     *
+     * @param queries The queries to collect. If no queries are provided, all queries will be collected.
+     * @returns A promise that resolves to the responses of all queries at once.
+     */
+    async responses<T extends unknown[] = R>(...queries: number[]): Promise<Responses<T, J>> {
+        await this.#connection.ready();
 
-		const { query, transaction, session, json } = this.#options;
-		const chunks = this.#connection.query(query, session, transaction);
-		const collections: unknown[] = [];
-		const responses: QueryResponse[] = [];
-		const queryIndexes =
-			queries.length > 0 ? new Map(queries.map((idx, i) => [idx, i])) : undefined;
+        const { query, transaction, session, json } = this.#options;
+        const chunks = this.#connection.query(query, session, transaction);
+        const collections: unknown[] = [];
+        const responses: QueryResponse[] = [];
+        const queryIndexes =
+            queries.length > 0 ? new Map(queries.map((idx, i) => [idx, i])) : undefined;
 
-		for await (const chunk of chunks) {
-			if (queryIndexes?.has(chunk.query) === false) {
-				if (chunk.error) {
-					throw new ResponseError(chunk.error);
-				}
+        for await (const chunk of chunks) {
+            if (queryIndexes?.has(chunk.query) === false) {
+                if (chunk.error) {
+                    throw new ResponseError(chunk.error);
+                }
 
-				continue;
-			}
+                continue;
+            }
 
-			const index = queryIndexes?.get(chunk.query) ?? chunk.query;
+            const index = queryIndexes?.get(chunk.query) ?? chunk.query;
 
-			if (chunk.error) {
-				responses[index] = {
-					success: false,
-					error: chunk.error,
-					stats: chunk.stats,
-				}
-				continue;
-			}
+            if (chunk.error) {
+                responses[index] = {
+                    success: false,
+                    error: chunk.error,
+                    stats: chunk.stats,
+                };
+                continue;
+            }
 
-			if (chunk.kind === "single") {
-				responses[index] = {
-					success: true,
-					result: maybeJsonify(chunk.result?.[0], json),
-					stats: chunk.stats,
-					type: chunk.type ?? "other",
-				}
-				continue;
-			}
+            if (chunk.kind === "single") {
+                responses[index] = {
+                    success: true,
+                    result: maybeJsonify(chunk.result?.[0], json),
+                    stats: chunk.stats,
+                    type: chunk.type ?? "other",
+                };
+                continue;
+            }
 
-			const additions = maybeJsonify(chunk.result ?? [], json);
-			let records = collections[index] as unknown[];
+            const additions = maybeJsonify(chunk.result ?? [], json);
+            let records = collections[index] as unknown[];
 
-			if (!records) {
-				records = additions;
-				collections[index] = records;
-			} else {
-				records.push(...additions);
-			}
+            if (!records) {
+                records = additions;
+                collections[index] = records;
+            } else {
+                records.push(...additions);
+            }
 
-			if (chunk.kind === "batched-final") {
-				responses[index] = {
-					success: true,
-					result: records,
-					stats: chunk.stats,
-					type: chunk.type ?? "other",
-				}
-			}
-		}
+            if (chunk.kind === "batched-final") {
+                responses[index] = {
+                    success: true,
+                    result: records,
+                    stats: chunk.stats,
+                    type: chunk.type ?? "other",
+                };
+            }
+        }
 
-		return responses as Responses<T, J>;
-	}
+        return responses as Responses<T, J>;
+    }
 
-	async dispatch(): Promise<Collect<R, J>> {
-		return this.collect();
-	}
+    async dispatch(): Promise<Collect<R, J>> {
+        return this.collect();
+    }
 }

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -25,288 +25,298 @@ export type QueryType = "live" | "kill" | "other";
  * @see https://github.com/surrealdb/surrealdb-protocol
  */
 export interface SurrealProtocol {
-	// Connection operations
-	health(): Promise<void>;
-	version(): Promise<VersionInfo>;
-	sessions(): Promise<Uuid[]>;
+    // Connection operations
+    health(): Promise<void>;
+    version(): Promise<VersionInfo>;
+    sessions(): Promise<Uuid[]>;
 
-	// Session operations
-	use(what: Nullable<NamespaceDatabase>, session: Session): Promise<void>;
-	signup(auth: AccessRecordAuth, session: Session): Promise<Tokens>;
-	signin(auth: AnyAuth, session: Session): Promise<Tokens>;
-	authenticate(token: Token, session: Session): Promise<void>;
-	set(name: string, value: unknown, session: Session): Promise<void>;
-	unset(name: string, session: Session): Promise<void>;
-	refresh(tokens: Tokens, session: Session): Promise<Tokens>;
-	revoke(tokens: Tokens, session: Session): Promise<void>;
-	invalidate(session: Session): Promise<void>;
-	reset(session: Session): Promise<void>;
+    // Session operations
+    use(what: Nullable<NamespaceDatabase>, session: Session): Promise<void>;
+    signup(auth: AccessRecordAuth, session: Session): Promise<Tokens>;
+    signin(auth: AnyAuth, session: Session): Promise<Tokens>;
+    authenticate(token: Token, session: Session): Promise<void>;
+    set(name: string, value: unknown, session: Session): Promise<void>;
+    unset(name: string, session: Session): Promise<void>;
+    refresh(tokens: Tokens, session: Session): Promise<Tokens>;
+    revoke(tokens: Tokens, session: Session): Promise<void>;
+    invalidate(session: Session): Promise<void>;
+    reset(session: Session): Promise<void>;
 
-	// Transaction operations
-	begin(session: Session): Promise<Uuid>;
-	commit(txn: Uuid, session: Session): Promise<void>;
-	cancel(txn: Uuid, session: Session): Promise<void>;
+    // Transaction operations
+    begin(session: Session): Promise<Uuid>;
+    commit(txn: Uuid, session: Session): Promise<void>;
+    cancel(txn: Uuid, session: Session): Promise<void>;
 
-	// Data management operations
-	importSql(data: string): Promise<void>;
-	exportSql(options: Partial<SqlExportOptions>): Promise<string>;
-	exportMlModel(options: MlExportOptions): Promise<Uint8Array>;
+    // Data management operations
+    importSql(data: string): Promise<void>;
+    exportSql(options: Partial<SqlExportOptions>): Promise<string>;
+    exportMlModel(options: MlExportOptions): Promise<Uint8Array>;
 
-	// Query operations
-	query<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>>;
-	liveQuery(id: Uuid): AsyncIterable<LiveMessage>;
+    // Query operations
+    query<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>>;
+    liveQuery(id: Uuid): AsyncIterable<LiveMessage>;
 }
 
 /**
  * An engine responsible for communicating to a SurrealDB datastore
  */
 export interface SurrealEngine extends SurrealProtocol, EventPublisher<EngineEvents> {
-	features: Set<Feature>;
-	open(state: ConnectionState): void;
-	close(): Promise<void>;
+    features: Set<Feature>;
+    open(state: ConnectionState): void;
+    close(): Promise<void>;
 }
 
 /**
  * The events emitted by a SurrealDB engine
  */
 export type EngineEvents = {
-	connected: [];
-	reconnecting: [];
-	disconnected: [];
-	error: [Error];
+    connected: [];
+    reconnecting: [];
+    disconnected: [];
+    error: [Error];
 };
 
 /**
  * Options used to configure behavior of the SurrealDB driver
  */
 export interface DriverOptions {
-	engines?: Engines;
-	codecs?: Codecs;
-	codecOptions?: CodecOptions;
-	websocketImpl?: typeof WebSocket;
-	fetchImpl?: typeof fetch;
+    engines?: Engines;
+    codecs?: Codecs;
+    codecOptions?: CodecOptions;
+    websocketImpl?: typeof WebSocket;
+    fetchImpl?: typeof fetch;
 }
 
 /**
  * Options used to customize a specific connection to a SurrealDB datastore
  */
 export interface ConnectOptions {
-	/**
-	 * The namespace to use for this connection.
-	 */
-	namespace?: string;
-	/**
-	 * The database to use for this connection.
-	 */
-	database?: string;
-	/**
-	 * Authentication details to use when connecting as a system user or with a token. You can provide a static value,
-	 * or a function which is called to compute the authentication details. Unlike when using the `.signin()` method,
-	 * the provided authentication details may be used for all sessions and will be reused when a session expires.
-	 *
-	 * When a callback is specified returning a Promise, the SDK will wait with signaling the connection as connected
-	 * until the Promise is resolved.
-	 *
-	 * When `.signin()`, `.signup()`, or `.authenticate()` is used this property will be ignored for the duration of the session.
-	 */
-	authentication?: AuthProvider;
-	/**
-	 * Automatically check for version compatibility on connect. When the version is not supported,
-	 * an error will be thrown and the connection will not be established.
-	 *
-	 * @default true
-	 */
-	versionCheck?: boolean;
-	/**
-	 * Automatically invalidate sessions when the access token expires.
-	 *
-	 * When set to `false` (the default), the driver will attempt to renew the session through a
-	 * series of steps:
-	 *
-	 * 1. Attempt to reuse the previous access token
-	 * 2. Attempt to issue a new access token using the refresh token
-	 * 3. Attempt to invoke the authentication provider
-	 *
-	 * If none of these steps succeed, the session will be invalidated regardless.
-	 *
-	 * @default false
-	 */
-	invalidateOnExpiry?: boolean;
-	/**
-	 * Configure reconnect behavior for supported engines (WebSocket).
-	 *
-	 * - When set to `false`, the driver will remain disconnected after a connection is lost.
-	 * - When set to `true`, the driver will attempt to reconnect using default options.
-	 * - When set to an object, the driver will attempt to reconnect using the provided options.
-	 *
-	 * @default true
-	 */
-	reconnect?: boolean | Partial<ReconnectOptions>;
+    /**
+     * The namespace to use for this connection.
+     */
+    namespace?: string;
+    /**
+     * The database to use for this connection.
+     */
+    database?: string;
+    /**
+     * Authentication details to use when connecting as a system user or with a token. You can provide a static value,
+     * or a function which is called to compute the authentication details. Unlike when using the `.signin()` method,
+     * the provided authentication details may be used for all sessions and will be reused when a session expires.
+     *
+     * When a callback is specified returning a Promise, the SDK will wait with signaling the connection as connected
+     * until the Promise is resolved.
+     *
+     * When `.signin()`, `.signup()`, or `.authenticate()` is used this property will be ignored for the duration of the session.
+     */
+    authentication?: AuthProvider;
+    /**
+     * Automatically check for version compatibility on connect. When the version is not supported,
+     * an error will be thrown and the connection will not be established.
+     *
+     * @default true
+     */
+    versionCheck?: boolean;
+    /**
+     * Automatically invalidate sessions when the access token expires.
+     *
+     * When set to `false` (the default), the driver will attempt to renew the session through a
+     * series of steps:
+     *
+     * 1. Attempt to reuse the previous access token
+     * 2. Attempt to issue a new access token using the refresh token
+     * 3. Attempt to invoke the authentication provider
+     *
+     * If none of these steps succeed, the session will be invalidated regardless.
+     *
+     * @default false
+     */
+    invalidateOnExpiry?: boolean;
+    /**
+     * Configure reconnect behavior for supported engines (WebSocket).
+     *
+     * - When set to `false`, the driver will remain disconnected after a connection is lost.
+     * - When set to `true`, the driver will attempt to reconnect using default options.
+     * - When set to an object, the driver will attempt to reconnect using the provided options.
+     *
+     * @default true
+     */
+    reconnect?: boolean | Partial<ReconnectOptions>;
 }
 
 /**
  * Options to configure reconnect behavior
  */
 export interface ReconnectOptions {
-	/** Reconnect after a connection has unexpectedly dropped */
-	enabled: boolean;
-	/** How many attempts will be made at reconnecting, -1 for unlimited */
-	attempts: number;
-	/** The minimum amount of time in milliseconds to wait before reconnecting */
-	retryDelay: number;
-	/** The maximum amount of time in milliseconds to wait before reconnecting */
-	retryDelayMax: number;
-	/** The amount to multiply the delay by after each failed attempt */
-	retryDelayMultiplier: number;
-	/** A float percentage to randomly offset each delay by  */
-	retryDelayJitter: number;
-	/** Handle errors caught during reconnecting */
-	catch?: (error: Error) => boolean;
+    /** Reconnect after a connection has unexpectedly dropped */
+    enabled: boolean;
+    /** How many attempts will be made at reconnecting, -1 for unlimited */
+    attempts: number;
+    /** The minimum amount of time in milliseconds to wait before reconnecting */
+    retryDelay: number;
+    /** The maximum amount of time in milliseconds to wait before reconnecting */
+    retryDelayMax: number;
+    /** The amount to multiply the delay by after each failed attempt */
+    retryDelayMultiplier: number;
+    /** A float percentage to randomly offset each delay by  */
+    retryDelayJitter: number;
+    /** Handle errors caught during reconnecting */
+    catch?: (error: Error) => boolean;
 }
 
 export interface ConnectionSession {
-	id: Session;
-	namespace: string | undefined;
-	database: string | undefined;
-	accessToken: string | undefined;
-	refreshToken: string | undefined;
-	variables: Record<string, unknown>;
-	authRenewal: ReturnType<typeof setTimeout> | undefined;
-	authOverriden: boolean;
+    id: Session;
+    namespace: string | undefined;
+    database: string | undefined;
+    accessToken: string | undefined;
+    refreshToken: string | undefined;
+    variables: Record<string, unknown>;
+    authRenewal: ReturnType<typeof setTimeout> | undefined;
+    authOverriden: boolean;
 }
 
 /**
  * The current state of a connection to a SurrealDB datastore
  */
 export interface ConnectionState {
-	url: URL;
-	reconnect: ReconnectContext;
-	rootSession: ConnectionSession;
-	sessions: Map<Uuid, ConnectionSession>;
+    url: URL;
+    reconnect: ReconnectContext;
+    rootSession: ConnectionSession;
+    sessions: Map<Uuid, ConnectionSession>;
 }
 
 /**
  * Options used to configure the value codec
  */
 export interface CodecOptions {
-	/** Use native `Date` objects instead of custom `DateTime` objects. Using `Date` objects will result in a loss of nanosecond precision. */
-	useNativeDates?: boolean;
-	/** Specify a custom visitor function to process encode values. */
-	valueEncodeVisitor?: (value: unknown) => unknown;
-	/** Specify a custom visitor function to process decode values. */
-	valueDecodeVisitor?: (value: unknown) => unknown;
+    /** Use native `Date` objects instead of custom `DateTime` objects. Using `Date` objects will result in a loss of nanosecond precision. */
+    useNativeDates?: boolean;
+    /** Specify a custom visitor function to process encode values. */
+    valueEncodeVisitor?: (value: unknown) => unknown;
+    /** Specify a custom visitor function to process decode values. */
+    valueDecodeVisitor?: (value: unknown) => unknown;
 }
 
 /**
  * A codec for encoding and decoding SurrealQL values
  */
 export interface ValueCodec {
-	encode: <T>(data: T) => Uint8Array;
-	decode: <T>(data: Uint8Array) => T;
+    encode: <T>(data: T) => Uint8Array;
+    decode: <T>(data: Uint8Array) => T;
 }
 
 /**
  * Context information passed to each controller and engine
  */
 export interface DriverContext {
-	options: DriverOptions;
-	uniqueId: () => string;
-	codecs: CodecRegistry;
+    options: DriverOptions;
+    uniqueId: () => string;
+    codecs: CodecRegistry;
 }
 
 /**
  * Represents a record response
  */
 export type RecordResult<T> = Prettify<
-	T extends object
-	? T extends { id: infer Id }
-	? Id extends RecordId
-	? T
-	: Id extends RecordIdValue
-	? { id: RecordId<string, Id> } & Omit<T, "id">
-	: { id: RecordId } & Omit<T, "id">
-	: { id: RecordId } & T
-	: { id: RecordId }
+    T extends object
+        ? T extends { id: infer Id }
+            ? Id extends RecordId
+                ? T
+                : Id extends RecordIdValue
+                  ? { id: RecordId<string, Id> } & Omit<T, "id">
+                  : { id: RecordId } & Omit<T, "id">
+            : { id: RecordId } & T
+        : { id: RecordId }
 >;
 
 /**
  * SurrealDB version information
  */
 export interface VersionInfo {
-	version: string;
+    version: string;
 }
 
 /**
  * A combination of namespace and database
  */
 export interface NamespaceDatabase {
-	namespace?: string;
-	database?: string;
+    namespace?: string;
+    database?: string;
 }
 
 /**
  * SurrealQL exporting options
  */
 export interface SqlExportOptions {
-	users: boolean;
-	accesses: boolean;
-	params: boolean;
-	functions: boolean;
-	analyzers: boolean;
-	tables: boolean | string[];
-	versions: boolean;
-	records: boolean;
-	sequences: boolean;
+    users: boolean;
+    accesses: boolean;
+    params: boolean;
+    functions: boolean;
+    analyzers: boolean;
+    tables: boolean | string[];
+    versions: boolean;
+    records: boolean;
+    sequences: boolean;
 }
 
 /**
  * SurrealML model exporting options
  */
 export interface MlExportOptions {
-	name: string;
-	version: string;
+    name: string;
+    version: string;
 }
 
 /**
  * Query statistics
  */
 export interface QueryStats {
-	recordsReceived: number;
-	bytesReceived: number;
-	recordsScanned: number;
-	bytesScanned: number;
-	duration: Duration;
+    recordsReceived: number;
+    bytesReceived: number;
+    recordsScanned: number;
+    bytesScanned: number;
+    duration: Duration;
 }
 
 /**
  * A single chunk returned from a query stream
  */
 export interface QueryChunk<T> {
-	query: number;
-	batch: number;
-	kind: QueryResponseKind;
-	stats?: QueryStats;
-	result?: T[];
-	type?: QueryType;
-	error?: {
-		code: number;
-		message: string;
-	};
+    query: number;
+    batch: number;
+    kind: QueryResponseKind;
+    stats?: QueryStats;
+    result?: T[];
+    type?: QueryType;
+    error?: {
+        code: number;
+        message: string;
+    };
 }
+
+/**
+ * A single successful response from a query
+ */
+export type QueryResponseSuccess<T = unknown> = {
+    success: true;
+    stats?: QueryStats;
+    type: "live" | "kill" | "other";
+    result: T;
+};
+
+/**
+ * A single failure response from a query
+ */
+export type QueryResponseFailure = {
+    success: false;
+    stats?: QueryStats;
+    error: {
+        code: number;
+        message: string;
+    };
+};
 
 /**
  * A single response from a query
  */
-export type QueryResponse<T = unknown> = {
-	success: true;
-	stats?: QueryStats;
-	type: "live" | "kill" | "other";
-	result: T;
-} | {
-	success: false;
-	stats?: QueryStats;
-	error: {
-		code: number;
-		message: string;
-	};
-}
+export type QueryResponse<T = unknown> = QueryResponseSuccess<T> | QueryResponseFailure;

--- a/packages/tests/integration/query/query.test.ts
+++ b/packages/tests/integration/query/query.test.ts
@@ -3,159 +3,159 @@ import { RecordId, surql } from "surrealdb";
 import { createSurreal, type Person, proto } from "../__helpers__";
 
 describe("query()", async () => {
-	test("awaitable query", async () => {
-		const surreal = await createSurreal();
-		await surreal.query(`UPSERT hello:world CONTENT { hello: "world" }`);
-		const [result] = await surreal.query<["world"]>(`RETURN hello:world.hello`);
+    test("awaitable query", async () => {
+        const surreal = await createSurreal();
+        await surreal.query(`UPSERT hello:world CONTENT { hello: "world" }`);
+        const [result] = await surreal.query<["world"]>(`RETURN hello:world.hello`);
 
-		expect(result).toEqual("world");
-	});
+        expect(result).toEqual("world");
+    });
 
-	test("collect query results", async () => {
-		const surreal = await createSurreal();
-		await surreal.query(`UPSERT hello:world CONTENT { hello: "world" }`);
-		const [result] = await surreal.query(`RETURN hello:world.hello`).collect<["world"]>();
+    test("collect query results", async () => {
+        const surreal = await createSurreal();
+        await surreal.query(`UPSERT hello:world CONTENT { hello: "world" }`);
+        const [result] = await surreal.query(`RETURN hello:world.hello`).collect<["world"]>();
 
-		expect(result).toEqual("world");
-	});
+        expect(result).toEqual("world");
+    });
 
-	test("collect specific query results", async () => {
-		const surreal = await createSurreal();
-		const [first, third] = await surreal
-			.query(`RETURN 1; RETURN 2; RETURN 3`)
-			.collect<[1, 3]>(0, 2);
+    test("collect specific query results", async () => {
+        const surreal = await createSurreal();
+        const [first, third] = await surreal
+            .query(`RETURN 1; RETURN 2; RETURN 3`)
+            .collect<[1, 3]>(0, 2);
 
-		expect(first).toEqual(1);
-		expect(third).toEqual(3);
-	});
+        expect(first).toEqual(1);
+        expect(third).toEqual(3);
+    });
 
-	test("collect query responses", async () => {
-		const surreal = await createSurreal();
-		await surreal.query(`UPSERT hello:world CONTENT { hello: "world" }`);
-		const [result] = await surreal.query(`RETURN hello:world.hello`).responses<["world"]>();
+    test("collect query responses", async () => {
+        const surreal = await createSurreal();
+        await surreal.query(`UPSERT hello:world CONTENT { hello: "world" }`);
+        const [result] = await surreal.query(`RETURN hello:world.hello`).responses<["world"]>();
 
-		expect(result.success).toEqual(true);
-		expect(result.success && result.result).toEqual("world");
-	});
+        expect(result.success).toEqual(true);
+        expect(result.success && result.result).toEqual("world");
+    });
 
-	test("collect specific query responses", async () => {
-		const surreal = await createSurreal();
-		const [first, third] = await surreal
-			.query(`RETURN 1; RETURN 2; RETURN 3`)
-			.responses<[1, 3]>(0, 2);
+    test("collect specific query responses", async () => {
+        const surreal = await createSurreal();
+        const [first, third] = await surreal
+            .query(`RETURN 1; RETURN 2; RETURN 3`)
+            .responses<[1, 3]>(0, 2);
 
-		expect(first.success).toEqual(true);
-		expect(first.success && first.result).toEqual(1);
-		expect(third.success).toEqual(true);
-		expect(third.success && third.result).toEqual(3);
-	});
+        expect(first.success).toEqual(true);
+        expect(first.success && first.result).toEqual(1);
+        expect(third.success).toEqual(true);
+        expect(third.success && third.result).toEqual(3);
+    });
 
-	test("stream query results", async () => {
-		const surreal = await createSurreal();
-		await surreal.query(/* surql */ `
+    test("stream query results", async () => {
+        const surreal = await createSurreal();
+        await surreal.query(/* surql */ `
 		CREATE |foo:1..100| CONTENT { hello: "world" };
 	`);
-		const stream = surreal.query(`SELECT * FROM foo;`).stream();
+        const stream = surreal.query(`SELECT * FROM foo;`).stream();
 
-		let valueCount = 0;
-		let doneCount = 0;
-		let errorCount = 0;
+        let valueCount = 0;
+        let doneCount = 0;
+        let errorCount = 0;
 
-		for await (const frame of stream) {
-			if (frame.isValue<{ hello: string }>()) {
-				expect(frame.value.hello).toEqual("world");
-				valueCount++;
-			} else if (frame.isDone()) {
-				doneCount++;
-			} else if (frame.isError()) {
-				errorCount++;
-			}
-		}
+        for await (const frame of stream) {
+            if (frame.isValue<{ hello: string }>()) {
+                expect(frame.value.hello).toEqual("world");
+                valueCount++;
+            } else if (frame.isDone()) {
+                doneCount++;
+            } else if (frame.isError()) {
+                errorCount++;
+            }
+        }
 
-		// In 2.x ranges are inclusive, in 3.x they are exclusive.
-		expect(valueCount).toBeGreaterThanOrEqual(99);
-		expect(valueCount).toBeLessThanOrEqual(100);
-		expect(doneCount).toEqual(1);
-		expect(errorCount).toEqual(0);
-	});
+        // In 2.x ranges are inclusive, in 3.x they are exclusive.
+        expect(valueCount).toBeGreaterThanOrEqual(99);
+        expect(valueCount).toBeLessThanOrEqual(100);
+        expect(doneCount).toEqual(1);
+        expect(errorCount).toEqual(0);
+    });
 
-	test("stream single result query", async () => {
-		const surreal = await createSurreal();
-		const stream = surreal.query(`RETURN { foo: "bar" }`).stream();
+    test("stream single result query", async () => {
+        const surreal = await createSurreal();
+        const stream = surreal.query(`RETURN { foo: "bar" }`).stream();
 
-		let valueCount = 0;
-		let doneCount = 0;
-		let errorCount = 0;
+        let valueCount = 0;
+        let doneCount = 0;
+        let errorCount = 0;
 
-		for await (const frame of stream) {
-			if (frame.isValue<{ foo: string }>() && frame.isSingle) {
-				expect(frame.value.foo).toEqual("bar");
-				valueCount++;
-			} else if (frame.isDone()) {
-				doneCount++;
-			} else if (frame.isError()) {
-				errorCount++;
-			}
-		}
+        for await (const frame of stream) {
+            if (frame.isValue<{ foo: string }>() && frame.isSingle) {
+                expect(frame.value.foo).toEqual("bar");
+                valueCount++;
+            } else if (frame.isDone()) {
+                doneCount++;
+            } else if (frame.isError()) {
+                errorCount++;
+            }
+        }
 
-		expect(valueCount).toEqual(1);
-		expect(doneCount).toEqual(1);
-		expect(errorCount).toEqual(0);
-	});
+        expect(valueCount).toEqual(1);
+        expect(doneCount).toEqual(1);
+        expect(errorCount).toEqual(0);
+    });
 
-	test("bound query", async () => {
-		const surreal = await createSurreal();
-		const record = new RecordId("hello", "world");
-		const query = surql`
+    test("bound query", async () => {
+        const surreal = await createSurreal();
+        const record = new RecordId("hello", "world");
+        const query = surql`
 			RETURN ${record}
 		`;
 
-		const [result] = await surreal.query(query).collect<[RecordId]>();
+        const [result] = await surreal.query(query).collect<[RecordId]>();
 
-		expect(result.equals(record)).toBeTrue();
-	});
+        expect(result.equals(record)).toBeTrue();
+    });
 
-	test("inner query", async () => {
-		const surreal = await createSurreal();
-		const record = new RecordId("hello", "world");
-		const { query, bindings } = surreal.query(surql`RETURN ${record}`).inner;
+    test("inner query", async () => {
+        const surreal = await createSurreal();
+        const record = new RecordId("hello", "world");
+        const { query, bindings } = surreal.query(surql`RETURN ${record}`).inner;
 
-		expect(query).toMatchSnapshot(proto("query"));
-		expect(bindings).toMatchSnapshot(proto("bindings"));
-	});
+        expect(query).toMatchSnapshot(proto("query"));
+        expect(bindings).toMatchSnapshot(proto("bindings"));
+    });
 
-	test("pre compiled", async () => {
-		const surreal = await createSurreal();
-		const compiled = surreal
-			.create<Person>(new RecordId("person", 2))
-			.content({
-				firstname: "Mary",
-				lastname: "Doe",
-			})
-			.compile();
+    test("pre compiled", async () => {
+        const surreal = await createSurreal();
+        const compiled = surreal
+            .create<Person>(new RecordId("person", 2))
+            .content({
+                firstname: "Mary",
+                lastname: "Doe",
+            })
+            .compile();
 
-		const [result] = await surreal.query(compiled).collect();
+        const [result] = await surreal.query(compiled).collect();
 
-		expect(result).toMatchObject({
-			firstname: "Mary",
-			lastname: "Doe",
-		});
-	});
+        expect(result).toMatchObject({
+            firstname: "Mary",
+            lastname: "Doe",
+        });
+    });
 
-	test("native dates", async () => {
-		const surreal = await createSurreal({
-			driverOptions: {
-				codecOptions: {
-					useNativeDates: true,
-				},
-			},
-		});
+    test("native dates", async () => {
+        const surreal = await createSurreal({
+            driverOptions: {
+                codecOptions: {
+                    useNativeDates: true,
+                },
+            },
+        });
 
-		const [date] = await surreal
-			.query(`<datetime>"2025-11-20T10:19:31.833294Z"`)
-			.collect<[Date]>();
+        const [date] = await surreal
+            .query(`<datetime>"2025-11-20T10:19:31.833294Z"`)
+            .collect<[Date]>();
 
-		expect(date).toBeValidDate();
-		expect(date.toISOString()).toBe("2025-11-20T10:19:31.833Z");
-	});
+        expect(date).toBeValidDate();
+        expect(date.toISOString()).toBe("2025-11-20T10:19:31.833Z");
+    });
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The behaviour around query result collecting was confusing

## What does this change do?

This PR introduces two changes
- You are no longer required to append `.collect()` when you want to fetch all results
- Added `.responses()` to collect responses instead of results, including failed queries

## What is your testing strategy?

Updated and added tests

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
