### PR TITLE
Fixed DateTime comparison jsdoc

### DIFF
--- a/packages/sqon/src/value/datetime.ts
+++ b/packages/sqon/src/value/datetime.ts
@@ -270,7 +270,7 @@ export class DateTime extends Value {
      * Compares this DateTime with another
      *
      * @param other The DateTime to compare with
-     * @returns -1 if other is before, 0 if equal, 1 if other is after
+     * @returns -1 if other is after, 0 if equal, 1 if other is before
      */
     compare(other: DateTime): number {
         const a = this.nanoseconds;


### PR DESCRIPTION
## What is the motivation?

I spend a few minutes understanding why my function wasn't working, the problem was from the JSDoc not matching the implementation.

## What does this change do?

A simple fix of the JSDoc for the `compare` method of the DateTime, nothing changed in the function execution.

## What is your testing strategy?

The function was already working, the only problem was the JSDoc that had swapped "before" and "after".

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)