### PR TITLE
feat(sdk): make the surql tag generic over its result type

### DIFF
--- a/packages/sdk/src/utils/tagged-template.ts
+++ b/packages/sdk/src/utils/tagged-template.ts
@@ -7,12 +7,19 @@ import { expr } from "./expr";
  * A template literal tag function for creating BoundQuery instances from query strings.
  * Interpolated values are automatically stored as bindings with unique names.
  *
+ * The result type can be specified to type the rows the query returns,
+ * e.g. `surql<[User[]]>` for a query whose first statement yields `User[]`.
+ *
  * @param strings The template string segments
  * @param values The interpolated values
  * @example const query = surql`SELECT * FROM users WHERE name = ${name}`;
+ * @example const query = surql<[User[]]>`SELECT * FROM user`;
  * @returns A BoundQuery instance
  */
-export function surql(strings: TemplateStringsArray, ...values: unknown[]): BoundQuery {
+export function surql<R extends unknown[] = unknown[]>(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+): BoundQuery<R> {
     const bindings: Record<string, unknown> = {};
     let result = "";
 
@@ -36,5 +43,5 @@ export function surql(strings: TemplateStringsArray, ...values: unknown[]): Boun
         }
     }
 
-    return new BoundQuery(result, bindings);
+    return new BoundQuery<R>(result, bindings);
 }

--- a/packages/tests/surrealdb/unit/utilities/tagged-template.test.ts
+++ b/packages/tests/surrealdb/unit/utilities/tagged-template.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, expectTypeOf, test } from "bun:test";
 import { eq, raw, surql, Table } from "surrealdb";
 import { resetIncrementalID } from "../../../../sdk/src/internal/get-incremental-id";
 import { BoundQuery } from "../../../../sdk/src/utils/bound-query";
@@ -72,6 +72,16 @@ describe("Tagged template", () => {
         expect(Object.values(query.bindings)).toContainEqual(new Table("user"));
         expect(Object.values(query.bindings)).toContain("john");
         expect(Object.values(query.bindings)).toContain(10);
+    });
+
+    test("result type defaults to unknown[]", () => {
+        const query = surql`SELECT * FROM user`;
+        expectTypeOf(query).toEqualTypeOf<BoundQuery<unknown[]>>();
+    });
+
+    test("result type can be specified via type argument", () => {
+        const query = surql<[{ name: string }[]]>`SELECT * FROM user`;
+        expectTypeOf(query).toEqualTypeOf<BoundQuery<[{ name: string }[]]>>();
     });
 
     test("query with binding conflict throws", () => {


### PR DESCRIPTION
## Problem

` surql`` ` returns `BoundQuery`, whose row type already defaults to `BoundQuery<unknown[]>` — but the tag function itself isn't generic, so there's no way for a caller to type the rows a query yields. You have to fall back to casting the result downstream.

## Change

Surface the existing `BoundQuery<R>` type parameter on the `surql` tag:

```ts
export function surql<R extends unknown[] = unknown[]>(
    strings: TemplateStringsArray,
    ...values: unknown[]
): BoundQuery<R>
```

So you can now write:

```ts
const q = surql<[User[]]>`SELECT * FROM user`;
//    ^? BoundQuery<[User[]]>
```

- `R` defaults to `unknown[]`, so **every existing call site is unchanged** (still infers `BoundQuery<unknown[]>`).
- The parameter is purely phantom — no runtime behavior changes; it just threads through to the constructed `BoundQuery<R>`.

## Testing

- Added two `expectTypeOf` cases to `tagged-template.test.ts`: the default `unknown[]` inference and explicit `surql<[…]>` annotation.
- `bun test` for the tagged-template suite — 10 pass / 0 fail.
- `tsc --noEmit` — no new type errors vs. baseline (verified by diffing the error set before/after the change).
- `biome check` — clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)