### PR TITLE
Add expiry margin setting

### DIFF
--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -118,7 +118,7 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
         this.#authProvider = options.authentication;
         this.#skipRenewal = options.invalidateOnExpiry ?? false;
         this.#checkVersion = options.versionCheck ?? true;
-        this.#expiryMargin = options.expiryMargin ?? 10;
+        this.#expiryMargin = options.expiryMargin ?? 60;
         this.#state = {
             url,
             sessions: new Map(),

--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -547,13 +547,17 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
         if (!payload || !payload.exp) return;
 
         const now = Math.floor(Date.now() / 1000);
-        const delay = Math.max(payload.exp - now - this.#expiryMargin, this.#expiryMargin) * 1000;
+        const remaining = Math.max(payload.exp - now, 0);
+        const delay = Math.min(
+            remaining,
+            Math.max(remaining - this.#expiryMargin, this.#expiryMargin),
+        );
 
         sessionState.authRenewal = setTimeout(() => {
             this.#applyAuthentication(session).catch((err) => {
                 this.#eventPublisher.publish("error", new AuthenticationError(err));
             });
-        }, delay);
+        }, delay * 1000);
     }
 
     async #abortAuthentication(session: Session): Promise<void> {
@@ -581,12 +585,13 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
 
             if (payload?.exp) {
                 const now = Math.floor(Date.now() / 1000);
-                const minimum = Math.max(
-                    payload.exp - now - this.#expiryMargin,
-                    this.#expiryMargin,
+                const remaining = Math.max(payload.exp - now, 0);
+                const renewalDelay = Math.min(
+                    remaining,
+                    Math.max(remaining - this.#expiryMargin, this.#expiryMargin),
                 );
 
-                if (payload.exp - now > minimum) {
+                if (remaining > renewalDelay) {
                     try {
                         await this.authenticate(sessionState.accessToken, session, true);
                         return;

--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -66,7 +66,7 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
     #status: ConnectionStatus = "disconnected";
     #authProvider: AuthProvider | undefined;
     #cachedVersion: string | undefined;
-    #expiryMargin: number = 10;
+    #expiryMargin: number = 60;
     #skipRenewal: boolean = false;
     #checkVersion: boolean = false;
 

--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -66,9 +66,9 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
     #status: ConnectionStatus = "disconnected";
     #authProvider: AuthProvider | undefined;
     #cachedVersion: string | undefined;
-
-    #skipRenewal = false;
-    #checkVersion = false;
+    #expiryMargin: number = 10;
+    #skipRenewal: boolean = false;
+    #checkVersion: boolean = false;
 
     subscribe<K extends keyof ConnectionEvents>(
         event: K,
@@ -118,6 +118,7 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
         this.#authProvider = options.authentication;
         this.#skipRenewal = options.invalidateOnExpiry ?? false;
         this.#checkVersion = options.versionCheck ?? true;
+        this.#expiryMargin = options.expiryMargin ?? 10;
         this.#state = {
             url,
             sessions: new Map(),
@@ -545,9 +546,8 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
 
         if (!payload || !payload.exp) return;
 
-        // Renew 60 seconds before expiry
         const now = Math.floor(Date.now() / 1000);
-        const delay = Math.max((payload.exp - now - 60) * 1000, 0);
+        const delay = Math.max(payload.exp - now - this.#expiryMargin, this.#expiryMargin) * 1000;
 
         sessionState.authRenewal = setTimeout(() => {
             this.#applyAuthentication(session).catch((err) => {
@@ -581,9 +581,12 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
 
             if (payload?.exp) {
                 const now = Math.floor(Date.now() / 1000);
-                const isValid = payload.exp - now > 60;
+                const minimum = Math.max(
+                    payload.exp - now - this.#expiryMargin,
+                    this.#expiryMargin,
+                );
 
-                if (isValid) {
+                if (payload.exp - now > minimum) {
                     try {
                         await this.authenticate(sessionState.accessToken, session, true);
                         return;

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -154,7 +154,7 @@ export interface ConnectOptions {
      * The amount of time in seconds before the expected expiry of the session token to attempt
      * a renewal or invalidation of the session.
      *
-     * @default 10
+     * @default 60
      */
     expiryMargin?: number;
     /**

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -151,6 +151,13 @@ export interface ConnectOptions {
      */
     invalidateOnExpiry?: boolean;
     /**
+     * The amount of time in seconds before the expected expiry of the session token to attempt
+     * a renewal or invalidation of the session.
+     *
+     * @default 10
+     */
+    expiryMargin?: number;
+    /**
      * Configure reconnect behavior for supported engines (WebSocket).
      *
      * - When set to `false`, the driver will remain disconnected after a connection is lost.

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -152,7 +152,8 @@ export interface ConnectOptions {
     invalidateOnExpiry?: boolean;
     /**
      * The amount of time in seconds before the expected expiry of the session token to attempt
-     * a renewal or invalidation of the session.
+     * a renewal or invalidation of the session. When the session duration is shorter than the
+     * expiry margin, the margin is skipped and the token expiry is used as the delay.
      *
      * @default 60
      */

--- a/packages/tests/surrealdb/integration/authentication.test.ts
+++ b/packages/tests/surrealdb/integration/authentication.test.ts
@@ -129,24 +129,48 @@ describe.skipIf(!isRemote)("record auth", async () => {
 });
 
 describe.skipIf(!isRemote)("session renewal", async () => {
+    beforeEach(async () => {
+        const surreal = await createSurreal();
+
+        if (is3x) {
+            await surreal.query(/* surql */ `
+                DEFINE USER IF NOT EXISTS renewal_test ON ROOT PASSWORD 'test' ROLES OWNER DURATION FOR TOKEN 2s;
+                DEFINE ACCESS IF NOT EXISTS renewal_user ON DATABASE TYPE RECORD
+                    SIGNUP ( CREATE type::record('user', $id) )
+                    SIGNIN ( SELECT * FROM type::record('user', $id) )
+                    DURATION FOR TOKEN 2s;
+            `);
+        } else {
+            await surreal.query(/* surql */ `
+                DEFINE USER IF NOT EXISTS renewal_test ON ROOT PASSWORD 'test' ROLES OWNER DURATION FOR TOKEN 2s;
+                DEFINE ACCESS IF NOT EXISTS renewal_user ON DATABASE TYPE RECORD
+                    SIGNUP ( CREATE type::thing('user', $id) )
+                    SIGNIN ( SELECT * FROM type::thing('user', $id) )
+                    DURATION FOR TOKEN 2s;
+            `);
+        }
+
+        await surreal.close();
+    });
+
     test("basic", async () => {
         const { connect } = await createIdleSurreal({
             auth: "none",
         });
 
         const authentication = mock(() => ({
-            username: "test",
+            username: "renewal_test",
             password: "test",
         }));
 
         await connect({
             authentication,
+            expiryMargin: 1,
         });
 
-        // Wait at least 1s for token to renew
+        // 2s token with 1s expiry margin schedules renewal after 1s
         await Bun.sleep(1500);
 
-        // Should be called twice in this timeframe
         expect(authentication).toBeCalledTimes(2);
     });
 
@@ -161,17 +185,17 @@ describe.skipIf(!isRemote)("session renewal", async () => {
 
         await connect({
             invalidateOnExpiry: true,
+            expiryMargin: 1,
         });
 
         await surreal.signup({
-            access: "user",
+            access: "renewal_user",
             variables: { id: 456 },
         });
 
-        // Wait at least 1s for token to renew
+        // 2s token with 1s expiry margin schedules invalidation after 1s
         await Bun.sleep(1500);
 
-        // One authentication, one renewal
         expect(handleAuth).toBeCalledTimes(2);
     });
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The SDK currently schedules token renewal (or invalidation) 60 seconds before the time defined in the `exp` field of the session token. This is not always suitable for use cases where very short session expiries are desired, as it causes the renewal to occur instantly.

## What does this change do?

This PR implements two changes

- **A new `expiryMargin` setting** used to control the amount of seconds before expiry the SDK will attempt renewal
- **A minimum renewal delay** which always waits for at least the time left in `exp`, while adding the `expiryMargin` only when the duration is long enough

## What is your testing strategy?

Existing tests

## Is this related to any issues?

Closes #618

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
