### PR TITLE
Fix RecordId typing on query methods

### DIFF
--- a/packages/sdk/src/api/queryable.ts
+++ b/packages/sdk/src/api/queryable.ts
@@ -148,7 +148,7 @@ export abstract class SurrealQueryable {
      *
      * @param recordId The record ID to select
      */
-    select<T>(recordId: RecordId): SelectPromise<RecordResult<T> | undefined, T>;
+    select<T>(recordId: AnyRecordId): SelectPromise<RecordResult<T> | undefined, T>;
 
     /**
      * Select all records based on the provided Record ID range
@@ -165,7 +165,7 @@ export abstract class SurrealQueryable {
     select<T>(table: Table): SelectPromise<RecordResult<T>[], T>;
 
     // Shadow implementation
-    select(what: RecordId | RecordIdRange | Table): unknown {
+    select(what: AnyRecordId | RecordIdRange | Table): unknown {
         return new SelectPromise(this.#connection, {
             what,
             transaction: this.#transaction,
@@ -179,7 +179,7 @@ export abstract class SurrealQueryable {
      *
      * @param recordId The record id of the record to create
      */
-    create<T>(recordId: RecordId): CreatePromise<RecordResult<T>, T>;
+    create<T>(recordId: AnyRecordId): CreatePromise<RecordResult<T>, T>;
 
     /**
      * Create a new record in the specified table
@@ -189,7 +189,7 @@ export abstract class SurrealQueryable {
     create<T>(table: Table): CreatePromise<RecordResult<T>[], T>;
 
     // Shadow implementation
-    create(what: RecordId | Table): unknown {
+    create(what: AnyRecordId | Table): unknown {
         return new CreatePromise(this.#connection, {
             what,
             transaction: this.#transaction,
@@ -287,7 +287,7 @@ export abstract class SurrealQueryable {
      *
      * @param recordId The record ID to update
      */
-    update<T>(recordId: RecordId): UpdatePromise<RecordResult<T>, T>;
+    update<T>(recordId: AnyRecordId): UpdatePromise<RecordResult<T>, T>;
 
     /**
      * Updates all records based on the provided Record ID range
@@ -304,7 +304,7 @@ export abstract class SurrealQueryable {
     update<T>(table: Table): UpdatePromise<RecordResult<T>[], T>;
 
     // Shadow implementation
-    update(what: RecordId | RecordIdRange | Table): unknown {
+    update(what: AnyRecordId | RecordIdRange | Table): unknown {
         return new UpdatePromise(this.#connection, {
             what,
             transaction: this.#transaction,
@@ -321,7 +321,7 @@ export abstract class SurrealQueryable {
      * @param recordId The record ID to upsert
      * @param data The record data to upsert
      */
-    upsert<T>(recordId: RecordId): UpsertPromise<RecordResult<T>, T>;
+    upsert<T>(recordId: AnyRecordId): UpsertPromise<RecordResult<T>, T>;
 
     /**
      * Upserts all records based on the provided Record ID range
@@ -344,7 +344,7 @@ export abstract class SurrealQueryable {
     upsert<T>(table: Table): UpsertPromise<RecordResult<T>[], T>;
 
     // Shadow implementation
-    upsert(what: RecordId | RecordIdRange | Table): unknown {
+    upsert(what: AnyRecordId | RecordIdRange | Table): unknown {
         return new UpsertPromise(this.#connection, {
             what,
             transaction: this.#transaction,
@@ -358,7 +358,7 @@ export abstract class SurrealQueryable {
      *
      * @param recordId The record ID to delete
      */
-    delete<T>(recordId: RecordId): DeletePromise<RecordResult<T>>;
+    delete<T>(recordId: AnyRecordId): DeletePromise<RecordResult<T>>;
 
     /**
      * Deletes all records based on the provided Record ID range
@@ -375,7 +375,7 @@ export abstract class SurrealQueryable {
     delete<T>(table: Table): DeletePromise<RecordResult<T>[]>;
 
     // Shadow implementation
-    delete(what: RecordId | RecordIdRange | Table): unknown {
+    delete(what: AnyRecordId | RecordIdRange | Table): unknown {
         return new DeletePromise(this.#connection, {
             what,
             output: "before",

--- a/packages/sdk/src/query/create.ts
+++ b/packages/sdk/src/query/create.ts
@@ -2,14 +2,14 @@ import type { ConnectionController } from "../controller";
 import { DispatchedPromise } from "../internal/dispatched-promise";
 import { _only, _output, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
-import type { Mutation, Output, Session, Values } from "../types";
+import type { AnyRecordId, Mutation, Output, Session, Values } from "../types";
 import { type BoundQuery, raw, surql } from "../utils";
 import type { Frame } from "../utils/frame";
-import type { DateTime, Duration, RecordId, Table, Uuid } from "../value";
+import type { DateTime, Duration, Table, Uuid } from "../value";
 import { Query } from "./query";
 
 interface CreateOptions {
-    what: RecordId | Table;
+    what: AnyRecordId | Table;
     mutation?: Mutation;
     data?: unknown;
     output?: Output;

--- a/packages/sdk/src/query/delete.ts
+++ b/packages/sdk/src/query/delete.ts
@@ -2,14 +2,14 @@ import type { ConnectionController } from "../controller";
 import { DispatchedPromise } from "../internal/dispatched-promise";
 import { _only, _output, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
-import type { Output, Session } from "../types";
+import type { AnyRecordId, Output, Session } from "../types";
 import { type BoundQuery, surql } from "../utils";
 import type { Frame } from "../utils/frame";
-import type { DateTime, Duration, RecordId, RecordIdRange, Table, Uuid } from "../value";
+import type { DateTime, Duration, RecordIdRange, Table, Uuid } from "../value";
 import { Query } from "./query";
 
 interface DeleteOptions {
-    what: RecordId | RecordIdRange | Table;
+    what: AnyRecordId | RecordIdRange | Table;
     output?: Output;
     timeout?: Duration;
     version?: DateTime;

--- a/packages/sdk/src/query/select.ts
+++ b/packages/sdk/src/query/select.ts
@@ -2,15 +2,15 @@ import type { ConnectionController } from "../controller";
 import { DispatchedPromise } from "../internal/dispatched-promise";
 import { _only, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
-import type { Expr, ExprLike, Session } from "../types";
+import type { AnyRecordId, Expr, ExprLike, Session } from "../types";
 import type { Field, Selection } from "../types/internal";
 import { type BoundQuery, surql } from "../utils";
 import type { Frame } from "../utils/frame";
-import type { DateTime, Duration, RecordId, RecordIdRange, Table, Uuid } from "../value";
+import type { DateTime, Duration, RecordIdRange, Table, Uuid } from "../value";
 import { Query } from "./query";
 
 interface SelectOptions {
-    what: RecordId | RecordIdRange | Table;
+    what: AnyRecordId | RecordIdRange | Table;
     fields?: string[];
     selection?: Selection;
     start?: number;

--- a/packages/sdk/src/query/update.ts
+++ b/packages/sdk/src/query/update.ts
@@ -2,14 +2,14 @@ import type { ConnectionController } from "../controller";
 import { DispatchedPromise } from "../internal/dispatched-promise";
 import { _only, _output, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
-import type { Expr, ExprLike, Mutation, Output, Session, Values } from "../types";
+import type { AnyRecordId, Expr, ExprLike, Mutation, Output, Session, Values } from "../types";
 import { type BoundQuery, raw, surql } from "../utils";
 import type { Frame } from "../utils/frame";
-import type { Duration, RecordId, RecordIdRange, Table, Uuid } from "../value";
+import type { Duration, RecordIdRange, Table, Uuid } from "../value";
 import { Query } from "./query";
 
 interface UpdateOptions {
-    what: RecordId | RecordIdRange | Table;
+    what: AnyRecordId | RecordIdRange | Table;
     mutation?: Mutation;
     data?: unknown;
     cond?: Expr;

--- a/packages/sdk/src/query/upsert.ts
+++ b/packages/sdk/src/query/upsert.ts
@@ -2,14 +2,14 @@ import type { ConnectionController } from "../controller";
 import { DispatchedPromise } from "../internal/dispatched-promise";
 import { _only, _output, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
-import type { Expr, ExprLike, Mutation, Output, Session, Values } from "../types";
+import type { AnyRecordId, Expr, ExprLike, Mutation, Output, Session, Values } from "../types";
 import { type BoundQuery, raw, surql } from "../utils";
 import type { Frame } from "../utils/frame";
-import type { Duration, RecordId, RecordIdRange, Table, Uuid } from "../value";
+import type { Duration, RecordIdRange, Table, Uuid } from "../value";
 import { Query } from "./query";
 
 interface UpsertOptions {
-    what: RecordId | RecordIdRange | Table;
+    what: AnyRecordId | RecordIdRange | Table;
     mutation?: Mutation;
     data?: unknown;
     cond?: Expr;

--- a/packages/tests/type-tests/values.test.ts
+++ b/packages/tests/type-tests/values.test.ts
@@ -1,11 +1,13 @@
 import { describe, expectTypeOf, test } from "bun:test";
 import {
+    type AnyRecordId,
     type Bound,
     BoundExcluded,
     BoundIncluded,
     RecordId,
     RecordIdRange,
     type RecordIdValue,
+    StringRecordId,
     Uuid,
 } from "surrealdb";
 
@@ -159,5 +161,13 @@ describe("record id range", () => {
         );
         // @ts-expect-error
         new RecordIdRange<"table", string>("table", new BoundIncluded(123), new BoundExcluded(321));
+    });
+});
+
+describe("StringRecordId", () => {
+    test("is accepted as AnyRecordId for select/update/delete", () => {
+        const stringId = new StringRecordId("person:1");
+        expectTypeOf(stringId).toMatchTypeOf<AnyRecordId>();
+        const _acceptsStringRecordId: AnyRecordId = stringId;
     });
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #540

## What does this change do?

Changes the typing from `RecordId` to `AnyRecordId`, to also support `StringRecordId`s

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

Fixes #540 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
