### PR TITLE
chore(spectron): bump version to 1.0.0-alpha.6

### DIFF
--- a/packages/spectron/package.json
+++ b/packages/spectron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@surrealdb/spectron",
-    "version": "1.0.0-alpha.5",
+    "version": "1.0.0-alpha.6",
     "type": "module",
     "license": "Apache-2.0",
     "description": "The official Spectron client for JavaScript.",


### PR DESCRIPTION
## Summary
Patch release of `@surrealdb/spectron`, bumping `1.0.0-alpha.5` → `1.0.0-alpha.6`.

Ships the request/response JSON type exports merged in #652, which lets consumers import the type aliases (`BatchMessage`, `MemoryHitJson`, `FactsResponseJson`, etc.) directly from the package root.

## Test plan
- [x] `validate:versions` passes (spectron is standalone; no cross-package version constraints affected)