### PR TITLE
fix(live): deliver KILLED notifications and end the subscription

### DIFF
--- a/packages/node/src-ts/engine.ts
+++ b/packages/node/src-ts/engine.ts
@@ -24,8 +24,8 @@ import { wrapSqonError } from "./wrap-sqon-error";
 interface LivePayload {
     id: Uuid;
     action: LiveAction;
-    result: LiveMessage;
-    record: RecordId;
+    result?: Record<string, unknown>;
+    record?: RecordId;
 }
 
 /**
@@ -195,12 +195,17 @@ export class NodeEngine extends RpcEngine implements SurrealEngine {
                     );
 
                     if (payload.id) {
-                        this.#live.dispatch(payload.id.toString(), {
-                            queryId: payload.id,
-                            action: payload.action,
-                            recordId: payload.record,
-                            value: payload.result,
-                        });
+                        this.#live.dispatch(
+                            payload.id.toString(),
+                            payload.action === "KILLED"
+                                ? { queryId: payload.id, action: "KILLED" }
+                                : {
+                                      queryId: payload.id,
+                                      action: payload.action,
+                                      recordId: payload.record as RecordId,
+                                      value: payload.result as Record<string, unknown>,
+                                  },
+                        );
                     }
                 }
             })();

--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -29,8 +29,8 @@ interface Call<T> {
 interface LivePayload {
     id: Uuid;
     action: LiveAction;
-    result: LiveMessage;
-    record: RecordId;
+    result?: Record<string, unknown>;
+    record?: RecordId;
 }
 
 /**
@@ -297,12 +297,18 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         }
 
         if (isLiveMessage(res.result)) {
-            this.#live.dispatch(res.result.id.toString(), {
-                queryId: res.result.id,
-                action: res.result.action,
-                recordId: res.result.record,
-                value: res.result.result,
-            });
+            const frame = res.result;
+            this.#live.dispatch(
+                frame.id.toString(),
+                frame.action === "KILLED"
+                    ? { queryId: frame.id, action: "KILLED" }
+                    : {
+                          queryId: frame.id,
+                          action: frame.action,
+                          recordId: frame.record as RecordId,
+                          value: frame.result as Record<string, unknown>,
+                      },
+            );
             return;
         }
 
@@ -313,10 +319,15 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
 function isLiveMessage(v: unknown): v is LivePayload {
     if (typeof v !== "object") return false;
     if (v === null) return false;
-    if (!("id" in v && "action" in v && "result" in v && "record" in v)) return false;
+    if (!("id" in v && "action" in v)) return false;
 
     if (!(v.id instanceof Uuid)) return false;
     if (!LIVE_ACTIONS.includes(v.action as LiveAction)) return false;
+
+    // A KILLED frame terminates the subscription and carries no record or value.
+    if (v.action === "KILLED") return true;
+
+    if (!("result" in v && "record" in v)) return false;
     if (typeof v.result !== "object") return false;
     if (v.result === null) return false;
     if (!(v.record instanceof RecordId)) return false;

--- a/packages/sdk/src/types/live.ts
+++ b/packages/sdk/src/types/live.ts
@@ -4,9 +4,23 @@ export const LIVE_ACTIONS = ["CREATE", "UPDATE", "DELETE", "KILLED"] as const;
 
 export type LiveResource = Table;
 export type LiveAction = (typeof LIVE_ACTIONS)[number];
-export type LiveMessage = {
-    queryId: Uuid;
-    action: LiveAction;
-    recordId: RecordId;
-    value: Record<string, unknown>;
-};
+
+/**
+ * A record change (`CREATE` / `UPDATE` / `DELETE`) carries the affected record
+ * id and its value; a `KILLED` message signals that the live query was
+ * terminated server-side (for example when its table is removed) and carries
+ * no record. It is the final message a subscription emits.
+ */
+export type LiveMessage =
+    | {
+          queryId: Uuid;
+          action: Exclude<LiveAction, "KILLED">;
+          recordId: RecordId;
+          value: Record<string, unknown>;
+      }
+    | {
+          queryId: Uuid;
+          action: "KILLED";
+          recordId?: undefined;
+          value?: undefined;
+      };

