### PR TITLE
ci: use ubuntu-latest and remove disabled build-wasm job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,6 +136,65 @@ jobs:
           retention-days: 1
           path: packages/spectron/dist/
 
+  # build-wasm:
+  #   name: Build WASM
+  #   needs: build-sdk
+  #   runs-on: runner-amd64-2xlarge
+  #   steps:
+  #     - name: Install Bun
+  #       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+  #       with:
+  #         bun-version: 1.2.21
+
+  #     - name: Code Checkout
+  #       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+  #     - name: Install Rust
+  #       uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+  #       with:
+  #         toolchain: stable
+  #         targets: wasm32-unknown-unknown
+
+  #     - name: Cache Rust
+  #       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+  #       with:
+  #         shared-key: wasm
+  #         workspaces: packages/wasm
+
+  #     - name: Install wasm-bindgen-cli
+  #       run: command -v wasm-bindgen && wasm-bindgen --version | grep -q 0.2.108 || cargo install -f wasm-bindgen-cli --version 0.2.108
+
+  #     - name: Install wasm-opt
+  #       run: command -v wasm-opt || cargo install wasm-opt
+
+  #     - name: Cache turbo
+  #       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+  #       with:
+  #         path: .turbo/cache
+  #         key: turbo-wasm-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('packages/wasm/src-rust/**', 'packages/wasm/src-ts/**', 'packages/wasm/Cargo.toml') }}
+  #         restore-keys: turbo-wasm-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
+
+  #     - name: Install dependencies
+  #       run: bun ci
+
+  #     - name: Download SDK build
+  #       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+  #       with:
+  #         name: sdk-build
+  #         path: packages/sdk/dist/
+
+  #     - name: Build WASM
+  #       run: bun run build:wasm
+
+  #     - name: Upload WASM artifacts
+  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+  #       with:
+  #         name: wasm-build
+  #         retention-days: 30
+  #         path: |
+  #           packages/wasm/dist/
+  #           packages/wasm/wasm/
+
   build-node:
     name: Build Node
     needs: build-sdk

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,69 +136,10 @@ jobs:
           retention-days: 1
           path: packages/spectron/dist/
 
-  # build-wasm:
-  #   name: Build WASM
-  #   needs: build-sdk
-  #   runs-on: runner-amd64-2xlarge
-  #   steps:
-  #     - name: Install Bun
-  #       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-  #       with:
-  #         bun-version: 1.2.21
-
-  #     - name: Code Checkout
-  #       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-  #     - name: Install Rust
-  #       uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-  #       with:
-  #         toolchain: stable
-  #         targets: wasm32-unknown-unknown
-
-  #     - name: Cache Rust
-  #       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-  #       with:
-  #         shared-key: wasm
-  #         workspaces: packages/wasm
-
-  #     - name: Install wasm-bindgen-cli
-  #       run: command -v wasm-bindgen && wasm-bindgen --version | grep -q 0.2.108 || cargo install -f wasm-bindgen-cli --version 0.2.108
-
-  #     - name: Install wasm-opt
-  #       run: command -v wasm-opt || cargo install wasm-opt
-
-  #     - name: Cache turbo
-  #       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-  #       with:
-  #         path: .turbo/cache
-  #         key: turbo-wasm-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('packages/wasm/src-rust/**', 'packages/wasm/src-ts/**', 'packages/wasm/Cargo.toml') }}
-  #         restore-keys: turbo-wasm-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
-
-  #     - name: Install dependencies
-  #       run: bun ci
-
-  #     - name: Download SDK build
-  #       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-  #       with:
-  #         name: sdk-build
-  #         path: packages/sdk/dist/
-
-  #     - name: Build WASM
-  #       run: bun run build:wasm
-
-  #     - name: Upload WASM artifacts
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-  #       with:
-  #         name: wasm-build
-  #         retention-days: 30
-  #         path: |
-  #           packages/wasm/dist/
-  #           packages/wasm/wasm/
-
   build-node:
     name: Build Node
     needs: build-sdk
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/publish-surreal.yml
+++ b/.github/workflows/publish-surreal.yml
@@ -101,12 +101,12 @@ jobs:
             target: x86_64-pc-windows-msvc
 
           - name: Linux x86_64 (gnu)
-            host: ubuntu-22.04
+            host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             build: bun run build:node --target x86_64-unknown-linux-gnu -x
 
           - name: Linux x86_64 (musl)
-            host: ubuntu-22.04
+            host: ubuntu-latest
             target: x86_64-unknown-linux-musl
             build: bun run build:node --target x86_64-unknown-linux-musl -x
 
@@ -116,12 +116,12 @@ jobs:
             build: bun run build:node --target aarch64-apple-darwin
 
           - name: Linux aarch64 (gnu)
-            host: ubuntu-22.04
+            host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             build: bun run build:node --target aarch64-unknown-linux-gnu -x
 
           - name: Linux aarch64 (musl)
-            host: ubuntu-22.04
+            host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             build: bun run build:node --target aarch64-unknown-linux-musl -x
 


### PR DESCRIPTION
## What changed

- Switched all `ubuntu-22.04` runners to `ubuntu-latest`:
  - `build-node` job in `.github/workflows/check.yml`
  - Four matrix hosts in `.github/workflows/publish-surreal.yml` (Linux x86_64/aarch64, gnu + musl)
- Removed the commented-out `build-wasm` job from `.github/workflows/check.yml`, along with its unused `runner-amd64-2xlarge` custom (self-hosted) runner reference.

## Why

The repo no longer uses any custom/self-hosted runners — the only reference (`runner-amd64-2xlarge`) was in a disabled, commented-out job, so it's dead weight. Standardizing on `ubuntu-latest` removes pinned OS versions so jobs track the current GitHub-hosted image.

## Reviewer notes

- All jobs now run exclusively on `ubuntu-latest`, `macos-latest`, or `windows-latest` (standard GitHub-hosted runners).
- The `ubuntu-22.04` pins were on the Linux native-module builds, which cross-compile via `cargo-zigbuild` — zig controls the glibc target independently of the runner OS, so bumping to 24.04 (what `ubuntu-latest` currently tracks) should not change the produced binaries. Worth a sanity check on the publish workflow if you want to be cautious.