### PR TITLE
fix(spectron): export request/response JSON types

### DIFF
--- a/packages/spectron/src/client.ts
+++ b/packages/spectron/src/client.ts
@@ -19,29 +19,30 @@ import type {
 } from "./types/domain.js";
 import type { components } from "./types/generated.js";
 
-type FactsResponseJson = components["schemas"]["FactsResponseJson"];
-type FactsBatchResponseJson = components["schemas"]["FactsBatchResponseJson"];
-type QueryMemoryResponseJson = components["schemas"]["QueryMemoryResponseJson"];
-type ChatResponseJson = components["schemas"]["ChatResponseJson"];
-type ForgetResponseJson = components["schemas"]["ForgetResponseJson"];
-type ContextQueryResponseJson = components["schemas"]["ContextQueryResponseJson"];
-type ReflectResponseJson = components["schemas"]["ReflectResponseJson"];
-type ConsolidateResponseJson = components["schemas"]["ConsolidateResponseJson"];
-type ElaborateResponseJson = components["schemas"]["ElaborateResponseJson"];
-type FsckReportJson = components["schemas"]["FsckReportJson"];
-type InspectResponseJson = components["schemas"]["InspectResponseJson"];
-type AuditResponseJson = components["schemas"]["AuditResponseJson"];
-type StateResponseJson = components["schemas"]["StateResponseJson"];
-type ProfileResponseJson = components["schemas"]["ProfileResponseJson"];
+export type FactsResponseJson = components["schemas"]["FactsResponseJson"];
+export type FactsBatchResponseJson = components["schemas"]["FactsBatchResponseJson"];
+export type QueryMemoryResponseJson = components["schemas"]["QueryMemoryResponseJson"];
+export type MemoryHitJson = components["schemas"]["MemoryHitJson"];
+export type ChatResponseJson = components["schemas"]["ChatResponseJson"];
+export type ForgetResponseJson = components["schemas"]["ForgetResponseJson"];
+export type ContextQueryResponseJson = components["schemas"]["ContextQueryResponseJson"];
+export type ReflectResponseJson = components["schemas"]["ReflectResponseJson"];
+export type ConsolidateResponseJson = components["schemas"]["ConsolidateResponseJson"];
+export type ElaborateResponseJson = components["schemas"]["ElaborateResponseJson"];
+export type FsckReportJson = components["schemas"]["FsckReportJson"];
+export type InspectResponseJson = components["schemas"]["InspectResponseJson"];
+export type AuditResponseJson = components["schemas"]["AuditResponseJson"];
+export type StateResponseJson = components["schemas"]["StateResponseJson"];
+export type ProfileResponseJson = components["schemas"]["ProfileResponseJson"];
 
 /**
  * The calling principal's identity and resolved authorisation for this context
  * (`GET /me`). Aliased to the generated OpenAPI `WhoamiJson` schema.
  */
 export type WhoamiResponseJson = components["schemas"]["WhoamiJson"];
