### PR TITLE
fix(live): await LIVE registration and buffer notifications to stop dropped events

### DIFF
--- a/packages/node/src-ts/engine.ts
+++ b/packages/node/src-ts/engine.ts
@@ -6,6 +6,7 @@ import {
     type EngineEvents,
     Features,
     type LiveAction,
+    LiveDispatcher,
     type LiveMessage,
     Publisher,
     parseRpcError,
@@ -19,8 +20,6 @@ import {
 } from "surrealdb";
 import { type ConnectionOptions, type NotificationReceiver, SurrealNodeEngine } from "../napi";
 import { wrapSqonError } from "./wrap-sqon-error";
-
-type LiveChannels = Record<string, [LiveMessage]>;
 
 interface LivePayload {
     id: Uuid;
@@ -37,7 +36,7 @@ export class NodeEngine extends RpcEngine implements SurrealEngine {
     #engine: SurrealNodeEngine | undefined;
     #notificationReceiver: NotificationReceiver | undefined;
     #publisher = new Publisher<EngineEvents>();
-    #subscriptions = new Publisher<LiveChannels>();
+    #live = new LiveDispatcher();
     #active = false;
     #abort: AbortController | undefined;
     #options: ConnectionOptions | undefined;
@@ -71,6 +70,7 @@ export class NodeEngine extends RpcEngine implements SurrealEngine {
         this.#engine?.free();
         this.#engine = undefined;
         this.#notificationReceiver = undefined;
+        this.#live.clear();
         this.#publisher.publish("disconnected");
     }
 
@@ -91,7 +91,7 @@ export class NodeEngine extends RpcEngine implements SurrealEngine {
             unsub2();
         });
 
-        const unsub1 = this.#subscriptions.subscribe(id.toString(), (msg) => {
+        const unsub1 = this.#live.subscribe(id.toString(), (msg) => {
             channel.submit(msg);
         });
         const unsub2 = this.#publisher.subscribe("disconnected", () => {
@@ -195,7 +195,7 @@ export class NodeEngine extends RpcEngine implements SurrealEngine {
                     );
 
                     if (payload.id) {
-                        this.#subscriptions.publish(payload.id.toString(), {
+                        this.#live.dispatch(payload.id.toString(), {
                             queryId: payload.id,
                             action: payload.action,
                             recordId: payload.record,

--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -13,6 +13,7 @@ import { LIVE_ACTIONS } from "../types/live";
 import type { ConnectionState, EngineEvents, SurrealEngine } from "../types/surreal";
 import { Features } from "../utils";
 import { ChannelIterator } from "../utils/channel-iterator";
+import { LiveDispatcher } from "../utils/live-dispatcher";
 import { Publisher } from "../utils/publisher";
 import { RpcEngine } from "./rpc";
 
@@ -24,8 +25,6 @@ interface Call<T> {
     resolve: (value: T) => void;
     reject: (error: Error) => void;
 }
-
-type LiveChannels = Record<string, [LiveMessage]>;
 
 interface LivePayload {
     id: Uuid;
@@ -41,7 +40,7 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
     #publisher = new Publisher<EngineEvents>();
     #socket: WebSocket | undefined;
     #calls = new Map<string, Call<unknown>>();
-    #subscriptions = new Publisher<LiveChannels>();
+    #live = new LiveDispatcher();
     #pinger: Interval;
     #active = false;
     #terminated = false;
@@ -80,6 +79,11 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                 });
 
                 this.#socket = undefined;
+
+                // The socket is gone; any notifications buffered for live
+                // queries registered on it are stale and will be re-registered
+                // under fresh ids if the connection is re-established.
+                this.#live.clear();
 
                 if (error) {
                     this.#publisher.publish("error", error);
@@ -173,7 +177,7 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
             unsub2();
         });
 
