### PR TITLE
Add RPC protocol v2 support for SurrealDB v3.0.0-beta

### DIFF
--- a/packages/node/src-ts/engine.ts
+++ b/packages/node/src-ts/engine.ts
@@ -97,7 +97,12 @@ export class NodeEngine extends RpcEngine implements SurrealEngine {
         }
 
         const id = this._context.uniqueId();
-        const payload = this._context.codecs.cbor.encode({ id, ...request });
+        const rpcVersion = this._state?.rpcVersion;
+        const payload = this._context.codecs.cbor.encode({
+            id,
+            ...(rpcVersion ? { version: rpcVersion } : {}),
+            ...request,
+        });
 
         const response = await this.#engine.execute(payload);
         const result = this._context.codecs.cbor.decode<Result>(response);

--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -40,6 +40,7 @@ import type {
 import {
     type BoundQuery,
     Features,
+    getRpcProtocolVersion,
     isVersionSupported,
     MAXIMUM_VERSION,
     MINIMUM_VERSION,
@@ -422,6 +423,11 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
             // Perform version check
             if (this.#checkVersion && !isVersionSupported(version)) {
                 throw new UnsupportedVersionError(version, MINIMUM_VERSION, MAXIMUM_VERSION);
+            }
+
+            // Set the RPC protocol version based on the detected SurrealDB version
+            if (this.#state) {
+                this.#state.rpcVersion = getRpcProtocolVersion(version);
             }
 
             // Restore all previous sessions

--- a/packages/sdk/src/engine/http.ts
+++ b/packages/sdk/src/engine/http.ts
@@ -89,9 +89,11 @@ export class HttpEngine extends RpcEngine implements SurrealEngine {
         }
 
         const id = this._context.uniqueId();
+        const rpcVersion = this._state.rpcVersion;
         const buffer = await fetchSurreal(this._context, this._state, session, {
             body: {
                 id,
+                ...(rpcVersion ? { version: rpcVersion } : {}),
                 ...request,
             },
         });

--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -145,8 +145,9 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
             }
 
             const id = this._context.uniqueId();
+            const rpcVersion = this._state?.rpcVersion;
             const call: Call<Result> = {
-                request: { id, ...request },
+                request: { id, ...(rpcVersion ? { version: rpcVersion } : {}), ...request },
                 resolve,
                 reject,
             };

--- a/packages/sdk/src/types/rpc.ts
+++ b/packages/sdk/src/types/rpc.ts
@@ -15,6 +15,13 @@ export type RpcQueryResultErr = {
     result: string;
 };
 
+/**
+ * RPC protocol version to use when communicating with SurrealDB.
+ * - Version 1: Default for SurrealDB v2.x
+ * - Version 2: Required for SurrealDB v3.x (introduces new auth response format, statement options)
+ */
+export type RpcProtocolVersion = 1 | 2;
+
 export type RpcRequest<
     Method extends string = string,
     Params extends unknown[] | undefined = unknown[],
@@ -23,6 +30,11 @@ export type RpcRequest<
     session?: Session;
     params?: Params;
     txn?: Uuid;
+    /**
+     * RPC protocol version. When omitted, defaults to version 1.
+     * Set to 2 for SurrealDB v3.x servers.
+     */
+    version?: RpcProtocolVersion;
 };
 
 export type RpcResponse<Result = unknown> = RpcSuccessResponse<Result> | RpcErrorResponse;

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -7,6 +7,7 @@ import type { Nullable } from "./helpers";
 import type { Prettify } from "./internal";
 import type { LiveMessage } from "./live";
 import type { EventPublisher } from "./publisher";
+import type { RpcProtocolVersion } from "./rpc";
 
 export type Session = Uuid | undefined;
 export type CodecType = "cbor" | "flatbuffer" | (string & {});
