### PR TITLE
Prefix imports with OPTION IMPORT

### DIFF
--- a/packages/sdk/src/engine/rpc.ts
+++ b/packages/sdk/src/engine/rpc.ts
@@ -202,7 +202,7 @@ export abstract class RpcEngine implements SurrealProtocol {
         endpoint.pathname = `${basepath}/import`;
 
         await fetchSurreal(this._context, this._state, this._state.rootSession, {
-            body: data,
+            body: typeof data === "string" ? new Blob([data]) : data,
             url: endpoint,
             headers: {
                 Accept: "application/json",

--- a/packages/tests/integration/import.test.ts
+++ b/packages/tests/integration/import.test.ts
@@ -6,18 +6,10 @@ describe("import", async () => {
     test("basic", async () => {
         const surreal = await createSurreal();
 
-        if (!surreal.isFeatureSupported(Features.ExportImportRaw)) {
-            return;
-        }
-
-        await surreal.import(
-            new Blob([
-                /* surql */ `
+        await surreal.import(/* surql */ `
 			OPTION IMPORT;
 			CREATE foo:1 CONTENT { hello: "world" };
-		`,
-            ]),
-        );
+		`);
 
         const [records] = await surreal
             .query(/* surql */ `


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

We are changing the import api to enforce `OPTION IMPORT;` as the first statement.

## What does this change do?

Prefixes import statements with `OPTION IMPORT;`.

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
