### PR TITLE
Return single value for StringRecordId

### DIFF
--- a/packages/sdk/src/internal/internal-expressions.ts
+++ b/packages/sdk/src/internal/internal-expressions.ts
@@ -1,6 +1,6 @@
 import { ExpressionError } from "../errors";
 import type { Expr, Output } from "../types";
-import { Duration, RecordId } from "../value";
+import { Duration, RecordId, StringRecordId } from "../value";
 
 const OUTPUTS: Map<Output, string> = new Map([
     ["null", "null"],
@@ -11,7 +11,10 @@ const OUTPUTS: Map<Output, string> = new Map([
 ]);
 
 export const _only = (value: unknown): Expr => ({
-    toSQL: (ctx) => (value instanceof RecordId ? `ONLY ${ctx.def(value)}` : ctx.def(value)),
+    toSQL: (ctx) =>
+        value instanceof RecordId || value instanceof StringRecordId
+            ? `ONLY ${ctx.def(value)}`
+            : ctx.def(value),
 });
 
 export const _output = (value: Output): Expr => ({

--- a/packages/tests/integration/__helpers__/database.ts
+++ b/packages/tests/integration/__helpers__/database.ts
@@ -1,11 +1,11 @@
-import { RecordId, type Surreal, surql, Table } from "surrealdb";
+import { RecordId, type StringRecordId, type Surreal, surql, Table } from "surrealdb";
 
 export const testTable: Table<"test"> = new Table("test");
 export const personTable: Table<"person"> = new Table("person");
 export const graphTable: Table<"graph"> = new Table("graph");
 
 export interface Person {
-    id: RecordId<"person">;
+    id: RecordId<"person"> | StringRecordId;
     firstname: string;
     lastname: string;
     age?: number;

--- a/packages/tests/integration/query/create.test.ts
+++ b/packages/tests/integration/query/create.test.ts
@@ -1,11 +1,25 @@
 import { describe, expect, test } from "bun:test";
-import { DateTime, Duration, RecordId } from "surrealdb";
+import { DateTime, Duration, RecordId, StringRecordId } from "surrealdb";
 import { createSurreal, type Person, personTable, proto } from "../__helpers__";
 
 describe("create()", async () => {
-    test("single", async () => {
+    test("single (record id)", async () => {
         const surreal = await createSurreal();
         const single = await surreal.create<Person>(new RecordId("person", 1)).content({
+            firstname: "John",
+            lastname: "Doe",
+        });
+
+        expect(single).toStrictEqual({
+            id: new RecordId("person", 1),
+            firstname: "John",
+            lastname: "Doe",
+        });
+    });
+
+    test("single (string record id)", async () => {
+        const surreal = await createSurreal();
+        const single = await surreal.create<Person>(new StringRecordId("person:1")).content({
             firstname: "John",
             lastname: "Doe",
         });

--- a/packages/tests/integration/query/delete.test.ts
+++ b/packages/tests/integration/query/delete.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { DateTime, Duration, RecordId } from "surrealdb";
+import { DateTime, Duration, RecordId, StringRecordId } from "surrealdb";
 import { createSurreal, insertMockRecords, type Person, personTable, proto } from "../__helpers__";
 
 describe("delete()", async () => {
-    test("single", async () => {
+    test("single (record id)", async () => {
         const surreal = await createSurreal();
         await insertMockRecords(surreal);
         const single = await surreal.delete<Person>(new RecordId("person", 1));
+
+        expect(single).toStrictEqual({
+            id: new RecordId("person", 1),
+            firstname: "John",
+            lastname: "Doe",
+        });
+    });
+
+    test("single (string record id)", async () => {
+        const surreal = await createSurreal();
+        await insertMockRecords(surreal);
+        const single = await surreal.delete<Person>(new StringRecordId("person:1"));
 
         expect(single).toStrictEqual({
             id: new RecordId("person", 1),

--- a/packages/tests/integration/query/insert.test.ts
+++ b/packages/tests/integration/query/insert.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, test } from "bun:test";
-import { DateTime, Duration, RecordId } from "surrealdb";
+import { DateTime, Duration, RecordId, StringRecordId } from "surrealdb";
 import { createSurreal, type Person, proto } from "../__helpers__";
 
 describe("insert()", async () => {
-    test("single", async () => {
+    test("single (record id)", async () => {
         const surreal = await createSurreal();
         const [single] = await surreal.insert<Person>({
             id: new RecordId("person", 1),
+            firstname: "John",
+            lastname: "Doe",
+        });
+
+        expect(single).toStrictEqual({
+            id: new RecordId("person", 1),
+            firstname: "John",
+            lastname: "Doe",
+        });
+    });
+
+    test("single (string record id)", async () => {
+        const surreal = await createSurreal();
+        const [single] = await surreal.insert<Person>({
+            id: new StringRecordId("person:1"),
             firstname: "John",
             lastname: "Doe",
         });

--- a/packages/tests/integration/query/select.test.ts
+++ b/packages/tests/integration/query/select.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, test } from "bun:test";
-import { BoundIncluded, DateTime, Duration, eq, RecordId, RecordIdRange } from "surrealdb";
+import {
+    BoundIncluded,
+    DateTime,
+    Duration,
+    eq,
+    RecordId,
+    RecordIdRange,
+    StringRecordId,
+} from "surrealdb";
 import { createSurreal, insertMockRecords, type Person, personTable, proto } from "../__helpers__";
 
 describe("select()", async () => {
-    test("single", async () => {
+    test("single (record id)", async () => {
         const surreal = await createSurreal();
         await insertMockRecords(surreal);
         const single = await surreal.select<Person>(new RecordId("person", 1));
+
+        expect(single).toStrictEqual({
+            id: new RecordId("person", 1),
+            firstname: "John",
+            lastname: "Doe",
+        });
+    });
+
+    test("single (string record id)", async () => {
+        const surreal = await createSurreal();
+        await insertMockRecords(surreal);
+        const single = await surreal.select<Person>(new StringRecordId("person:1"));
 
         expect(single).toStrictEqual({
             id: new RecordId("person", 1),

--- a/packages/tests/integration/query/update.test.ts
+++ b/packages/tests/integration/query/update.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { Duration, eq, RecordId } from "surrealdb";
+import { Duration, eq, RecordId, StringRecordId } from "surrealdb";
 import { createSurreal, insertMockRecords, type Person, proto } from "../__helpers__";
 
 describe("update()", async () => {
-    test("single", async () => {
+    test("single (record id)", async () => {
         const surreal = await createSurreal();
         await insertMockRecords(surreal);
         const single = await surreal.update<Person>(new RecordId("person", 1));
+
+        expect(single).toStrictEqual({
+            id: new RecordId("person", 1),
+            firstname: "John",
+            lastname: "Doe",
+        });
+    });
+
+    test("single (string record id)", async () => {
+        const surreal = await createSurreal();
+        await insertMockRecords(surreal);
+        const single = await surreal.update<Person>(new StringRecordId("person:1"));
 
         expect(single).toStrictEqual({
             id: new RecordId("person", 1),

--- a/packages/tests/integration/query/upsert.test.ts
+++ b/packages/tests/integration/query/upsert.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, test } from "bun:test";
-import { Duration, eq, RecordId } from "surrealdb";
+import { Duration, eq, RecordId, StringRecordId } from "surrealdb";
 import { createSurreal, type Person, proto } from "../__helpers__";
 
 describe("upsert()", async () => {
-    test("single", async () => {
+    test("single (record id)", async () => {
         const surreal = await createSurreal();
         const single = await surreal.upsert(new RecordId("person", 1));
+
+        expect(single).toStrictEqual({
+            id: new RecordId("person", 1),
+        });
+    });
+
+    test("single (string record id)", async () => {
+        const surreal = await createSurreal();
+        const single = await surreal.upsert(new StringRecordId("person:1"));
 
         expect(single).toStrictEqual({
             id: new RecordId("person", 1),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

String record ids return an array instead of a single value, which deviates from the typings

## What does this change do?

Identify string record ids and return a single value response

## What is your testing strategy?

Added tests

## Is this related to any issues?

Fixes #565 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
