### PR TITLE
fix: add missing ne (!=) operator

### DIFF
--- a/packages/sdk/src/utils/expr.ts
+++ b/packages/sdk/src/utils/expr.ts
@@ -73,6 +73,16 @@ export const eeq = (field: string, v: unknown): Expr => ({
 });
 
 /**
+ * Represents a not equal comparison operation (!=)
+ *
+ * @param field The field name
+ * @param v The value to compare against
+ */
+export const ne = (field: string, v: unknown): Expr => ({
+    toSQL: (ctx) => `${field} != ${ctx.def(v)}`,
+});
+
+/**
  * Represents a greater than comparison operation (>)
  *
  * @param field The field name

--- a/packages/tests/unit/utilities/__snapshots__/expression.test.ts.snap
+++ b/packages/tests/unit/utilities/__snapshots__/expression.test.ts.snap
@@ -8,6 +8,14 @@ exports[`expression equality 2`] = `
 }
 `;
 
+exports[`expression not equality 1`] = `"foo != $bind__1"`;
+
+exports[`expression not equality 2`] = `
+{
+  "bind__1": "bar",
+}
+`;
+
 exports[`expression and 1`] = `"(foo = $bind__1 AND hello = $bind__2 AND alpha = $bind__3)"`;
 
 exports[`expression and 2`] = `

--- a/packages/tests/unit/utilities/expression.test.ts
+++ b/packages/tests/unit/utilities/expression.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { and, between, eq, expr, inside, not, or, raw } from "surrealdb";
+import { and, between, eq, expr, inside, ne, not, or, raw } from "surrealdb";
 import { resetIncrementalID } from "../../../sdk/src/internal/get-incremental-id";
 
 beforeEach(() => {
@@ -16,6 +16,13 @@ describe("expression", () => {
 
     test("equality", () => {
         const json = expr(eq("foo", "bar"));
+
+        expect(json.query).toMatchSnapshot();
+        expect(json.bindings).toMatchSnapshot();
+    });
+
+    test("not equality", () => {
+        const json = expr(ne("foo", "bar"));
 
         expect(json.query).toMatchSnapshot();
         expect(json.bindings).toMatchSnapshot();


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `ne` (`!=`) operator was missing from the SDK, although it is a standard operator in SurrealDB and is already described in the SDK documentation.

## What does this change do?

Adds the `ne` operator function to the expression builder and includes a corresponding unit test.

## What is your testing strategy?

I added a "not equality" test case to `packages/tests/unit/utilities/expression.test.ts` and generated the required snapshots.

## Is this related to any issues?

Fixes #554 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
