### PR TITLE
feat(sdk): add db.gql() for ISO GQL queries

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -188,6 +188,24 @@ let [created] = await db
     .collect<[Person]>();
 ```
 
+#### ISO GQL queries
+
+In addition to SurrealQL, you can run [ISO GQL](https://www.iso.org/standard/76120.html)
+(ISO/IEC 39075) queries with the `gql` method. It behaves exactly like `query`
+— returning the same awaitable `Query` instance — but executes the string with
+the server's GQL engine. A namespace and database must be selected first.
+
+```ts
+// Run a GQL query and collect the results
+const [people] = await db.gql<[{ name: string }[]]>(
+    "MATCH (p:person) WHERE p.age > $min RETURN p.name AS name ORDER BY name",
+    { min: 21 },
+);
+```
+
+> GQL is served by remote (WebSocket/HTTP) engines connected to a SurrealDB
+> instance with GQL enabled.
+
 ### Subscribing to live queries
 
 You can subscribe to live queries to receive updates when the data in the database changes.
@@ -279,7 +297,7 @@ When using the embedded engine, call `.close()` when you are done to shut down t
 | Area | Key exports |
 | --- | --- |
 | Client | `Surreal`, `SurrealSession`, `SurrealTransaction` |
-| Query API | `.query()`, `.select()`, `.create()`, `.update()`, `.delete()`, `.insert()`, `.upsert()`, `.relate()`, `.live()` |
+| Query API | `.query()`, `.gql()`, `.select()`, `.create()`, `.update()`, `.delete()`, `.insert()`, `.upsert()`, `.relate()`, `.live()` |
 | Remote engines | `createRemoteEngines()`, `WebSocketEngine`, `HttpEngine` |
 | Bound queries | `surql`, `BoundQuery`, `expr`, comparison and logical operators |
 | Value types | `RecordId`, `Table`, `DateTime`, `Decimal`, `Uuid`, and more (from `@surrealdb/sqon`) |

--- a/packages/sdk/src/api/queryable.ts
+++ b/packages/sdk/src/api/queryable.ts
@@ -103,6 +103,39 @@ export abstract class SurrealQueryable {
     }
 
     /**
+     * Runs an ISO GQL (ISO/IEC 39075) query against the database.
+     *
+     * GQL is the standardized graph query language. Unlike {@link query}, the
+     * provided string is executed by the server's GQL engine rather than the
+     * SurrealQL engine. The resulting `Query` instance behaves identically to a
+     * SurrealQL query: await it (or use `.collect()`, `.stream()`, `.responses()`)
+     * to process the results.
+     *
+     * A namespace and database must be selected before running a GQL query.
+     *
+     * @example
+     * ```ts
+     * const [people] = await db.gql("MATCH (p:person) RETURN p.name AS name");
+     * ```
+     *
+     * @param query The GQL query string
+     * @param bindings Assigns variables which can be referenced in the query
+     * @returns A `Query` instance which can be used to execute or configure the query
+     */
+    gql<R extends unknown[] = unknown[]>(
+        query: string,
+        bindings?: Record<string, unknown>,
+    ): Query<R> {
+        return new Query(this.#connection, {
+            query: new BoundQuery(query, bindings),
+            transaction: this.#transaction,
+            session: this.#session,
+            json: false,
+            dialect: "gql",
+        });
+    }
+
+    /**
      * Returns the record representing the currently authenticated record user by
      * selecting the [$auth parameter](https://surrealdb.com/docs/surrealql/parameters#auth).
      *

--- a/packages/sdk/src/controller/index.ts
+++ b/packages/sdk/src/controller/index.ts
@@ -432,6 +432,11 @@ export class ConnectionController implements SurrealProtocol, EventPublisher<Con
         return this.#engine.query(query, session, txn);
     }
 
+    gql<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>> {
+        if (!this.#engine) throw new ConnectionUnavailableError();
+        return this.#engine.gql(query, session, txn);
+    }
+
     liveQuery(id: Uuid): AsyncIterable<LiveMessage> {
         if (!this.#engine) throw new ConnectionUnavailableError();
         return this.#engine.liveQuery(id);

--- a/packages/sdk/src/engine/diagnostics.ts
+++ b/packages/sdk/src/engine/diagnostics.ts
@@ -248,13 +248,34 @@ export class DiagnosticsEngine implements SurrealEngine {
     }
 
     query<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>> {
+        return this.#instrumentQuery(
+            this.#delegate.query<T>(query, session, txn),
+            query,
+            session,
+            txn,
+        );
+    }
+
+    gql<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>> {
+        return this.#instrumentQuery(
+            this.#delegate.gql<T>(query, session, txn),
+            query,
+            session,
+            txn,
+        );
+    }
+
+    #instrumentQuery<T>(
+        delegateResult: AsyncIterable<QueryChunk<T>>,
+        query: BoundQuery,
+        session: Session,
+        txn?: Uuid,
+    ): AsyncIterable<QueryChunk<T>> {
         const measure = Duration.measure();
         const callback = this.#callback;
         const debugKey = Uuid.v4();
 
         callback({ type: "query", key: debugKey, phase: "before" });
-
-        const delegateResult = this.#delegate.query(query, session, txn);
 
         return {
             async *[Symbol.asyncIterator]() {

--- a/packages/sdk/src/engine/http.ts
+++ b/packages/sdk/src/engine/http.ts
@@ -94,7 +94,8 @@ export class HttpEngine extends RpcEngine implements SurrealEngine {
         }
 
         switch (request.method) {
-            case "query": {
+            case "query":
+            case "gql": {
                 request.params = [
                     request.params?.[0],
                     {

--- a/packages/sdk/src/engine/rpc.ts
+++ b/packages/sdk/src/engine/rpc.ts
@@ -245,9 +245,22 @@ export abstract class RpcEngine implements SurrealProtocol {
         });
     }
 
-    async *query<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>> {
+    query<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>> {
+        return this.#dispatchQuery<T>("query", query, session, txn);
+    }
+
+    gql<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>> {
+        return this.#dispatchQuery<T>("gql", query, session, txn);
+    }
+
+    async *#dispatchQuery<T>(
+        method: "query" | "gql",
+        query: BoundQuery,
+        session: Session,
+        txn?: Uuid,
+    ): AsyncIterable<QueryChunk<T>> {
         const responses: RpcQueryResult[] = await this.send({
-            method: "query",
+            method,
             params: [query.query, query.bindings],
             session,
             txn,

--- a/packages/sdk/src/query/query.ts
+++ b/packages/sdk/src/query/query.ts
@@ -3,7 +3,7 @@ import type { ConnectionController } from "../controller";
 import { DispatchedPromise } from "../internal/dispatched-promise";
 import { type MaybeJsonify, maybeJsonify } from "../internal/maybe-jsonify";
 import { RetryContext } from "../internal/retry";
-import type { QueryResponse, RetryValue, Session } from "../types";
+import type { QueryChunk, QueryResponse, RetryValue, Session } from "../types";
 import type { BoundQuery } from "../utils";
 import { DoneFrame, ErrorFrame, type Frame, ValueFrame } from "../utils/frame";
 
@@ -13,6 +13,11 @@ interface QueryOptions {
     session: Session;
     json: boolean;
     retry?: RetryValue;
+    /**
+     * The query dialect to execute the query as. Defaults to `"sql"` (SurrealQL);
+     * `"gql"` routes the query through the ISO GQL (ISO/IEC 39075) endpoint.
+     */
+    dialect?: "sql" | "gql";
 }
 
 type Collect<T extends unknown[], J extends boolean> = T extends []
@@ -44,6 +49,18 @@ export class Query<
      */
     get inner(): BoundQuery {
         return this.#options.query;
+    }
+
+    /**
+     * Obtain the stream of response chunks for this query, routing to the
+     * transport that matches the configured dialect.
+     */
+    #chunks<T = unknown>(): AsyncIterable<QueryChunk<T>> {
+        const { query, transaction, session, dialect } = this.#options;
+
+        return dialect === "gql"
+            ? this.#connection.gql<T>(query, session, transaction)
+            : this.#connection.query<T>(query, session, transaction);
     }
 
     /**
@@ -110,8 +127,8 @@ export class Query<
         const context = new RetryContext(options);
 
         return context.run(async () => {
-            const { query, transaction, session, json } = this.#options;
-            const chunks = this.#connection.query(query, session, transaction);
+            const { json } = this.#options;
+            const chunks = this.#chunks();
             const responses: unknown[] = [];
             const queryIndexes =
                 queries.length > 0 ? new Map(queries.map((idx, i) => [idx, i])) : undefined;
@@ -171,8 +188,8 @@ export class Query<
     async *stream<T = unknown>(): AsyncIterable<Frame<T, J>> {
         await this.#connection.ready();
 
-        const { query, transaction, session, json } = this.#options;
-        const chunks = this.#connection.query(query, session, transaction);
+        const { json } = this.#options;
+        const chunks = this.#chunks<T>();
 
         for await (const chunk of chunks) {
             if (chunk.error) {
@@ -223,8 +240,8 @@ export class Query<
     async responses<T extends unknown[] = R>(...queries: number[]): Promise<Responses<T, J>> {
         await this.#connection.ready();
 
-        const { query, transaction, session, json } = this.#options;
-        const chunks = this.#connection.query(query, session, transaction);
+        const { json } = this.#options;
+        const chunks = this.#chunks();
         const collections: unknown[] = [];
         const responses: QueryResponse[] = [];
         const queryIndexes =

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -72,6 +72,7 @@ export interface SurrealProtocol {
 
     // Query operations
     query<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>>;
+    gql<T>(query: BoundQuery, session: Session, txn?: Uuid): AsyncIterable<QueryChunk<T>>;
     liveQuery(id: Uuid): AsyncIterable<LiveMessage>;
 }
 

--- a/packages/tests/surrealdb/integration/query/gql.test.ts
+++ b/packages/tests/surrealdb/integration/query/gql.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { satisfies } from "semver";
+import { createSurreal, requestVersion, SURREAL_BACKEND } from "../__helpers__";
+
+const { version } = await requestVersion();
+
+// ISO GQL (ISO/IEC 39075) is served by the WebSocket/HTTP RPC `gql` method from
+// SurrealDB 3.2 onwards. The embedded (node/wasm) engines are built against a
+// core that does not yet expose the GQL method, so the suite only runs against
+// remote engines.
+const hasGql =
+    SURREAL_BACKEND === "remote" && satisfies(version, ">=3.2.0-0", { includePrerelease: true });
+
+describe.if(hasGql)("gql", () => {
+    test("match returns records", async () => {
+        const surreal = await createSurreal();
+        await surreal.query(
+            "CREATE person:alice SET name = 'Alice', age = 30; CREATE person:bob SET name = 'Bob', age = 25;",
+        );
+
+        const [names] = await surreal.gql<[{ name: string }[]]>(
+            "MATCH (p:person) RETURN p.name AS name ORDER BY name",
+        );
+
+        expect(names).toEqual([{ name: "Alice" }, { name: "Bob" }]);
+    });
+
+    test("match with bound variable", async () => {
+        const surreal = await createSurreal();
+        await surreal.query(
+            "CREATE person:alice SET name = 'Alice', age = 30; CREATE person:bob SET name = 'Bob', age = 25;",
+        );
+
+        const [names] = await surreal.gql<[{ name: string }[]]>(
+            "MATCH (p:person) WHERE p.age > $min RETURN p.name AS name ORDER BY name",
+            { min: 26 },
+        );
+
+        expect(names).toEqual([{ name: "Alice" }]);
+    });
+
+    test("responses reports success", async () => {
+        const surreal = await createSurreal();
+        await surreal.query("CREATE person:alice SET name = 'Alice';");
+
+        const [response] = await surreal.gql("MATCH (p:person) RETURN p.name AS name").responses();
+
+        expect(response.success).toBe(true);
+    });
+});


### PR DESCRIPTION
## What is the motivation?

Users can query SurrealDB with SurrealQL through `db.query()`, but the SDK had no way to run **ISO GQL** (ISO/IEC 39075) queries — even though the server already exposes a `gql` RPC method (parallel to `query`). This adds first-class GQL support so users can query with GQL specifically.

## What does this change do?

Adds a `gql()` method to the query API that executes ISO GQL queries via the server's `gql` RPC method, mirroring `query()`. `db.gql(query, bindings?)` returns the same `Query` instance as `db.query()`, so `.collect()`, `.stream()`, `.responses()`, `.json()`, `.retry()` and awaiting all behave identically, and it composes with transactions via `tx.gql()`.

- `SurrealProtocol`, `RpcEngine` and `DiagnosticsEngine` gain a `gql()` method; `query()` and `gql()` share a single response-mapping generator so there is no duplicated decoding logic.
- `ConnectionController` forwards `gql()` to the active engine.
- The `Query` class gains a `dialect` option that selects the SurrealQL or GQL transport when streaming response chunks.
- The HTTP engine injects session variables for `gql` exactly as it does for `query`.

```ts
const [people] = await db.gql<[{ name: string }[]]>("MATCH (p:person) WHERE p.age > $min RETURN p.name AS name ORDER BY name", { min: 21 });
```

**Scope:** this covers the remote **WebSocket** and **HTTP** engines against a GQL-enabled SurrealDB instance. The embedded **node/wasm** engines are intentionally **not** included here: their bundled `surrealdb-core` (3.0.x) predates the `gql` RPC method, and the only published core that ships it (3.2.1) also changes the `RpcProtocol` session model and the datastore/notification construction APIs — i.e. a 2-minor-version core upgrade rather than a GQL wiring change. That is tracked as a separate follow-up.

## What is your testing strategy?

`tsc --noEmit` (typecheck) and `biome check` (lint) pass for the changed SDK code. Verified end-to-end against a real `surreal 3.2.1` server (with GQL enabled) over both WebSocket and HTTP: a basic `MATCH … RETURN`, a query using a bound variable (`$min`), and `.responses()` parity all returned the expected records. Added a version-gated integration test at `packages/tests/surrealdb/integration/query/gql.test.ts` (runs against remote engines on SurrealDB >= 3.2).

## Is this related to any issues?

Not linked to an existing issue.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)