### PR TITLE
Add error cause

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,7 +2,7 @@ export * from "./api";
 export * from "./cbor";
 export * from "./engine";
 export * from "./errors";
-export { parseRpcError, type RpcErrorObject } from "./internal/parse-error";
+export { parseRpcError, type RpcErrorCause, type RpcErrorObject } from "./internal/parse-error";
 export * from "./types";
 export * from "./utils";
 export * from "./value";


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The server will soon support a "cause" field on errors, allowing for effectively stack traces.

## What does this change do?

Adds the `cause` field

## What is your testing strategy?

Added tests

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
