### PR TITLE
chore(spectron): bump version to 1.0.0-alpha.5

### DIFF
--- a/packages/spectron/package.json
+++ b/packages/spectron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@surrealdb/spectron",
-    "version": "1.0.0-alpha.4",
+    "version": "1.0.0-alpha.5",
     "type": "module",
     "license": "Apache-2.0",
     "description": "The official Spectron client for JavaScript.",


### PR DESCRIPTION
Bumps `@surrealdb/spectron` from `1.0.0-alpha.4` to `1.0.0-alpha.5`.

This releases the multipart request timeout fix from #639, where large multipart uploads were being aborted by the default 30-second request timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)