### PR TITLE
chore(sdk): bump surrealdb to 2.0.5

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "surrealdb",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "type": "module",
     "license": "Apache-2.0",
     "description": "The official SurrealDB SDK for JavaScript.",


### PR DESCRIPTION
Bumps the `surrealdb` SDK package from `2.0.4` to `2.0.5`.

Ships the live-query notification-loss fix merged in #644 (`db.live()` now awaits LIVE registration + `LiveDispatcher` buffers per-id notifications).

- One-line change to `packages/sdk/package.json`.
- `bun run validate:versions` passes: `@surrealdb/node`/`@surrealdb/wasm` stay at 3.0.4 and their `surrealdb` range (`^2.0.1`) already satisfies 2.0.5, so no other package is touched.

Publishing to npm is a separate step — once merged, publish a **v2.0.5** GitHub Release to trigger `publish-sdk.yml`.