### PR TITLE
Circular dependency when working with bundlers

### DIFF
--- a/packages/sdk/build.ts
+++ b/packages/sdk/build.ts
@@ -10,7 +10,24 @@ await bundle.write({ format: "cjs", file: "./dist/surrealdb.cjs" });
 // Server-side bundle (Node/Bun/Deno)
 const serverBundle = await rolldown({
     input: "./src/index.server.ts",
-    external: ["node:util", "surrealdb"],
+    external: ["node:util"],
+    plugins: [
+        {
+            name: "use-base-bundle",
+            resolveId(source) {
+                if (source === "surrealdb") {
+                    // @ts-expect-error: outputOptions is not typed in rolldown's plugin API
+                    const extension = this.outputOptions.format === "esm" ? "mjs" : "cjs";
+                    return {
+                        id: `./surrealdb.${extension}`,
+                        external: true,
+                    };
+                }
+
+                return null;
+            },
+        },
+    ],
 });
 await serverBundle.write({ format: "esm", file: "./dist/surrealdb.server.mjs" });
 await serverBundle.write({ format: "cjs", file: "./dist/surrealdb.server.cjs" });

--- a/packages/sdk/src/value/record-id-range.ts
+++ b/packages/sdk/src/value/record-id-range.ts
@@ -88,13 +88,23 @@ interface RecordIdRangeConstructor {
         beg: Bound<I>,
         end: Bound<I>,
     ): RecordIdRange<T, WidenRecordIdValue<I>>;
+    new <R extends RecordIdRange<string, RecordIdValue>>(
+        table: R["table"]["name"],
+        beg: R["begin"],
+        end: R["end"],
+    ): RecordIdRange<
+        R["table"]["name"],
+        R["begin"] extends Bound<infer I> ? (I extends RecordIdValue ? I : never) : never
+    >;
 }
 
 /**
  * A SurrealQL record ID range value.
  */
-interface _RecordIdRange<Tb extends string = string, Id extends RecordIdValue = RecordIdValue>
-    extends RecordIdRange<Tb, Id> {}
+type _RecordIdRange<
+    Tb extends string = string,
+    Id extends RecordIdValue = RecordIdValue,
+> = RecordIdRange<Tb, Id>;
 const _RecordIdRange = RecordIdRange as RecordIdRangeConstructor;
 
 export { _RecordIdRange as RecordIdRange };

--- a/packages/sdk/src/value/record-id.ts
+++ b/packages/sdk/src/value/record-id.ts
@@ -66,13 +66,19 @@ interface RecordIdConstructor {
         table: T | Table<T>,
         id: I,
     ): RecordId<T, WidenRecordIdValue<I>>;
+    new <R extends RecordId<string, RecordIdValue>>(
+        table: R["table"]["name"],
+        id: R["id"],
+    ): RecordId<R["table"]["name"], R["id"]>;
 }
 
 /**
  * A SurrealQL record ID value.
  */
-interface _RecordId<Tb extends string = string, Id extends RecordIdValue = RecordIdValue>
-    extends RecordId<Tb, Id> {}
+type _RecordId<Tb extends string = string, Id extends RecordIdValue = RecordIdValue> = RecordId<
+    Tb,
+    Id
+>;
 const _RecordId = RecordId as RecordIdConstructor;
 
 export { _RecordId as RecordId };


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently we are trying to export the `base` bundle in the `server` bundle through the package name. This causes a circular dependency when bundlers resolve to the same entrypoint and cache doesn't hit. Noticed while working on a Tanstack Start project where it wasn't possible to import the `surrealdb` package on the server side as it was always resolving to be undefined.

## What does this change do?

Introduce a rolldown plugin to use the correct bundle according to the output format.

## What is your testing strategy?

Verified a tanstack start project works properly when bundles are build with this setup.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
