### PR TITLE
fix(sqon): repair encode/decode visitor hooks in JsonCodec

### DIFF
--- a/packages/sqon/src/codec/json/codec.ts
+++ b/packages/sqon/src/codec/json/codec.ts
@@ -84,6 +84,7 @@ export class JsonCodec implements ValueCodec<unknown> {
 
     #serialize(input: unknown): unknown {
         const value = this.#encodeValue(input);
+        const wasEncoded = value !== input;
 
         if (this.#isEncodePrimitive(value)) {
             return value;
@@ -160,7 +161,7 @@ export class JsonCodec implements ValueCodec<unknown> {
 
                     if (encoded !== undefined) {
                         result[key] = encoded;
-                        if (key[0] === "$") escaped = true;
+                        if (!wasEncoded && key[0] === "$") escaped = true;
                     }
                 }
 
@@ -194,11 +195,11 @@ export class JsonCodec implements ValueCodec<unknown> {
 
     #deserialize(input: unknown): unknown {
         if (this.#isDecodePrimitive(input)) {
-            return input;
+            return this.#decodeValue(input);
         }
 
         if (Array.isArray(input)) {
-            return input.map((v) => this.#deserialize(v));
+            return this.#decodeValue(input.map((v) => this.#deserialize(v)));
         }
 
         const obj = input as Record<string, unknown>;
@@ -259,10 +260,12 @@ export class JsonCodec implements ValueCodec<unknown> {
             return this.#decodeValue(new Future(obj.$future));
         }
 
-        return Object.fromEntries(
-            Object.entries(obj)
-                .map(([k, v]) => [k, this.#deserialize(v)])
-                .filter(([, decoded]) => decoded !== undefined),
+        return this.#decodeValue(
+            Object.fromEntries(
+                Object.entries(obj)
+                    .map(([k, v]) => [k, this.#deserialize(v)])
+                    .filter(([, decoded]) => decoded !== undefined),
+            ),
         );
     }
 

--- a/packages/sqon/src/codec/json/visitor.test.ts
+++ b/packages/sqon/src/codec/json/visitor.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { JsonCodec } from "./codec.ts";
+
+interface CustomShape {
+    $custom: {
+        property: string;
+    };
+}
+
+class Custom {
+    constructor(public property: string) {}
+
+    encode(): CustomShape {
+        return { $custom: { property: this.property } };
+    }
+
+    static decode(input: CustomShape): Custom {
+        return new Custom(input.$custom.property);
+    }
+
+    static isCustomShape(input: unknown): input is CustomShape {
+        if (typeof input !== "object" || input === null) return false;
+        const keys = Object.keys(input);
+        return keys.length === 1 && keys[0] === "$custom";
+    }
+}
+
+test("codec visitor hooks round-trip custom values", () => {
+    const codec = new JsonCodec({
+        valueEncodeVisitor: (x) => (x instanceof Custom ? x.encode() : x),
+        valueDecodeVisitor: (x) => (Custom.isCustomShape(x) ? Custom.decode(x) : x),
+    });
+
+    const input = { prop: new Custom("foobar") };
+    const enc = codec.encode(input);
+    const dec = codec.decode<typeof input>(enc);
+
+    expect(enc).toEqual({ prop: { $custom: { property: "foobar" } } });
+    expect(dec).toEqual(input);
+});
+
+test("plain data with a $-prefixed key is still escaped when no visitor transforms it", () => {
+    const codec = new JsonCodec({
+        valueEncodeVisitor: (x) => (x instanceof Custom ? x.encode() : x),
+        valueDecodeVisitor: (x) => (Custom.isCustomShape(x) ? Custom.decode(x) : x),
+    });
+
+    const input = { $literal: "not a custom value" };
+    const enc = codec.encode(input);
+    const dec = codec.decode(enc);
+
+    expect(enc).toEqual({ $object: { $literal: "not a custom value" } });
+    expect(dec).toEqual(input);
+});
+
+test("literal data shaped like a custom marker is not mistaken for a real Custom instance", () => {
+    const codec = new JsonCodec({
+        valueEncodeVisitor: (x) => (x instanceof Custom ? x.encode() : x),
+        valueDecodeVisitor: (x) => (Custom.isCustomShape(x) ? Custom.decode(x) : x),
+    });
+
+    // Not a `Custom` instance -- just plain data that happens to share its wire shape.
+    const input = { prop: { $custom: { property: "foobar" } } };
+    const enc = codec.encode(input);
+    const dec = codec.decode(enc);
+
+    expect(enc).toEqual({ prop: { $object: { $custom: { property: "foobar" } } } });
+    expect(dec).toEqual(input);
+    expect(dec.prop).not.toBeInstanceOf(Custom);
+});


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`JsonCodec`'s `valueEncodeVisitor` / `valueDecodeVisitor` hooks were reported as non-functional for custom types:

```ts
const codec = new JsonCodec({
  valueEncodeVisitor: (x) => x instanceof Custom ? x.encode() : x,
  valueDecodeVisitor: (x) => Custom.isCustomShape(x) ? Custom.decode(x) : x,
});

codec.decode(codec.encode(new Custom("foobar")));
// expected: Custom { property: "foobar" }
// actual:   { $custom: { property: "foobar" } }  -- never converted back
```

## What does this change do?

Three related fixes in `packages/sqon/src/codec/json/codec.ts`:

1. **Decode visitor wasn't called for unrecognized shapes.** It only ran inside the branches for built-in types (`isDatetime`, `isDecimal`, ...). A custom type is by definition unrecognized, so it always fell through untouched.

```ts
// before: generic fallback returned a plain object, visitor never consulted
return Object.fromEntries(...)
// after
return this.#decodeValue(Object.fromEntries(...))
```

2. **Encode was double-wrapping custom shapes.** Any `$`-prefixed key triggers the `$object` escape (protects plain data from colliding with reserved shapes). A custom encoder's own output (e.g. `{ $custom: {...} }`) tripped that same rule and got wrapped again.

```ts
// only escape keys the encoder didn't already produce on purpose
const wasEncoded = value !== input;
if (!wasEncoded && key[0] === "$") escaped = true;
```

3. **`$object` unwrap must not re-run the visitor.** Fix (1) initially also called `#decodeValue` right after unwrapping `$object`. That defeats the escape's purpose: plain data merely shaped like `{ $custom: {...} }` (not a real `Custom` instance) would get unwrapped and then misidentified anyway. Reverted that one call site to a plain unwrap.

## What is your testing strategy?

Added `packages/sqon/src/codec/json/visitor.test.ts`:

```ts
test("codec visitor hooks round-trip custom values", ...)
test("plain data with a $-prefixed key is still escaped when no visitor transforms it", ...)
test("literal data shaped like a custom marker is not mistaken for a real Custom instance", ...)
```

- [x] `bun test src/codec/json/visitor.test.ts` in `packages/sqon` - 3/3 pass
- [x] Manually confirmed default `JsonCodec` (no visitors) still round-trips `RecordId` / `Duration` / `Decimal`

## Is this related to any issues?

None linked.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)