@@ -183,6 +184,13 @@ export interface ConnectionState {
     reconnect: ReconnectContext;
     rootSession: ConnectionSession;
     sessions: Map<Uuid, ConnectionSession>;
+    /**
+     * The RPC protocol version to use for this connection.
+     * Set after version detection during connection establishment.
+     * - Version 1: SurrealDB v2.x
+     * - Version 2: SurrealDB v3.x
+     */
+    rpcVersion?: RpcProtocolVersion;
 }
 
 /**

--- a/packages/sdk/src/utils/is-version-supported.ts
+++ b/packages/sdk/src/utils/is-version-supported.ts
@@ -1,5 +1,10 @@
+import type { RpcProtocolVersion } from "../types/rpc";
+
 export const MINIMUM_VERSION = "2.0.0";
 export const MAXIMUM_VERSION = "4.0.0";
+
+/** The minimum SurrealDB version that supports RPC protocol v2 */
+export const RPC_V2_MINIMUM_VERSION = "3.0.0";
 
 /**
  * Returns whether a SurrealDB version is supported by the SDK.
@@ -24,4 +29,22 @@ export function isVersionSupported(
             numeric: true,
         }) === 1
     );
+}
+
+/**
+ * Returns the RPC protocol version to use for a given SurrealDB version.
+ *
+ * @param version The SurrealDB version string
+ * @returns The RPC protocol version to use (1 for v2.x, 2 for v3.x+)
+ */
+export function getRpcProtocolVersion(version: string): RpcProtocolVersion {
+    const trimmed = version.replace(/^surrealdb-/, "").trim();
+
+    // Use RPC v2 for SurrealDB v3.0.0 and above
+    const isV3OrAbove =
+        RPC_V2_MINIMUM_VERSION.localeCompare(trimmed, undefined, {
+            numeric: true,
+        }) <= 0;
+
+    return isV3OrAbove ? 2 : 1;
 }

--- a/packages/tests/unit/utilities/version.test.ts
+++ b/packages/tests/unit/utilities/version.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isVersionSupported } from "surrealdb";
+import { getRpcProtocolVersion, isVersionSupported } from "surrealdb";
 
 describe("isVersionSupported()", () => {
     test("1.0.0 should be unsupported", () => {
@@ -24,5 +24,39 @@ describe("isVersionSupported()", () => {
 
     test("4.0.0 should be unsupported", () => {
         expect(isVersionSupported("4.0.0")).toBe(false);
+    });
+});
+
+describe("getRpcProtocolVersion()", () => {
+    test("2.0.0 should use RPC v1", () => {
+        expect(getRpcProtocolVersion("2.0.0")).toBe(1);
+    });
+
+    test("2.4.0 should use RPC v1", () => {
+        expect(getRpcProtocolVersion("2.4.0")).toBe(1);
+    });
+
+    test("2.99.99 should use RPC v1", () => {
+        expect(getRpcProtocolVersion("2.99.99")).toBe(1);
+    });
+
+    test("3.0.0 should use RPC v2", () => {
+        expect(getRpcProtocolVersion("3.0.0")).toBe(2);
+    });
+
+    test("3.0.0-beta.1 should use RPC v2", () => {
+        expect(getRpcProtocolVersion("3.0.0-beta.1")).toBe(2);
+    });
+
+    test("3.1.0 should use RPC v2", () => {
+        expect(getRpcProtocolVersion("3.1.0")).toBe(2);
+    });
+
+    test("surrealdb-3.0.0 prefix should be handled", () => {
+        expect(getRpcProtocolVersion("surrealdb-3.0.0")).toBe(2);
+    });
+
+    test("surrealdb-2.4.0 prefix should be handled", () => {
+        expect(getRpcProtocolVersion("surrealdb-2.4.0")).toBe(1);
     });
 });

--- a/packages/wasm/src-ts/engine.ts
+++ b/packages/wasm/src-ts/engine.ts
@@ -93,7 +93,12 @@ export class WebAssemblyEngine extends RpcEngine implements SurrealEngine {
         }
 
         const id = this._context.uniqueId();
-        const payload = this._context.codecs.cbor.encode({ id, ...request });
+        const rpcVersion = this._state?.rpcVersion;
+        const payload = this._context.codecs.cbor.encode({
+            id,
+            ...(rpcVersion ? { version: rpcVersion } : {}),
+            ...request,
+        });
 
         const response = await this.#broker.execute(payload);
         return this._context.codecs.cbor.decode<Result>(response);


### PR DESCRIPTION
This update adds support for the new RPC protocol v2 introduced in SurrealDB v3.0.0. The SDK now automatically detects the SurrealDB version and uses the appropriate RPC protocol version:

- RPC v1 for SurrealDB v2.x
- RPC v2 for SurrealDB v3.x and above

Changes:
- Add RpcProtocolVersion type (1 | 2) to RPC types
- Add version field to RpcRequest type
- Add rpcVersion field to ConnectionState for tracking protocol version
- Add getRpcProtocolVersion() utility function for version detection
- Update ConnectionController to set RPC version after connection
- Update WebSocket, HTTP, Node, and WASM engines to include version field in RPC requests when connecting to v3+ servers
- Add unit tests for the new getRpcProtocolVersion function

The RPC v2 protocol includes:
- New auth response format (object with token/refresh properties)
- Statement options for select, insert, create, upsert, update, relate, delete
- Consolidated merge/patch methods into update with mutation options

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Provide information on the motivation for why you have made this change.

## What does this change do?

Provide a description of what this pull request does.

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
