### PR TITLE
Duration compare

### DIFF
--- a/packages/sqon/src/value/duration.ts
+++ b/packages/sqon/src/value/duration.ts
@@ -188,6 +188,20 @@ export class Duration extends Value {
     }
 
     /**
+     * Compare this duration with another
+     *
+     * @param other The duration to compare with
+     * @returns -1 if this is shorter, 0 if equal, 1 if this is longer
+     */
+    compare(other: Duration): number {
+        if (this.#seconds < other.#seconds) return -1
+        if (this.#seconds > other.#seconds) return 1
+        if (this.#nanoseconds < other.#nanoseconds) return -1
+        if (this.#nanoseconds > other.#nanoseconds) return 1
+        return 0
+    }
+
+    /**
      * Adds two durations together
      *
      * @param other The duration to add

--- a/packages/sqon/src/value/duration.ts
+++ b/packages/sqon/src/value/duration.ts
@@ -194,11 +194,11 @@ export class Duration extends Value {
      * @returns -1 if this is shorter, 0 if equal, 1 if this is longer
      */
     compare(other: Duration): number {
-        if (this.#seconds < other.#seconds) return -1
-        if (this.#seconds > other.#seconds) return 1
-        if (this.#nanoseconds < other.#nanoseconds) return -1
-        if (this.#nanoseconds > other.#nanoseconds) return 1
-        return 0
+        if (this.#seconds < other.#seconds) return -1;
+        if (this.#seconds > other.#seconds) return 1;
+        if (this.#nanoseconds < other.#nanoseconds) return -1;
+        if (this.#nanoseconds > other.#nanoseconds) return 1;
+        return 0;
     }
 
     /**

--- a/packages/tests/surrealdb/unit/sqon/values/duration.test.ts
+++ b/packages/tests/surrealdb/unit/sqon/values/duration.test.ts
@@ -69,6 +69,12 @@ describe("Duration", () => {
         expect(new Duration("1s").equals(new Duration("1s500ms"))).toBe(false);
     });
 
+    test("compare", () => {
+        expect(new Duration("1ms").compare(new Duration("2ms"))).toBe(-1);
+        expect(new Duration("3y").compare(new Duration("2s"))).toBe(1);
+        expect(new Duration("24h").compare(new Duration("1d"))).toBe(0);
+    });
+
     test("add", () => {
         const a = new Duration("1s");
         const b = new Duration("500ms");


### PR DESCRIPTION
## What is the motivation?

I needed a way to compare durations and this seems cleaner than converting them to native JS class and compare them.

## What does this change do?

It just add a `compare` method on Duration class, the same way as it works for DateTime.

## What is your testing strategy?

There's a few comparison in `duration.test.js:72`.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
