### PR TITLE
Fix non plain object RecordId's id part

### DIFF
--- a/packages/sdk/src/internal/validation.ts
+++ b/packages/sdk/src/internal/validation.ts
@@ -11,10 +11,18 @@ export function isValidIdPart(v: unknown): v is RecordIdValue {
         case "bigint":
             return true;
         case "object":
-            return Array.isArray(v) || v !== null;
+            if (v === null) return false;
+            if (Array.isArray(v)) return true;
+            return isPlainObject(v);
         default:
             return false;
     }
+}
+
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
+    if (v === null || typeof v !== "object") return false;
+    const proto = Object.getPrototypeOf(v);
+    return proto === null || proto === Object.prototype;
 }
 
 export function isValidIdBound(bound: unknown): bound is Bound<RecordIdValue> {

--- a/packages/tests/unit/values/record-id.test.ts
+++ b/packages/tests/unit/values/record-id.test.ts
@@ -1,7 +1,32 @@
 import { describe, expect, test } from "bun:test";
-import { RecordId, Uuid } from "surrealdb";
+import { Decimal, RecordId, Uuid } from "surrealdb";
 
 describe("record ids", () => {
+    test.only("valid id part", () => {
+        expect(() => new RecordId("table", "b")).not.toThrow();
+        expect(() => new RecordId("table", 123)).not.toThrow();
+        expect(() => new RecordId("table", 9223372036854775807n)).not.toThrow();
+        expect(
+            () => new RecordId("table", new Uuid("d2f72714-a387-487a-8eae-451330796ff4")),
+        ).not.toThrow();
+        expect(() => new RecordId("table", ["a", "b", "c"])).not.toThrow();
+        expect(() => new RecordId("table", { a: 1, b: 2, c: 3 })).not.toThrow();
+        // @ts-expect-error
+        expect(() => new RecordId("table", null)).toThrow();
+        // @ts-expect-error
+        expect(() => new RecordId("table", undefined)).toThrow();
+        // @ts-expect-error
+        expect(() => new RecordId("table", new Date())).toThrow();
+        // @ts-expect-error
+        expect(() => new RecordId("table", new Decimal(123))).toThrow();
+        // @ts-expect-error
+        expect(() => new RecordId("table", new Map([["a", 1]]))).toThrow();
+        // @ts-expect-error
+        expect(() => new RecordId("table", new Set([1, 2, 3]))).toThrow();
+        // @ts-expect-error
+        expect(() => new RecordId("table", new Set([new RecordId("table", 1)]))).toThrow();
+    });
+
     test("toString()", () => {
         expect(new RecordId("table", 123).toString()).toBe("table:123");
         expect(new RecordId("table", "123").toString()).toBe("table:⟨123⟩");


### PR DESCRIPTION
- **fix: toSurqlString serializes decimal as number**
- **Fix non plain object RecordId's id part**

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Current validation accepts any kind of objects. Be it Decimal instances, Durations, Maps, Sets, user defined classes, etc, whatever. 

## What does this change do?

Updates RecordId's id part validation to make sure only plain objects are accepted

## What is your testing strategy?

Added tests

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
