### PR TITLE
Guard SharedArrayBuffer reference in Uuid constructor

### DIFF
--- a/packages/sqon/src/value/uuid.ts
+++ b/packages/sqon/src/value/uuid.ts
@@ -3,6 +3,12 @@ import { JsonCodec } from "../codec/json/codec.ts";
 import { hasSymbol, markSymbol, UUID_SYMBOL } from "../utils/symbols.ts";
 import { Value } from "./value.ts";
 
+// SharedArrayBuffer is only exposed on cross-origin-isolated pages, so
+// referencing it directly throws a ReferenceError everywhere else.
+function isSharedArrayBuffer(value: unknown): value is SharedArrayBuffer {
+    return typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer;
+}
+
 /**
  * A SurrealQL UUID value.
  */
@@ -38,7 +44,7 @@ export class Uuid extends Value {
     constructor(uuid: Uuid | UUID | string | ArrayBufferLike | Uint8Array) {
         super();
 
-        if (uuid instanceof ArrayBuffer || uuid instanceof SharedArrayBuffer) {
+        if (uuid instanceof ArrayBuffer || isSharedArrayBuffer(uuid)) {
             this.#inner = UUID.ofInner(new Uint8Array(uuid));
         } else if (uuid instanceof Uint8Array) {
             this.#inner = UUID.ofInner(uuid);

--- a/packages/tests/surrealdb/unit/sqon/values/uuid.test.ts
+++ b/packages/tests/surrealdb/unit/sqon/values/uuid.test.ts
@@ -54,6 +54,21 @@ describe("Uuid", () => {
         );
     });
 
+    test("construct when SharedArrayBuffer is undefined", () => {
+        // Non-cross-origin-isolated pages have no SharedArrayBuffer global, so
+        // referencing it unguarded threw ReferenceError on every construction.
+        const globals = globalThis as { SharedArrayBuffer?: unknown };
+        const saved = globals.SharedArrayBuffer;
+        delete globals.SharedArrayBuffer;
+
+        try {
+            expect(new Uuid(EXAMPLE).toString()).toBe(EXAMPLE);
+            expect(Uuid.v4()).toBeInstanceOf(Uuid);
+        } finally {
+            globals.SharedArrayBuffer = saved;
+        }
+    });
+
     test("toUint8Array returns 16 bytes", () => {
         const uuid = new Uuid(EXAMPLE);
         const bytes = uuid.toUint8Array();


### PR DESCRIPTION
## What is the motivation?

`SharedArrayBuffer` isn't a defined global on pages that aren't cross-origin isolated. The `Uuid` constructor referenced it unguarded as its first check, so `uuid instanceof SharedArrayBuffer` threw `ReferenceError` before it could compare anything. Every client-side construction hit it, including `new Uuid("...")` and `Uuid.v4()`.

## What does this change do?

Guards the reference with `typeof SharedArrayBuffer !== "undefined"`, wrapped in a small `isSharedArrayBuffer` type-guard. Inlining the check defeats TypeScript's narrowing and breaks the typecheck at `UUID.parse`, so the helper keeps it clean and matches the `typeof` guards already used in `datetime.ts`/`duration.ts`.

## What is your testing strategy?

Added a regression test that deletes `globalThis.SharedArrayBuffer`, constructs a Uuid, then restores the global. It throws without this change and passes with it. Full sqon unit suite stays green.

## Is this related to any issues?

Closes #636

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
