### PR TITLE
fix(auth): omit undefined namespace/database for bearer signin

### DIFF
--- a/packages/sdk/src/internal/build-rpc-auth.ts
+++ b/packages/sdk/src/internal/build-rpc-auth.ts
@@ -3,12 +3,19 @@ import type { AnyAuth, ConnectionSession } from "../types";
 
 export function buildRpcAuth(session: ConnectionSession, auth: AnyAuth): Record<string, unknown> {
     if ("key" in auth) {
-        return {
-            ns: auth.namespace,
-            db: auth.database,
+        if (auth.database && !auth.namespace) {
+            throw new MissingNamespaceDatabaseError();
+        }
+
+        const result: Record<string, unknown> = {
             ac: auth.access,
             key: auth.key,
         };
+
+        if (auth.namespace) result.ns = auth.namespace;
+        if (auth.database) result.db = auth.database;
+
+        return result;
     }
 
     // Record user authentication

--- a/packages/tests/surrealdb/integration/authentication.test.ts
+++ b/packages/tests/surrealdb/integration/authentication.test.ts
@@ -307,4 +307,29 @@ describe.skipIf(!isRemote || !is3x)("bearer access", async () => {
 
         expect(res.access).toBeString();
     });
+
+    test.skipIf(!is3x)("namespace bearer signin omits the database", async () => {
+        const surreal = await createSurreal({ auth: "root" });
+
+        await surreal.query(surql`
+            DEFINE ACCESS ns_bearer ON NAMESPACE TYPE BEARER FOR USER DURATION FOR GRANT 60s FOR TOKEN 60s;
+            DEFINE USER ns_tester ON NAMESPACE PASSWORD 'test' ROLES OWNER;
+        `);
+
+        const [grant] = await surreal
+            .query<[{ grant: { key: string } }]>(surql`
+                ACCESS ns_bearer ON NAMESPACE GRANT FOR USER ns_tester;
+            `)
+            .collect();
+
+        // A namespace-level bearer carries no database, so signin must omit the
+        // database rather than send a null that misroutes to the database path.
+        const res = await surreal.signin({
+            namespace: "test",
+            access: "ns_bearer",
+            key: grant.grant.key,
+        });
+
+        expect(res.access).toBeString();
+    });
 });


### PR DESCRIPTION
## Problem

`buildRpcAuth`'s bearer (`key`) branch unconditionally emitted `ns`, `db`, `ac`, `key`. When a caller signs in with a namespace-level bearer (no `database`) or a root-level bearer (no `namespace`/`database`), the absent fields are `undefined`, which the CBOR codec encodes as `NONE`. The server sees the field as *present* and routes the request to the database access path, so namespace- and root-level bearer signin fail (`Expected string, got null` / `access method does not exist`).

## Fix

Mirror the guarded system-user branch: build the payload with only `ac` + `key`, add `ns`/`db` only when defined, and reject a `database` supplied without a `namespace`. Now the wire shape matches the server's routing:

- `{ access, key }` → `{ ac, key }` (root)
- `{ namespace, access, key }` → `{ ns, ac, key }` (namespace)
- `{ namespace, database, access, key }` → `{ ns, db, ac, key }` (database)

## Tests

- Added an integration regression in `authentication.test.ts`: a namespace-level bearer GRANT + `signin({ namespace, access, key })` now succeeds. This case failed before the change (the `undefined` database misrouted to the database path). Verified green against a stock `surreal` 3.2.1 (`3 pass / 0 fail`).
- The bearer output shapes were also checked directly for all four cases (root / namespace / database / database-without-namespace-throws).

## Note

This is transport-shaping only — it strictly narrows what the client sends and cannot broaden server-side authorization (the server independently validates scope). Root-level bearer signin additionally depends on a companion server-side fix that adds the missing root-access dispatch arm; namespace-level bearer signin is fully fixed by this change alone against current servers.
