### PR TITLE
fix(spectron): send camelCase query params for document list/chunks

### DIFF
--- a/packages/spectron/src/components/documents.ts
+++ b/packages/spectron/src/components/documents.ts
@@ -184,7 +184,7 @@ export class Documents {
     ): Promise<ChunkPageJson> {
         const q: Record<string, unknown> = {};
         if (options?.page !== undefined) q.page = options.page;
-        if (options?.pageSize !== undefined) q.page_size = options.pageSize;
+        if (options?.pageSize !== undefined) q.pageSize = options.pageSize;
         const body = await this.transport.requestJson(
             "GET",
             `${this.base}/${encodePathSegment(documentId)}/chunks`,
@@ -202,9 +202,9 @@ export class Documents {
     }): Promise<DocumentPageJson> {
         const q: Record<string, unknown> = {};
         if (options?.status !== undefined) q.status = options.status;
-        if (options?.mimeType !== undefined) q.mime_type = options.mimeType;
+        if (options?.mimeType !== undefined) q.mimeType = options.mimeType;
         if (options?.page !== undefined) q.page = options.page;
-        if (options?.pageSize !== undefined) q.page_size = options.pageSize;
+        if (options?.pageSize !== undefined) q.pageSize = options.pageSize;
         const body = await this.transport.requestJson("GET", this.base, { query: q });
         return body as DocumentPageJson;
     }


### PR DESCRIPTION
## What is the motivation?

The `@surrealdb/spectron` alpha.3 OpenAPI **renamed** the document list/chunk query params from snake_case to camelCase:

| | alpha.2 | alpha.3 |
|---|---|---|
| `documents.list` | `mime_type`, `page_size` | **`mimeType`, `pageSize`** |
| `documents.chunks` | `page_size` | **`pageSize`** |

But the SDK's hand-written runtime still emitted the **old snake_case** keys. The transport writes query keys verbatim (`url.searchParams.set(k, …)` in `transport.ts`), so against an alpha.3 server these params no longer matched and were **silently ignored** — pagination fell back to the server's default page size with no error. (`page` was unaffected, being single-word.)

This surfaced while double-checking surrealist's pagination call sites: surrealist passes the SDK's typed camelCase options correctly, so it can't control the wire format — the bug is in the SDK.

## What does this change do?

Renames the three offending query keys in `Documents.list` and `Documents.chunks` (`packages/spectron/src/components/documents.ts`) to match the regenerated alpha.3 OpenAPI:

- `chunks`: `q.page_size` → `q.pageSize`
- `list`: `q.mime_type` → `q.mimeType`, `q.page_size` → `q.pageSize`

## What is your testing strategy?

- Verified the OpenAPI (`src/types/generated.ts`) is the source of truth: `list_documents` declares `mimeType`/`pageSize`, `list_chunks` declares `pageSize` — all camelCase.
- Confirmed the transport sends keys verbatim with no camel↔snake conversion, so the source key is what hits the wire.
- Swept every other component for the same bug class — `traces`(`limit`), `entities`(`type`), `scopes`/`principals`(`path`, `ref`) are single-word; `principals.effective`(`asOf`), `keys`(`ttlSeconds`), and the keyword `list` spread are already correct camelCase and match the OpenAPI. `documents` was the only offender.
- `tsc --noEmit` clean for spectron; package builds, and `dist/spectron.mjs` now emits `q.pageSize`/`q.mimeType` with no snake_case remaining.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)