### PR TITLE
chore(spectron): bump version to 1.0.0-alpha.4

### DIFF
--- a/packages/spectron/package.json
+++ b/packages/spectron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@surrealdb/spectron",
-    "version": "1.0.0-alpha.3",
+    "version": "1.0.0-alpha.4",
     "type": "module",
     "license": "Apache-2.0",
     "description": "The official Spectron client for JavaScript.",


### PR DESCRIPTION
## What is the motivation?

[#624](https://github.com/surrealdb/surrealdb.js/pull/624) fixed the document `list`/`chunks` query params to send camelCase (`mimeType`/`pageSize`) matching the alpha.3 OpenAPI. That behaviour fix needs a published release so consumers (e.g. surrealist) pick it up. This bumps the package version for that release.

## What does this change do?

Bumps `@surrealdb/spectron` from `1.0.0-alpha.3` to `1.0.0-alpha.4` in `packages/spectron/package.json`. No code changes.

## What is your testing strategy?

Version-only change. `scripts/validate-versions.ts` governs only the wasm/node/sdk trio, so spectron's version has no cross-package constraints to satisfy.

## Is this related to any issues?

Follows up [#624](https://github.com/surrealdb/surrealdb.js/pull/624) (the camelCase query-param fix), which merged the fix but not the version bump.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)