### PR TITLE
Add protocol validation for WebSocket-only features (sessions, transa…

### DIFF
--- a/packages/sdk/src/api/session.ts
+++ b/packages/sdk/src/api/session.ts
@@ -1,4 +1,5 @@
 import type { ConnectionController } from "../controller";
+import { UnsupportedProtocolFeatureError } from "../errors";
 import type {
     AccessRecordAuth,
     AnyAuth,
@@ -8,7 +9,7 @@ import type {
     Token,
     Tokens,
 } from "../types";
-import { Publisher } from "../utils";
+import { Features, Publisher } from "../utils";
 import { SurrealQueryable } from "./queryable";
 import { SurrealTransaction } from "./transaction";
 
@@ -123,9 +124,15 @@ export class SurrealSession extends SurrealQueryable {
      * - variables
      * - authentication state
      *
+     * Note: Sessions require a WebSocket connection (ws:// or wss://). HTTP(S) connections are not supported.
+     *
      * @returns The new session
      */
     async forkSession(): Promise<SurrealSession> {
+        const protocol = this.#connection.state?.url.protocol;
+        if (protocol === "http:" || protocol === "https:") {
+            throw new UnsupportedProtocolFeatureError(Features.Sessions);
+        }
         const created = await this.#connection.createSession(this.#session);
 
         return SurrealSession.of(this, created);
@@ -157,9 +164,15 @@ export class SurrealSession extends SurrealQueryable {
      * multiple queries atomically. When the desired queries have been executed, call `commit()` to apply the changes to the database.
      * If the transaction is no longer needed, call `cancel()` to discard the changes.
      *
+     * Note: Transactions require a WebSocket connection (ws:// or wss://). HTTP(S) connections are not supported.
+     *
      * @returns A new transaction instance
      */
     async beginTransaction(): Promise<SurrealTransaction> {
+        const protocol = this.#connection.state?.url.protocol;
+        if (protocol === "http:" || protocol === "https:") {
+            throw new UnsupportedProtocolFeatureError(Features.Transactions);
+        }
         const transactionId = await this.#connection.begin(this.#session);
         return new SurrealTransaction(this.#connection, this.#session, transactionId);
     }

--- a/packages/sdk/src/api/surreal.ts
+++ b/packages/sdk/src/api/surreal.ts
@@ -1,6 +1,10 @@
 import { CborCodec, FlatBufferCodec, JsonCodec, type Uuid } from "@surrealdb/sqon";
 import { ConnectionController } from "../controller";
-import { UnavailableFeatureError, UnsupportedFeatureError } from "../errors";
+import {
+    UnavailableFeatureError,
+    UnsupportedFeatureError,
+    UnsupportedProtocolFeatureError,
+} from "../errors";
 import type { Feature } from "../internal/feature";
 import { getIncrementalID } from "../internal/get-incremental-id";
 import { parseEndpoint } from "../internal/http";
@@ -13,6 +17,7 @@ import type {
     SqlExportOptions,
     VersionInfo,
 } from "../types";
+import { Features } from "../utils";
 import { Publisher } from "../utils/publisher";
 import { ExportModelPromise, ExportPromise } from "./export";
 import { type SessionEvents, SurrealSession } from "./session";
@@ -201,9 +206,15 @@ export class Surreal extends SurrealSession implements EventPublisher<SurrealEve
     /**
      * Lists all sessions created on the current connection.
      *
+     * Note: Sessions require a WebSocket connection (ws:// or wss://). HTTP(S) connections are not supported.
+     *
      * @returns A list of active session IDs
      */
     sessions(): Promise<Uuid[]> {
+        const protocol = this.#connection.state?.url.protocol;
+        if (protocol === "http:" || protocol === "https:") {
+            throw new UnsupportedProtocolFeatureError(Features.Sessions);
+        }
         return this.#connection.sessions();
     }
 
@@ -216,9 +227,15 @@ export class Surreal extends SurrealSession implements EventPublisher<SurrealEve
      *
      * You can invoke `reset()` on the created session to destroy it, after which it cannot be used again.
      *
+     * Note: Sessions require a WebSocket connection (ws:// or wss://). HTTP(S) connections are not supported.
+     *
      * @returns The new session
      */
     async newSession(): Promise<SurrealSession> {
+        const protocol = this.#connection.state?.url.protocol;
+        if (protocol === "http:" || protocol === "https:") {
+            throw new UnsupportedProtocolFeatureError(Features.Sessions);
+        }
         const created = await this.#connection.createSession(null);
 
         return SurrealSession.of(this, created);

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -644,6 +644,20 @@ export class UnsupportedFeatureError extends SurrealError {
 }
 
 /**
+ * Thrown when a feature is not supported by the current protocol
+ */
+export class UnsupportedProtocolFeatureError extends SurrealError {
+    override name = "UnsupportedProtocolFeatureError";
+
+    readonly feature: Feature;
+
+    constructor(feature: Feature) {
+        super(`The configured engine does not support the feature: ${feature.name}`);
+        this.feature = feature;
+    }
+}
+
+/**
  * Thrown when a feature is not available in the used version of SurrealDB
  */
 export class UnavailableFeatureError extends SurrealError {

--- a/packages/sdk/src/query/live.ts
+++ b/packages/sdk/src/query/live.ts
@@ -1,5 +1,6 @@
 import type { Uuid } from "@surrealdb/sqon";
 import type { ConnectionController } from "../controller";
+import { UnsupportedProtocolFeatureError } from "../errors";
 import { DispatchedPromise } from "../internal/dispatched-promise";
 import type { Expr, ExprLike, LiveResource, Session } from "../types";
 import type { Field, Selection } from "../types/internal";
@@ -102,6 +103,11 @@ export class ManagedLivePromise<T> extends DispatchedPromise<LiveSubscription> {
     protected async dispatch(): Promise<LiveSubscription> {
         await this.#connection.ready();
 
+        const protocol = this.#connection.state?.url.protocol;
+        if (protocol === "http:" || protocol === "https:") {
+            throw new UnsupportedProtocolFeatureError(Features.LiveQueries);
+        }
+
         this.#connection.assertFeature(Features.LiveQueries);
 
         return new ManagedLiveSubscription(
@@ -166,6 +172,11 @@ export class UnmanagedLivePromise extends DispatchedPromise<LiveSubscription> {
 
     protected async dispatch(): Promise<LiveSubscription> {
         await this.#connection.ready();
+
+        const protocol = this.#connection.state?.url.protocol;
+        if (protocol === "http:" || protocol === "https:") {
+            throw new UnsupportedProtocolFeatureError(Features.LiveQueries);
+        }
 
         this.#connection.assertFeature(Features.LiveQueries);
 


### PR DESCRIPTION
…ctions, live queries)

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Throw clear errors when trying to access features unavailable with the current connection protocol

## What does this change do?

Throws errors when code tries to use SDK features available only via WS/WSS when connected over HTTP(S)

## What is your testing strategy?

Tests didn't regress, this is a simple PR.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