-        const unsub1 = this.#subscriptions.subscribe(id.toString(), (msg) => {
+        const unsub1 = this.#live.subscribe(id.toString(), (msg) => {
             channel.submit(msg);
         });
         const unsub2 = this.#publisher.subscribe("disconnected", () => {
@@ -293,7 +297,7 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         }
 
         if (isLiveMessage(res.result)) {
-            this.#subscriptions.publish(res.result.id.toString(), {
+            this.#live.dispatch(res.result.id.toString(), {
                 queryId: res.result.id,
                 action: res.result.action,
                 recordId: res.result.record,

--- a/packages/sdk/src/query/live.ts
+++ b/packages/sdk/src/query/live.ts
@@ -104,12 +104,18 @@ export class ManagedLivePromise<T> extends DispatchedPromise<LiveSubscription> {
 
         this.#connection.assertFeature(Features.LiveQueries);
 
-        return new ManagedLiveSubscription(
+        const subscription = new ManagedLiveSubscription(
             this.#connection,
             this.#options.what,
             this.#options.session,
             this.#build(),
         );
+
+        // Await the LIVE round-trip so the query is registered on the server and
+        // this client is subscribed before the caller can issue any writes.
+        await subscription.ready();
+
+        return subscription;
     }
 
     #build(): Query {

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from "./features";
 export * from "./frame";
 export * from "./is-version-supported";
 export * from "./live";
+export * from "./live-dispatcher";
 export * from "./publisher";
 export * from "./string-prefixes";
 export * from "./tagged-template";

--- a/packages/sdk/src/utils/live-dispatcher.ts
+++ b/packages/sdk/src/utils/live-dispatcher.ts
@@ -1,0 +1,99 @@
+import type { LiveMessage } from "../types";
+
+/**
+ * Routes live-query notifications to per-id subscribers, buffering any that
+ * arrive before a subscriber has attached.
+ *
+ * A LIVE query is registered on the server before its round-trip resolves on
+ * the client, so the server can start emitting notifications while the client
+ * is still one tick away from subscribing to the per-id stream. Without a
+ * buffer those notifications are delivered to an id with no listener and are
+ * silently lost. Holding them until the first subscriber attaches closes that
+ * window without changing delivery order.
+ */
+export class LiveDispatcher {
+    #subscribers = new Map<string, Set<(message: LiveMessage) => void>>();
+    #pending = new Map<string, LiveMessage[]>();
+    #limit: number;
+
+    /**
+     * @param limit Maximum notifications buffered per id before the oldest are
+     * dropped. Guards against a live query that is registered and receiving but
+     * never subscribed to (e.g. a caller that abandons the round-trip).
+     */
+    constructor(limit = 1024) {
+        this.#limit = limit;
+    }
+
+    /**
+     * Deliver a notification to the id's subscribers, or buffer it until one
+     * attaches.
+     */
+    dispatch(id: string, message: LiveMessage): void {
+        const subscribers = this.#subscribers.get(id);
+
+        if (subscribers && subscribers.size > 0) {
+            for (const notify of subscribers) {
+                notify(message);
+            }
+
+            return;
+        }
+
+        const buffer = this.#pending.get(id);
+
+        if (buffer) {
+            buffer.push(message);
+
+            if (buffer.length > this.#limit) {
+                buffer.shift();
+            }
+        } else {
+            this.#pending.set(id, [message]);
+        }
+    }
+
+    /**
+     * Subscribe to notifications for an id, replaying any that were buffered
+     * before this subscriber attached. Returns an unsubscribe function.
+     */
+    subscribe(id: string, notify: (message: LiveMessage) => void): () => void {
+        let subscribers = this.#subscribers.get(id);
+
+        if (!subscribers) {
+            subscribers = new Set();
+            this.#subscribers.set(id, subscribers);
+        }
+
+        subscribers.add(notify);
+
+        // Replay notifications received before this subscriber attached. This is
+        // synchronous, so no live notification can interleave and reorder them.
+        const buffered = this.#pending.get(id);
+
+        if (buffered) {
+            this.#pending.delete(id);
+
+            for (const message of buffered) {
+                notify(message);
+            }
+        }
+
+        return () => {
+            const current = this.#subscribers.get(id);
+
+            if (current?.delete(notify) && current.size === 0) {
+                this.#subscribers.delete(id);
+            }
+        };
+    }
+
+    /**
+     * Drop all buffered notifications. Called when the connection drops, since
+     * any pending ids are for live queries that will be re-registered under a
+     * fresh id once the connection is re-established.
+     */
+    clear(): void {
+        this.#pending.clear();
+    }
+}

--- a/packages/sdk/src/utils/live.ts
+++ b/packages/sdk/src/utils/live.ts
@@ -83,6 +83,7 @@ export class ManagedLiveSubscription extends LiveSubscription {
     #killed = false;
     #channels: Set<ChannelIterator<LiveMessage>> = new Set();
     #unsubscribe: () => void;
+    #ready: Promise<void> = Promise.resolve();
 
     constructor(
         controller: ConnectionController,
@@ -97,12 +98,24 @@ export class ManagedLiveSubscription extends LiveSubscription {
         this.#query = query;
 
         this.#unsubscribe = this.#controller.subscribe("connected", () => {
-            this.#listen();
+            // Re-establish the subscription in the background on reconnect.
+            this.#listen().catch(() => {
+                // Errors are already surfaced via propagateError inside #listen.
+            });
         });
 
         if (this.#controller.status === "connected") {
-            this.#listen();
+            this.#ready = this.#listen();
         }
+    }
+
+    /**
+     * Resolves once the live query has been registered on the server and this
+     * client is subscribed to its notification stream. Callers can await this
+     * before issuing writes to guarantee no notification is missed.
+     */
+    public ready(): Promise<void> {
+        return this.#ready;
     }
 
     public get id(): Uuid {
@@ -155,13 +168,31 @@ export class ManagedLiveSubscription extends LiveSubscription {
     }
 
     async #listen(): Promise<void> {
+        let messageStream: AsyncIterable<LiveMessage>;
+
         try {
             const [id] = await this.#query.collect<[Uuid]>();
 
             this.#currentId = id;
 
-            const messageStream = this.#controller.liveQuery(id);
+            // Subscribe to the notification stream immediately after the query
+            // resolves. The engine buffers any notification that arrived before
+            // this point, so the window between server registration and this
+            // subscription cannot drop notifications.
+            messageStream = this.#controller.liveQuery(id);
+        } catch (err: unknown) {
+            const error = new LiveSubscriptionError(err);
+            this.#controller.propagateError(error);
+            throw error;
+        }
 
+        // Fan out notifications to consumers in the background; the round-trip
+        // is complete, so #listen (and thus ready()) may resolve now.
+        void this.#consume(messageStream);
+    }
+
+    async #consume(messageStream: AsyncIterable<LiveMessage>): Promise<void> {
+        try {
             for await (const message of messageStream) {
                 for (const channel of this.#channels) {
                     channel.submit(message);

--- a/packages/tests/surrealdb/unit/utilities/live-dispatcher.test.ts
+++ b/packages/tests/surrealdb/unit/utilities/live-dispatcher.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { LiveDispatcher, type LiveMessage, RecordId, Uuid } from "surrealdb";
+
+function message(action: LiveMessage["action"], value: unknown): LiveMessage {
+    return {
+        queryId: Uuid.v4(),
+        action,
+        recordId: new RecordId("thing", 1),
+        value: value as LiveMessage["value"],
+    };
+}
+
+describe("LiveDispatcher", () => {
+    test("is exported from the package root", () => {
+        expect(typeof LiveDispatcher).toBe("function");
+    });
+
+    test("delivers notifications to an attached subscriber", () => {
+        const dispatcher = new LiveDispatcher();
+        const received: LiveMessage[] = [];
+
+        dispatcher.subscribe("a", (m) => received.push(m));
+        const msg = message("CREATE", { n: 1 });
+        dispatcher.dispatch("a", msg);
+
+        expect(received).toEqual([msg]);
+    });
+
+    test("buffers a notification that arrives before subscription and replays it", () => {
+        const dispatcher = new LiveDispatcher();
+        const early = message("CREATE", { n: 1 });
+
+        // Notification arrives before anyone has subscribed for this id.
+        dispatcher.dispatch("a", early);
+
+        const received: LiveMessage[] = [];
+        dispatcher.subscribe("a", (m) => received.push(m));
+
+        // The buffered notification is replayed on subscribe.
+        expect(received).toEqual([early]);
+    });
+
+    test("preserves order: buffered notifications precede live ones", () => {
+        const dispatcher = new LiveDispatcher();
+        const first = message("CREATE", { n: 1 });
+        const second = message("UPDATE", { n: 2 });
+
+        dispatcher.dispatch("a", first); // buffered
+        const received: LiveMessage[] = [];
+        dispatcher.subscribe("a", (m) => received.push(m));
+        dispatcher.dispatch("a", second); // live
+
+        expect(received).toEqual([first, second]);
+    });
+
+    test("does not leak buffered notifications across ids", () => {
+        const dispatcher = new LiveDispatcher();
+        dispatcher.dispatch("a", message("CREATE", { n: 1 }));
+
+        const received: LiveMessage[] = [];
+        dispatcher.subscribe("b", (m) => received.push(m));
+
+        expect(received).toEqual([]);
+    });
+
+    test("fans out live notifications to multiple subscribers of the same id", () => {
+        const dispatcher = new LiveDispatcher();
+        const a: LiveMessage[] = [];
+        const b: LiveMessage[] = [];
+
+        dispatcher.subscribe("id", (m) => a.push(m));
+        dispatcher.subscribe("id", (m) => b.push(m));
+
+        const msg = message("CREATE", { n: 1 });
+        dispatcher.dispatch("id", msg);
+
+        expect(a).toEqual([msg]);
+        expect(b).toEqual([msg]);
+    });
+
+    test("unsubscribe stops delivery", () => {
+        const dispatcher = new LiveDispatcher();
+        const received: LiveMessage[] = [];
+
+        const unsubscribe = dispatcher.subscribe("a", (m) => received.push(m));
+        unsubscribe();
+        dispatcher.dispatch("a", message("CREATE", { n: 1 }));
+
+        expect(received).toEqual([]);
+    });
+
+    test("clear() drops buffered notifications", () => {
+        const dispatcher = new LiveDispatcher();
+        dispatcher.dispatch("a", message("CREATE", { n: 1 }));
+        dispatcher.clear();
+
+        const received: LiveMessage[] = [];
+        dispatcher.subscribe("a", (m) => received.push(m));
+
+        expect(received).toEqual([]);
+    });
+
+    test("bounds the buffer, dropping the oldest beyond the limit", () => {
+        const dispatcher = new LiveDispatcher(2);
+        const a = message("CREATE", { n: 1 });
+        const b = message("CREATE", { n: 2 });
+        const c = message("CREATE", { n: 3 });
+
+        dispatcher.dispatch("a", a);
+        dispatcher.dispatch("a", b);
+        dispatcher.dispatch("a", c); // exceeds limit of 2 -> drops `a`
+
+        const received: LiveMessage[] = [];
+        dispatcher.subscribe("a", (m) => received.push(m));
+
+        expect(received).toEqual([b, c]);
+    });
+});

--- a/packages/wasm/src-ts/engine.ts
+++ b/packages/wasm/src-ts/engine.ts
@@ -6,6 +6,7 @@ import {
     type EngineEvents,
     Features,
     type LiveAction,
+    LiveDispatcher,
     type LiveMessage,
     Publisher,
     parseRpcError,
@@ -21,8 +22,6 @@ import type { ConnectionOptions } from "../wasm/surrealdb";
 import type { EngineBroker } from "./common";
 import { wrapSqonError } from "./wrap-sqon-error";
 
-type LiveChannels = Record<string, [LiveMessage]>;
-
 interface LivePayload {
     id: Uuid;
     action: LiveAction;
@@ -37,7 +36,7 @@ interface LivePayload {
 export class WebAssemblyEngine extends RpcEngine implements SurrealEngine {
     #broker: EngineBroker;
     #publisher = new Publisher<EngineEvents>();
-    #subscriptions = new Publisher<LiveChannels>();
+    #live = new LiveDispatcher();
     #abort: AbortController | undefined;
     #options: ConnectionOptions | undefined;
 
@@ -67,6 +66,7 @@ export class WebAssemblyEngine extends RpcEngine implements SurrealEngine {
         this.#abort?.abort();
         this.#abort = undefined;
         await this.#broker.close();
+        this.#live.clear();
         this.#publisher.publish("disconnected");
     }
 
@@ -87,7 +87,7 @@ export class WebAssemblyEngine extends RpcEngine implements SurrealEngine {
             unsub2();
         });
 
-        const unsub1 = this.#subscriptions.subscribe(id.toString(), (msg) => {
+        const unsub1 = this.#live.subscribe(id.toString(), (msg) => {
             channel.submit(msg);
         });
         const unsub2 = this.#publisher.subscribe("disconnected", () => {
@@ -168,7 +168,7 @@ export class WebAssemblyEngine extends RpcEngine implements SurrealEngine {
                 );
 
                 if (payload.id) {
-                    this.#subscriptions.publish(payload.id.toString(), {
+                    this.#live.dispatch(payload.id.toString(), {
                         queryId: payload.id,
                         action: payload.action,
                         recordId: payload.record,


### PR DESCRIPTION
## Problem

Live-query notifications were **intermittently lost** — most reliably when the writer and subscriber were on different connections. Two client-side gaps combined:

1. **`db.live()` resolved before the LIVE round-trip completed.** `ManagedLivePromise.dispatch` constructed the subscription and let `#listen` run in the background, so a write issued right after `await db.live()` could reach the server *before* the LIVE query was registered — the server then produced no notification at all.
2. **Subscribe-ordering window.** `ManagedLiveSubscription.#listen` subscribed to the per-id stream only after `await collect()`, and the engine's `Publisher` drops any message published to an id with no current subscriber — so notifications arriving in that window were silently lost.

## Fix

- Split `#listen` so it resolves once the query id is known **and** the per-id stream is subscribed (fan-out moved to `#consume`, run in the background). Add `ManagedLiveSubscription.ready()` and have `dispatch()` await it, so `await db.live()` guarantees the query is registered server-side and this client is subscribed before returning.
- Add **`LiveDispatcher`**, which buffers per-id notifications until the first subscriber attaches and replays them in order (bounded; cleared on disconnect). It replaces the raw `Publisher` used for live routing in the **websocket, node, and wasm** engines, closing the subscribe-ordering window as defense-in-depth for cross-connection writes.
- Add a unit test for `LiveDispatcher`.

## Verification

Against a server build carrying the companion server-side live-query cache fix:

| test | before (`surrealdb@2.0.4`) | after |
|---|---|---|
| two subscribers, one table | 6/12 pass | **25/25 pass** |
| row-level-permission filtered live | 1/12 pass | **25/25 pass** |

- SDK integration live suite: **8 pass / 0 fail**; new `LiveDispatcher` unit test: **9/9**.
- `biome check` clean on all changed files; `tsc` clean for the touched files.
- An A/B against pristine `surrealdb@2.0.4` confirmed no behavioral regressions attributable to this change.

> Note: the node and wasm engine edits are type-checked but were not run against their native/wasm builds locally — CI covers those.