-type Triple = components["schemas"]["Triple"];
-type BatchMessage = components["schemas"]["BatchMessage"];
-type GeoFilterJson = components["schemas"]["GeoFilterJson"];
+export type Triple = components["schemas"]["Triple"];
+export type BatchMessage = components["schemas"]["BatchMessage"];
+export type GeoFilterJson = components["schemas"]["GeoFilterJson"];
 
 /** Options for constructing a {@link Spectron} client. */
 export interface SpectronOptions {

--- a/packages/spectron/src/components/documents.ts
+++ b/packages/spectron/src/components/documents.ts
@@ -5,19 +5,19 @@ import type { Transport } from "../transport.js";
 import type { QueryMode, SpectronFileInput } from "../types/domain.js";
 import type { components } from "../types/generated.js";
 
-type DocumentJson = components["schemas"]["DocumentJson"];
-type DocumentPageJson = components["schemas"]["DocumentPageJson"];
-type ChunkPageJson = components["schemas"]["ChunkPageJson"];
-type UploadResponse = components["schemas"]["UploadResponse"];
-type QueryRequestJson = components["schemas"]["QueryRequestJson"];
-type QueryResponseJson = components["schemas"]["QueryResponseJson"];
-type KeywordPageJson = components["schemas"]["KeywordPageJson"];
-type KeywordSearchResponseJson = components["schemas"]["KeywordSearchResponseJson"];
-type KeywordSearchRequestJson = components["schemas"]["KeywordSearchRequestJson"];
-type KeywordDetailJson = components["schemas"]["KeywordDetailJson"];
-type DocumentKeywordsResponse = components["schemas"]["DocumentKeywordsResponse"];
-type DocumentKeywordJson = components["schemas"]["DocumentKeywordJson"];
-type RecomputeLinksResponse = components["schemas"]["RecomputeLinksResponse"];
+export type DocumentJson = components["schemas"]["DocumentJson"];
+export type DocumentPageJson = components["schemas"]["DocumentPageJson"];
+export type ChunkPageJson = components["schemas"]["ChunkPageJson"];
+export type UploadResponse = components["schemas"]["UploadResponse"];
+export type QueryRequestJson = components["schemas"]["QueryRequestJson"];
+export type QueryResponseJson = components["schemas"]["QueryResponseJson"];
+export type KeywordPageJson = components["schemas"]["KeywordPageJson"];
+export type KeywordSearchResponseJson = components["schemas"]["KeywordSearchResponseJson"];
+export type KeywordSearchRequestJson = components["schemas"]["KeywordSearchRequestJson"];
+export type KeywordDetailJson = components["schemas"]["KeywordDetailJson"];
+export type DocumentKeywordsResponse = components["schemas"]["DocumentKeywordsResponse"];
+export type DocumentKeywordJson = components["schemas"]["DocumentKeywordJson"];
+export type RecomputeLinksResponse = components["schemas"]["RecomputeLinksResponse"];
 
 /** Options shared by document upload and reprocess. */
 export interface DocumentUploadOptions {

--- a/packages/spectron/src/components/entities.ts
+++ b/packages/spectron/src/components/entities.ts
@@ -2,11 +2,11 @@ import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
 
-type EntityDetailJson = components["schemas"]["EntityDetailJson"];
-type EntityListResponseJson = components["schemas"]["EntityListResponseJson"];
-type EntityResponseJson = components["schemas"]["EntityResponseJson"];
-type EntityHistoryResponseJson = components["schemas"]["EntityHistoryResponseJson"];
-type AttributeDetailJson = components["schemas"]["AttributeDetailJson"];
+export type EntityDetailJson = components["schemas"]["EntityDetailJson"];
+export type EntityListResponseJson = components["schemas"]["EntityListResponseJson"];
+export type EntityResponseJson = components["schemas"]["EntityResponseJson"];
+export type EntityHistoryResponseJson = components["schemas"]["EntityHistoryResponseJson"];
+export type AttributeDetailJson = components["schemas"]["AttributeDetailJson"];
 
 /** Entity records, attributes, relations, and attribute history. */
 export class Entities {

--- a/packages/spectron/src/components/lifecycle.ts
+++ b/packages/spectron/src/components/lifecycle.ts
@@ -2,7 +2,7 @@ import { getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
 
-type LifecycleResponseJson = components["schemas"]["LifecycleResponseJson"];
+export type LifecycleResponseJson = components["schemas"]["LifecycleResponseJson"];
 
 /** Operator lifecycle sweeps (expiry and decay). */
 export class Lifecycle {

--- a/packages/spectron/src/components/principals.ts
+++ b/packages/spectron/src/components/principals.ts
@@ -3,8 +3,8 @@ import type { Transport } from "../transport.js";
 import type { Verb } from "../types/domain.js";
 import type { components } from "../types/generated.js";
 
-type PrincipalJson = components["schemas"]["PrincipalJson"];
-type EffectiveGrantsJson = components["schemas"]["EffectiveGrantsJson"];
+export type PrincipalJson = components["schemas"]["PrincipalJson"];
+export type EffectiveGrantsJson = components["schemas"]["EffectiveGrantsJson"];
 
 /** Principals and their scope grants (requires the `manage` grant). */
 export class Principals {

--- a/packages/spectron/src/components/scopes.ts
+++ b/packages/spectron/src/components/scopes.ts
@@ -2,8 +2,8 @@ import { getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
 
-type ScopeNodeJson = components["schemas"]["ScopeNodeJson"];
-type ForgetScopeResponseJson = components["schemas"]["ForgetScopeResponseJson"];
+export type ScopeNodeJson = components["schemas"]["ScopeNodeJson"];
+export type ForgetScopeResponseJson = components["schemas"]["ForgetScopeResponseJson"];
 
 /** The scope tree: register, list, delete, and forget scope subtrees. */
 export class Scopes {

--- a/packages/spectron/src/components/sessions.ts
+++ b/packages/spectron/src/components/sessions.ts
@@ -3,10 +3,10 @@ import { normaliseScope, type Scope } from "../scope.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
 
-type SessionResponseJson = components["schemas"]["SessionResponseJson"];
-type SessionContextResponseJson = components["schemas"]["SessionContextResponseJson"];
-type TurnListResponseJson = components["schemas"]["TurnListResponseJson"];
-type TurnResponseJson = components["schemas"]["TurnResponseJson"];
+export type SessionResponseJson = components["schemas"]["SessionResponseJson"];
+export type SessionContextResponseJson = components["schemas"]["SessionContextResponseJson"];
+export type TurnListResponseJson = components["schemas"]["TurnListResponseJson"];
+export type TurnResponseJson = components["schemas"]["TurnResponseJson"];
 
 /** An open conversation session within a Spectron context. */
 export class Session {

--- a/packages/spectron/src/components/traces.ts
+++ b/packages/spectron/src/components/traces.ts
@@ -2,9 +2,9 @@ import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
 
-type TraceListResponseJson = components["schemas"]["TraceListResponseJson"];
-type TraceRecordJson = components["schemas"]["TraceRecordJson"];
-type TraceStatsResponseJson = components["schemas"]["TraceStatsResponseJson"];
+export type TraceListResponseJson = components["schemas"]["TraceListResponseJson"];
+export type TraceRecordJson = components["schemas"]["TraceRecordJson"];
+export type TraceStatsResponseJson = components["schemas"]["TraceStatsResponseJson"];
 
 /** Retrieval decision traces for a context. */
 export class Traces {

--- a/packages/spectron/src/index.ts
+++ b/packages/spectron/src/index.ts
@@ -1,20 +1,78 @@
 export {
+    type AuditResponseJson,
+    type BatchMessage,
     type ChatOptions,
+    type ChatResponseJson,
+    type ConsolidateResponseJson,
+    type ContextQueryResponseJson,
+    type ElaborateResponseJson,
+    type FactsBatchResponseJson,
+    type FactsResponseJson,
+    type ForgetResponseJson,
+    type FsckReportJson,
+    type GeoFilterJson,
+    type InspectResponseJson,
+    type MemoryHitJson,
+    type ProfileResponseJson,
+    type QueryMemoryResponseJson,
     type RecallOptions,
+    type ReflectResponseJson,
     type RememberManyOptions,
     type RememberOptions,
     Spectron,
     type SpectronOptions,
+    type StateResponseJson,
+    type Triple,
     type WhoamiResponseJson,
 } from "./client.js";
-export { DocumentKeywords, Documents, type DocumentUploadOptions } from "./components/documents.js";
-export { Entities } from "./components/entities.js";
+export {
+    type ChunkPageJson,
+    DocumentKeywords,
+    Documents,
+    type DocumentJson,
+    type DocumentKeywordJson,
+    type DocumentKeywordsResponse,
+    type DocumentPageJson,
+    type DocumentUploadOptions,
+    type KeywordDetailJson,
+    type KeywordPageJson,
+    type KeywordSearchRequestJson,
+    type KeywordSearchResponseJson,
+    type QueryRequestJson,
+    type QueryResponseJson,
+    type RecomputeLinksResponse,
+    type UploadResponse,
+} from "./components/documents.js";
+export {
+    type AttributeDetailJson,
+    Entities,
+    type EntityDetailJson,
+    type EntityHistoryResponseJson,
+    type EntityListResponseJson,
+    type EntityResponseJson,
+} from "./components/entities.js";
 export { type KeyDetailJson, Keys, type MintedKeyJson } from "./components/keys.js";
-export { Lifecycle } from "./components/lifecycle.js";
-export { Principals } from "./components/principals.js";
-export { Scopes } from "./components/scopes.js";
-export { Session, Sessions } from "./components/sessions.js";
-export { Traces } from "./components/traces.js";
+export { Lifecycle, type LifecycleResponseJson } from "./components/lifecycle.js";
+export {
+    type EffectiveGrantsJson,
+    Principals,
+    type PrincipalJson,
+} from "./components/principals.js";
+export { type ForgetScopeResponseJson, Scopes, type ScopeNodeJson } from "./components/scopes.js";
+export {
+    Session,
+    type SessionContextResponseJson,
+    type SessionResponseJson,
+    Sessions,
+    type TurnListResponseJson,
+    type TurnResponseJson,
+} from "./components/sessions.js";
+export {
+    Traces,
+    type TraceListResponseJson,
+    type TraceRecordJson,
+    type TraceStatsResponseJson,
+} from "./components/traces.js";
 export {
     AuthError,
     ConnectionError,

--- a/packages/spectron/src/index.ts
+++ b/packages/spectron/src/index.ts
@@ -27,12 +27,12 @@ export {
 } from "./client.js";
 export {
     type ChunkPageJson,
-    DocumentKeywords,
-    Documents,
     type DocumentJson,
     type DocumentKeywordJson,
+    DocumentKeywords,
     type DocumentKeywordsResponse,
     type DocumentPageJson,
+    Documents,
     type DocumentUploadOptions,
     type KeywordDetailJson,
     type KeywordPageJson,
@@ -55,10 +55,10 @@ export { type KeyDetailJson, Keys, type MintedKeyJson } from "./components/keys.
 export { Lifecycle, type LifecycleResponseJson } from "./components/lifecycle.js";
 export {
     type EffectiveGrantsJson,
-    Principals,
     type PrincipalJson,
+    Principals,
 } from "./components/principals.js";
-export { type ForgetScopeResponseJson, Scopes, type ScopeNodeJson } from "./components/scopes.js";
+export { type ForgetScopeResponseJson, type ScopeNodeJson, Scopes } from "./components/scopes.js";
 export {
     Session,
     type SessionContextResponseJson,
@@ -68,10 +68,10 @@ export {
     type TurnResponseJson,
 } from "./components/sessions.js";
 export {
-    Traces,
     type TraceListResponseJson,
     type TraceRecordJson,
     type TraceStatsResponseJson,
+    Traces,
 } from "./components/traces.js";
 export {
     AuthError,


### PR DESCRIPTION
## Summary
- Exports all request/response JSON type aliases (`BatchMessage`, `MemoryHitJson`, `FactsResponseJson`, and many others across `client.ts` and `components/*.ts`) from the `@surrealdb/spectron` package root, so consumers can import them directly instead of deriving them via `Parameters<Spectron[...]>[0][number]` gymnastics.
- Adds a `MemoryHitJson` alias (was previously only reachable as a nested field type on `QueryMemoryResponseJson`).

Addresses: https://surrealdb.slack.com/archives/C0916KVBP1Q/p1784645577422139

## Test plan
- [x] `bun run build:spectron` — package builds and `.d.ts` includes the new exports
- [x] `bun run test:spectron` — 37 pass, 1 skip, 0 fail