### PR TITLE
Disable request timeout for multipart requests

### DIFF
--- a/packages/spectron/src/transport.ts
+++ b/packages/spectron/src/transport.ts
@@ -121,7 +121,6 @@ export class Transport {
     ): Promise<unknown | null> {
         const methodUpper = method.toUpperCase();
         const url = buildUrl(this.endpoint, path, init?.query);
-        const timeoutMs = init?.timeoutMs ?? this.timeoutMs;
         const schedule = backoffSchedule(this.maxRetries);
 
         const headerObj = this.baseHeaders("application/json");
@@ -129,8 +128,10 @@ export class Transport {
         let body: BodyInit | undefined;
         let serialisedBody = "";
         const bodyInput = init?.body;
+		const isMultipart = bodyInput instanceof FormData;
+
         if (bodyInput !== undefined) {
-            if (bodyInput instanceof FormData) {
+            if (isMultipart) {
                 body = bodyInput;
             } else {
                 serialisedBody = JSON.stringify(bodyInput);
@@ -138,6 +139,13 @@ export class Transport {
                 headerObj["Content-Type"] = "application/json";
             }
         }
+
+        // Multipart uploads can legitimately stream large bodies for longer than
+        // the default request timeout, so the fixed deadline is not applied to
+        // them, only an explicit per-request `timeoutMs` bounds a multipart send.
+        const timeoutMs = isMultipart
+            ? (init?.timeoutMs ?? 0)
+            : (init?.timeoutMs ?? this.timeoutMs);
 
         // Idempotent writes carry a key so retries within a 30s window collapse
         // to a single server-side effect.
@@ -148,8 +156,9 @@ export class Transport {
         let attempt = 0;
         for (;;) {
             const controller = new AbortController();
-            const timer = setTimeout(() => controller.abort(), timeoutMs);
-            const headersForFetch: HeadersInit = { ...headerObj };
+            const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+			const headersForFetch: HeadersInit = { ...headerObj };
+
             if (body instanceof FormData) {
                 delete (headersForFetch as Record<string, string>)["Content-Type"];
             }
@@ -160,7 +169,8 @@ export class Transport {
                     headers: headersForFetch,
                     body: methodUpper === "GET" || methodUpper === "HEAD" ? undefined : body,
                     signal: controller.signal,
-                });
+				});
+
                 clearTimeout(timer);
 
                 if (

--- a/packages/spectron/src/transport.ts
+++ b/packages/spectron/src/transport.ts
@@ -128,7 +128,7 @@ export class Transport {
         let body: BodyInit | undefined;
         let serialisedBody = "";
         const bodyInput = init?.body;
-		const isMultipart = bodyInput instanceof FormData;
+        const isMultipart = bodyInput instanceof FormData;
 
         if (bodyInput !== undefined) {
             if (isMultipart) {
@@ -156,8 +156,9 @@ export class Transport {
         let attempt = 0;
         for (;;) {
             const controller = new AbortController();
-            const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
-			const headersForFetch: HeadersInit = { ...headerObj };
+            const timer =
+                timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+            const headersForFetch: HeadersInit = { ...headerObj };
 
             if (body instanceof FormData) {
                 delete (headersForFetch as Record<string, string>)["Content-Type"];
@@ -169,7 +170,7 @@ export class Transport {
                     headers: headersForFetch,
                     body: methodUpper === "GET" || methodUpper === "HEAD" ? undefined : body,
                     signal: controller.signal,
-				});
+                });
 
                 clearTimeout(timer);
 

--- a/packages/tests/spectron/unit/transport.test.ts
+++ b/packages/tests/spectron/unit/transport.test.ts
@@ -84,4 +84,66 @@ describe("Transport", () => {
         });
         await expect(t.requestJson("GET", "/y")).rejects.toBeInstanceOf(ConnectionError);
     });
+
+    // A fetch impl that resolves after `delayMs`, or rejects with an AbortError
+    // as soon as its signal fires — mimicking a slow upload against the timeout.
+    const slowFetch = (delayMs: number) =>
+        mock((_url: string | URL, init?: RequestInit) => {
+            return new Promise<Response>((resolve, reject) => {
+                const signal = init?.signal;
+                const timer = setTimeout(() => {
+                    resolve(
+                        new Response(JSON.stringify({ ok: true }), {
+                            status: 200,
+                            headers: { "Content-Type": "application/json" },
+                        }),
+                    );
+                }, delayMs);
+                signal?.addEventListener("abort", () => {
+                    clearTimeout(timer);
+                    reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+                });
+            });
+        });
+
+    test("multipart requests are not aborted by the default timeout", async () => {
+        const t = new Transport({
+            apiKey: "k",
+            endpoint: "https://example.test",
+            timeoutMs: 5,
+            maxRetries: 0,
+            fetchImpl: slowFetch(30) as unknown as typeof fetch,
+        });
+        const form = new FormData();
+        form.append("file", new Blob(["data"]), "f.bin");
+        const body = await t.requestJson("POST", "/documents", { body: form });
+        expect(body).toEqual({ ok: true });
+    });
+
+    test("multipart requests still honor an explicit per-request timeout", async () => {
+        const t = new Transport({
+            apiKey: "k",
+            endpoint: "https://example.test",
+            maxRetries: 0,
+            fetchImpl: slowFetch(30) as unknown as typeof fetch,
+        });
+        const form = new FormData();
+        form.append("file", new Blob(["data"]), "f.bin");
+        await expect(
+            t.requestJson("POST", "/documents", { body: form, timeoutMs: 5 }),
+        ).rejects.toBeInstanceOf(ConnectionError);
+    });
+
+    test("JSON requests are still aborted by the default timeout", async () => {
+        const t = new Transport({
+            apiKey: "k",
+            endpoint: "https://example.test",
+            timeoutMs: 5,
+            maxRetries: 0,
+            fetchImpl: slowFetch(30) as unknown as typeof fetch,
+        });
+        await expect(t.requestJson("POST", "/x", { body: { a: 1 } })).rejects.toBeInstanceOf(
+            ConnectionError,
+        );
+    });
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

File uploads result in a forced 30s timeout

## What does this change do?

Disable any timeout for multipart requests

## What is your testing strategy?

Added test

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
