### PR TITLE
Fix reconnect options

### DIFF
--- a/packages/sdk/src/internal/reconnect.ts
+++ b/packages/sdk/src/internal/reconnect.ts
@@ -18,16 +18,12 @@ export class ReconnectContext {
 
     // Process options as passed by the user
     constructor(input: undefined | Partial<ReconnectOptions> | boolean) {
-        if (!input) {
-            this.options = DEFAULT_RECONNECT_OPTIONS;
-        } else if (input === true) {
-            this.options = DEFAULT_RECONNECT_OPTIONS;
-        } else {
-            this.options = {
-                ...DEFAULT_RECONNECT_OPTIONS,
-                ...input,
-            };
-        }
+        const override = typeof input === "boolean" ? { enabled: input } : input;
+
+        this.options = {
+            ...DEFAULT_RECONNECT_OPTIONS,
+            ...override,
+        };
     }
 
     get attempts(): number {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Passing `false` to reconnect options does not disable reconnecting due to incorrect parsing logic

## What does this change do?

Correctly respect the provided value

## What is your testing strategy?

Existing tests

## Is this related to any issues?

Closes #629

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
