### PR TITLE
fix 'await using' test

### DIFF
--- a/packages/tests/integration/sessions.test.ts
+++ b/packages/tests/integration/sessions.test.ts
@@ -125,8 +125,13 @@ describe.if(is3x && SURREAL_PROTOCOL === "ws")("sessions", async () => {
     test("await using", async () => {
         const surreal = await createSurreal();
 
-        await using session = await surreal.forkSession();
-
-        expect(session.isValid).toBeTrue();
+        let session: Awaited<ReturnType<typeof surreal.forkSession>>;
+        {
+            await using s = await surreal.forkSession();
+            expect(s.isValid).toBeTrue();
+            session = s;
+        }
+        // Block exited — disposal has run; session was dropped
+        expect(session.isValid).toBeFalse();
     });
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `await using` test would regularly time out inside the surrealdb repository, where a debug build was used for testing the JavaScript SDK. Looking at the test, it relied on the test ending for the `using` keyword, which was being tested, to come into effect (calling the async dispose symbol). The test by itself was probably flawed, but my suspicion is that that also caused a race condition with an "after test" hook.

## What does this change do?

Ensures that the feature is fully tested *within* the test to prevent any race conditions.

## What is your testing strategy?

^^

## Is this related to any issues?

no

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
