### PR TITLE
Fix number and bigint comparison

### DIFF
--- a/packages/sdk/src/utils/equals.ts
+++ b/packages/sdk/src/utils/equals.ts
@@ -8,6 +8,12 @@ import { Value } from "../value/value";
  * @returns Whether the two values are recursively equal
  */
 export function equals(x: unknown, y: unknown): boolean {
+    if (typeof x === "bigint" && typeof y === "number") {
+        return x <= Number.MAX_SAFE_INTEGER ? Number(x) === y : x === BigInt(y);
+    }
+    if (typeof x === "number" && typeof y === "bigint") {
+        return y <= Number.MAX_SAFE_INTEGER ? x === Number(y) : BigInt(x) === y;
+    }
     if (Object.is(x, y)) return true;
     if (x instanceof Date && y instanceof Date) {
         return x.getTime() === y.getTime();


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently a RecordId created with a BigInt value and one created with a Number value are not considered equal even though their numeric values are the same.

SurrealDB's number data type is dynamic and returns `number` or `bigint` depending on the value.

<img width="1044" height="236" alt="image" src="https://github.com/user-attachments/assets/90755207-1afd-4fea-aaa2-8914935cf8d0" />

## What does this change do?

Update the `equals` util function so that comparing ids with mismatching value types casts the values to fit the other.

## What is your testing strategy?

Tests added.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
