### PR TITLE
Fix Linux GNU aarch64 build by removing '-x' build option

### DIFF
--- a/.github/workflows/publish-surreal.yml
+++ b/.github/workflows/publish-surreal.yml
@@ -103,7 +103,7 @@ jobs:
           - name: Linux x86_64 (gnu)
             host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            build: bun run build:node --target x86_64-unknown-linux-gnu -x
+            build: bun run build:node --target x86_64-unknown-linux-gnu
 
           - name: Linux x86_64 (musl)
             host: ubuntu-22.04
@@ -118,7 +118,7 @@ jobs:
           - name: Linux aarch64 (gnu)
             host: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
-            build: bun run build:node --target aarch64-unknown-linux-gnu -x
+            build: bun run build:node --target aarch64-unknown-linux-gnu
 
           - name: Linux aarch64 (musl)
             host: ubuntu-22.04

--- a/.github/workflows/publish-surreal.yml
+++ b/.github/workflows/publish-surreal.yml
@@ -103,7 +103,7 @@ jobs:
           - name: Linux x86_64 (gnu)
             host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: bun run build:node --target x86_64-unknown-linux-gnu -x
+            build: bun run build:node --target x86_64-unknown-linux-gnu
 
           - name: Linux x86_64 (musl)
             host: ubuntu-latest
@@ -118,7 +118,7 @@ jobs:
           - name: Linux aarch64 (gnu)
             host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            build: bun run build:node --target aarch64-unknown-linux-gnu -x
+            build: bun run build:node --target aarch64-unknown-linux-gnu
 
           - name: Linux aarch64 (musl)
             host: ubuntu-latest


### PR DESCRIPTION
## What is the motivation?

The Linux arm64 GNU binary shipped in `@surrealdb/node@3.0.3` (and below) fails to load on most Linux distributions (Arch Linux, Debian, Fedora, Ubuntu) due to a C++ ABI incompatibility introduced by Zig cross-compilation. You can check the test result [here](https://github.com/mdrv/surrealdb.js/actions/runs/23659970047).

```sh
bun add v1.3.11 (af24e281)
Resolving dependencies
Resolved, downloaded and extracted [28]
Saved lockfile

installed @surrealdb/node@3.0.3

396 | 	} catch (err) {
397 | 		if (process.env.NAPI_RS_FORCE_WASI) loadErrors.push(err);
398 | 	}
399 | }
400 | if (!nativeBinding) {
401 | 	if (loadErrors.length > 0) throw new Error("Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.", { cause: loadErrors });
                                            ^
error: Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
      at /tmp/test/node_modules/@surrealdb/node/dist/surrealdb-node.mjs:401:39
      at loadAndEvaluateModule (2:1)

Bun v1.3.11 (Linux arm64)
Error: Process completed with exit code 1.
```

## What does this change do?

Removes the `-x` flag from the `zigbuild` invocation for the Linux GNU targets in `publish-surreal.yml`. Without `-x`, Zig acts purely as a linker without injecting its own C++ runtime overrides, producing a binary that links correctly against the system `libstdc++` on any glibc-based distribution. The MUSL targets are unaffected and unchanged.

## What is your testing strategy?

Tested via [GitHub Actions](https://github.com/mdrv/surrealdb.js/actions/runs/23659970047) covering 4 distros × 2 architectures (x86_64 + arm64) using the fixed package published as `@mdrv/surrealdb-node` vs. `@surrealdb/node`:

| Distro | x86_64 | arm64 |
|---|---|---|
| Ubuntu 24.04 | ✅ | ✅ |
| Debian bookworm | ✅ | ✅ |
| Fedora (latest) | ✅ | ✅ |
| Arch Linux | ✅ | ✅ |
| Alpine (musl) | ✅ | ✅ |

All arm64 runners fail with the upstream package and pass with the fixed build. You can verify independently by installing `@mdrv/surrealdb-node`.

## Is this related to any issues?

- https://github.com/surrealdb/surrealdb.js/issues/575
- https://github.com/surrealdb/surrealdb.js/issues/585

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
