### PR TITLE
fix(live): sync isAlive with session/connection teardown (2.0.6)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "surrealdb",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "type": "module",
     "license": "Apache-2.0",
     "description": "The official SurrealDB SDK for JavaScript.",

--- a/packages/sdk/src/utils/live.ts
+++ b/packages/sdk/src/utils/live.ts
@@ -131,7 +131,10 @@ export class ManagedLiveSubscription extends LiveSubscription {
     }
 
     public get isAlive(): boolean {
-        return !this.#killed;
+        // Alive until permanent teardown: killed explicitly, the owning session
+        // destroyed, or the connection closed for good. hasSession() stays true
+        // across a transient reconnect, whose state is not cleared.
+        return !this.#killed && this.#controller.hasSession(this.#session);
     }
 
     public async kill(): Promise<void> {
@@ -254,7 +257,10 @@ export class UnmanagedLiveSubscription extends LiveSubscription {
     }
 
     public get isAlive(): boolean {
-        return !this.#killed;
+        // Alive until permanent teardown: killed explicitly, the owning session
+        // destroyed, or the connection closed for good. hasSession() stays true
+        // across a transient reconnect, whose state is not cleared.
+        return !this.#killed && this.#controller.hasSession(this.#session);
     }
 
     public async kill(): Promise<void> {

--- a/packages/tests/surrealdb/integration/sessions.test.ts
+++ b/packages/tests/surrealdb/integration/sessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Features } from "surrealdb";
+import { Features, Table } from "surrealdb";
 import {
     createSurreal,
     requestVersion,
@@ -68,6 +68,25 @@ describe.if(is3x && (SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem"))(
             await session.closeSession();
 
             expect(session.isValid).toBeFalse();
+        });
+
+        test("closeSession() marks its live subscriptions not alive", async () => {
+            const surreal = await createSurreal();
+            const session = await surreal.forkSession();
+            await session.query("DEFINE TABLE watched SCHEMALESS");
+
+            const sub = await session.live(new Table("watched"));
+            expect(sub.isAlive).toBeTrue();
+
+            await session.closeSession();
+
+            // The owning session was disposed, so the subscription is no longer alive.
+            expect(sub.isAlive).toBeFalse();
+
+            // A subscription on the still-open root session is unaffected.
+            const rootSub = await surreal.live(new Table("watched"));
+            expect(rootSub.isAlive).toBeTrue();
+            await rootSub.kill();
         });
 
         test("request sessions list", async () => {


### PR DESCRIPTION
## Problem

`ManagedLiveSubscription.isAlive` (and the unmanaged variant) was just `!#killed`, so it only became `false` via an explicit `kill()`. When the subscription's **owning session was destroyed** (`closeSession()`) or the **connection closed for good**, `isAlive` kept reporting `true` even though delivery had already stopped.

## Fix

`isAlive` now also reflects the connection's session state:

```ts
return !this.#killed && this.#controller.hasSession(this.#session);
```

`hasSession()` returns `false` once the session is destroyed or the connection state is cleared (permanent close), but stays `true` across a **transient reconnect** (which emits `reconnecting`, not `disconnected`, and never clears state) — so a managed subscription that can still auto-resume is correctly reported alive. No new events or control-flow needed.

Adds a `sessions` integration test asserting a live subscription on a forked session reports `isAlive === false` after `closeSession()`, while one on the still-open root session stays alive.

## Verification (against a #657 server build)

- New sessions test + full `live` integration suite: green (10/0 and 8/0).
- Conformance suite (private): the `sessions-multiplex` "belongs to its session" test — previously pinning the wart `expect(isAlive).toBe(true)` — now asserts `false` and passes; `live` suite unaffected.
- `biome check` clean; `validate:versions` passes (node/wasm stay 3.0.4, range `^2.0.1` satisfies 2.0.6).

Bumps `surrealdb` to **2.0.6**.