--- a/packages/sdk/src/utils/live.ts
+++ b/packages/sdk/src/utils/live.ts
@@ -81,6 +81,7 @@ export class ManagedLiveSubscription extends LiveSubscription {
     #session: Session;
     #query: Query;
     #killed = false;
+    #serverKilled = false;
     #channels: Set<ChannelIterator<LiveMessage>> = new Set();
     #unsubscribe: () => void;
     #ready: Promise<void> = Promise.resolve();
@@ -134,7 +135,7 @@ export class ManagedLiveSubscription extends LiveSubscription {
         // Alive until permanent teardown: killed explicitly, the owning session
         // destroyed, or the connection closed for good. hasSession() stays true
         // across a transient reconnect, whose state is not cleared.
-        return !this.#killed && this.#controller.hasSession(this.#session);
+        return !this.#killed && !this.#serverKilled && this.#controller.hasSession(this.#session);
     }
 
     public async kill(): Promise<void> {
@@ -200,6 +201,20 @@ export class ManagedLiveSubscription extends LiveSubscription {
                 for (const channel of this.#channels) {
                     channel.submit(message);
                 }
+
+                // A server-side KILLED (e.g. the subscription's table was
+                // removed) is terminal: deliver it, stop tracking, and do not
+                // restart on reconnect. isAlive flips to false.
+                if (message.action === "KILLED") {
+                    this.#serverKilled = true;
+                    this.#unsubscribe();
+
+                    for (const channel of this.#channels) {
+                        channel.cancel();
+                    }
+
+                    return;
+                }
             }
         } catch (err: unknown) {
             this.#controller.propagateError(new LiveSubscriptionError(err));
@@ -217,6 +232,7 @@ export class UnmanagedLiveSubscription extends LiveSubscription {
     #controller: ConnectionController;
     #session: Session;
     #killed = false;
+    #serverKilled = false;
     #channels: Set<ChannelIterator<LiveMessage>> = new Set();
 
     constructor(controller: ConnectionController, session: Session, id: Uuid) {
@@ -235,6 +251,13 @@ export class UnmanagedLiveSubscription extends LiveSubscription {
             for await (const message of messageStream) {
                 for (const channel of this.#channels) {
                     channel.submit(message);
+                }
+
+                // A server-side KILLED is terminal: deliver it, then stop.
+                // isAlive flips to false.
+                if (message.action === "KILLED") {
+                    this.#serverKilled = true;
+                    break;
                 }
             }
 
@@ -260,7 +283,7 @@ export class UnmanagedLiveSubscription extends LiveSubscription {
         // Alive until permanent teardown: killed explicitly, the owning session
         // destroyed, or the connection closed for good. hasSession() stays true
         // across a transient reconnect, whose state is not cleared.
-        return !this.#killed && this.#controller.hasSession(this.#session);
+        return !this.#killed && !this.#serverKilled && this.#controller.hasSession(this.#session);
     }
 
     public async kill(): Promise<void> {

--- a/packages/tests/surrealdb/integration/query/live.test.ts
+++ b/packages/tests/surrealdb/integration/query/live.test.ts
@@ -6,12 +6,14 @@ import {
     type Person,
     personTable,
     proto,
+    requestVersion,
     respawnServer,
     SURREAL_BACKEND,
     SURREAL_PROTOCOL,
 } from "../__helpers__";
 
 const _isRemote = SURREAL_BACKEND === "remote";
+const { is3x } = await requestVersion();
 
 describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
     "live() / liveOf()",
@@ -287,30 +289,35 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
             expect(messages[2].action).toEqual("DELETE");
         });
 
-        test("removing the subscribed table delivers KILLED and ends the subscription", async () => {
-            const surreal = await createSurreal();
-            await insertMockRecords(surreal);
-            const subscription = await surreal.live(personTable);
-            const messages: LiveMessage[] = [];
+        // REMOVE TABLE terminates the live query with a KILLED notification on
+        // 3.x servers; 2.x does not emit one, so this is gated to 3.x.
+        test.skipIf(!is3x)(
+            "removing the subscribed table delivers KILLED and ends the subscription",
+            async () => {
+                const surreal = await createSurreal();
+                await insertMockRecords(surreal);
+                const subscription = await surreal.live(personTable);
+                const messages: LiveMessage[] = [];
 
-            expect(subscription.isAlive).toBeTrue();
+                expect(subscription.isAlive).toBeTrue();
 
-            (async () => {
-                await Bun.sleep(100);
-                // Removing the subscribed table terminates the live query
-                // server-side, which emits a KILLED notification.
-                await surreal.query("REMOVE TABLE person");
-            })();
+                (async () => {
+                    await Bun.sleep(100);
+                    // Removing the subscribed table terminates the live query
+                    // server-side, which emits a KILLED notification.
+                    await surreal.query("REMOVE TABLE person");
+                })();
 
-            for await (const message of subscription) {
-                messages.push(message);
-            }
+                for await (const message of subscription) {
+                    messages.push(message);
+                }
 
-            // The final message is the server-side KILLED (which carries no
-            // record), and the subscription is no longer alive afterwards.
-            expect(messages.at(-1)?.action).toEqual("KILLED");
-            expect(subscription.isAlive).toBeFalse();
-        });
+                // The final message is the server-side KILLED (which carries no
+                // record), and the subscription is no longer alive afterwards.
+                expect(messages.at(-1)?.action).toEqual("KILLED");
+                expect(subscription.isAlive).toBeFalse();
+            },
+        );
 
         test.todo("iterable survives reconnect", async () => {
             const surreal = await createSurreal({

--- a/packages/tests/surrealdb/integration/query/live.test.ts
+++ b/packages/tests/surrealdb/integration/query/live.test.ts
@@ -287,6 +287,31 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
             expect(messages[2].action).toEqual("DELETE");
         });
 
+        test("removing the subscribed table delivers KILLED and ends the subscription", async () => {
+            const surreal = await createSurreal();
+            await insertMockRecords(surreal);
+            const subscription = await surreal.live(personTable);
+            const messages: LiveMessage[] = [];
+
+            expect(subscription.isAlive).toBeTrue();
+
+            (async () => {
+                await Bun.sleep(100);
+                // Removing the subscribed table terminates the live query
+                // server-side, which emits a KILLED notification.
+                await surreal.query("REMOVE TABLE person");
+            })();
+
+            for await (const message of subscription) {
+                messages.push(message);
+            }
+
+            // The final message is the server-side KILLED (which carries no
+            // record), and the subscription is no longer alive afterwards.
+            expect(messages.at(-1)?.action).toEqual("KILLED");
+            expect(subscription.isAlive).toBeFalse();
+        });
+
         test.todo("iterable survives reconnect", async () => {
             const surreal = await createSurreal({
                 reconnect: {

--- a/packages/tests/surrealdb/unit/utilities/live-dispatcher.test.ts
+++ b/packages/tests/surrealdb/unit/utilities/live-dispatcher.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { LiveDispatcher, type LiveMessage, RecordId, Uuid } from "surrealdb";
 
-function message(action: LiveMessage["action"], value: unknown): LiveMessage {
+function message(action: Exclude<LiveMessage["action"], "KILLED">, value: unknown): LiveMessage {
     return {
         queryId: Uuid.v4(),
         action,
         recordId: new RecordId("thing", 1),
-        value: value as LiveMessage["value"],
+        value: value as Record<string, unknown>,
     };
 }
 

--- a/packages/wasm/src-ts/engine.ts
+++ b/packages/wasm/src-ts/engine.ts
@@ -25,8 +25,8 @@ import { wrapSqonError } from "./wrap-sqon-error";
 interface LivePayload {
     id: Uuid;
     action: LiveAction;
-    result: LiveMessage;
-    record: RecordId;
+    result?: Record<string, unknown>;
+    record?: RecordId;
 }
 
 /**
@@ -168,12 +168,17 @@ export class WebAssemblyEngine extends RpcEngine implements SurrealEngine {
                 );
 
                 if (payload.id) {
-                    this.#live.dispatch(payload.id.toString(), {
-                        queryId: payload.id,
-                        action: payload.action,
-                        recordId: payload.record,
-                        value: payload.result,
-                    });
+                    this.#live.dispatch(
+                        payload.id.toString(),
+                        payload.action === "KILLED"
+                            ? { queryId: payload.id, action: "KILLED" }
+                            : {
+                                  queryId: payload.id,
+                                  action: payload.action,
+                                  recordId: payload.record as RecordId,
+                                  value: payload.result as Record<string, unknown>,
+                              },
+                    );
                 }
             });
 


### PR DESCRIPTION
## Problem

When a live query is terminated server-side — for example by `REMOVE TABLE` on the subscribed table — the server emits a `KILLED` live notification. The WebSocket engine dropped it: `isLiveMessage` requires a `result` and a `record`, which a `KILLED` frame has neither of, so the guard failed and the frame fell through to the `error` event instead of reaching the subscription. As a result the subscriber never saw the termination, and `subscription.isAlive` stayed `true` even though the query was dead.

## Fix

- **`engine/websocket.ts`** — `isLiveMessage` now accepts a `KILLED` frame on `id` + `action` alone (record-change frames still require `record` + `result`), and the handler dispatches it as a `LiveMessage` instead of raising `UnexpectedServerResponseError`.
- **`utils/live.ts`** — on receiving a `KILLED` message a subscription delivers it to its consumers, flips `isAlive` to `false`, and ends the stream; a managed subscription also stops (it is not restarted on reconnect, since the query was terminated server-side).
- **`types/live.ts`** — `LiveMessage` becomes a discriminated union: `CREATE`/`UPDATE`/`DELETE` carry `recordId` + `value` as before, while `KILLED` carries neither. `KILLED` is the final message a subscription emits.

## Behavior

`KILLED` is now a real, delivered action. A `for await` loop over a subscription receives the `KILLED` message and then ends; `subscription.subscribe(fn)` sees it; and `isAlive` reflects the server-side termination.

## Tests

Adds an integration regression in `live.test.ts`: subscribing to a table, then `REMOVE TABLE` from the same connection, delivers a final `KILLED` message and flips `isAlive` to `false`. Verified green against a stock `surreal` 3.2.1 (full live-query file: 9 pass / 0 fail; the new test stable across repeated runs). The existing CREATE/UPDATE/DELETE/isAlive tests are unaffected.

## Note

Making `LiveMessage` a discriminated union is a type-level change: consumers that read `message.value` must now narrow on `action` (a `KILLED` message has no `value`). This surfaces a case that previously existed at runtime but was silently dropped, so it is a deliberate, correctness-motivated change — flagging it for the version-bump decision.
