### PR TITLE
Support cancelling and observing document uploads

### DIFF
--- a/packages/spectron/src/components/documents.ts
+++ b/packages/spectron/src/components/documents.ts
@@ -1,7 +1,7 @@
 import { spectronFileInputToBlob } from "../file-body.js";
 import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import { normaliseScope, type Scope } from "../scope.js";
-import type { Transport } from "../transport.js";
+import type { Transport, UploadProgressListener } from "../transport.js";
 import type { QueryMode, SpectronFileInput } from "../types/domain.js";
 import type { components } from "../types/generated.js";
 
@@ -35,6 +35,27 @@ export interface DocumentUploadOptions {
     scopes?: Scope;
     /** Descriptive `key=value` labels stamped onto the document and its chunks. */
     labels?: string[];
+    /**
+     * Aborts the upload. Rejects with `CancelledError`, which is deliberately
+     * distinct from a timeout or a transport failure.
+     */
+    signal?: AbortSignal;
+    /**
+     * Observes the request body being sent, so a large upload can show real
+     * progress instead of an indefinite spinner.
+     *
+     * Supplying this switches the request onto `XMLHttpRequest`, the only browser
+     * API that reports request-body progress. Without it the upload takes the
+     * regular `fetch` path.
+     */
+    onUploadProgress?: UploadProgressListener;
+    /**
+     * Deadline for the upload, in milliseconds.
+     *
+     * Multipart sends have no deadline by default, because a large body can
+     * legitimately take longer than any fixed one. Pass a value to bound it.
+     */
+    timeoutMs?: number;
 }
 
 async function buildUploadForm(options: DocumentUploadOptions): Promise<FormData> {
@@ -60,6 +81,15 @@ async function buildUploadForm(options: DocumentUploadOptions): Promise<FormData
             : "upload");
     form.append("file", blob, name);
     return form;
+}
+
+/** The per-request transport options an upload forwards from its own options. */
+function sendOptions(options: DocumentUploadOptions) {
+    return {
+        signal: options.signal,
+        onUploadProgress: options.onUploadProgress,
+        timeoutMs: options.timeoutMs,
+    };
 }
 
 /** Keyword graph helpers for the document corpus. */
@@ -145,7 +175,10 @@ export class Documents {
     /** Uploads a document (multipart). Returns the ingestion handle. */
     async upload(options: DocumentUploadOptions): Promise<UploadResponse> {
         const form = await buildUploadForm(options);
-        const body = await this.transport.requestJson("POST", this.base, { body: form });
+        const body = await this.transport.requestJson("POST", this.base, {
+            body: form,
+            ...sendOptions(options),
+        });
         return body as UploadResponse;
     }
 
@@ -153,7 +186,10 @@ export class Documents {
     async reprocess(documentId: string, options: DocumentUploadOptions): Promise<UploadResponse> {
         const form = await buildUploadForm(options);
         const path = `${this.base}/${encodePathSegment(documentId)}`;
-        const body = await this.transport.requestJson("PUT", path, { body: form });
+        const body = await this.transport.requestJson("PUT", path, {
+            body: form,
+            ...sendOptions(options),
+        });
         if (body === null) {
             return { id: documentId, status: "queued", contentHash: "", deduplicated: false };
         }
@@ -170,10 +206,14 @@ export class Documents {
     }
 
     /** Raw document bytes. */
-    async raw(documentId: string): Promise<ArrayBuffer> {
+    async raw(documentId: string, options?: { timeoutMs?: number }): Promise<ArrayBuffer> {
         return this.transport.requestBytes(
             "GET",
             `${this.base}/${encodePathSegment(documentId)}/raw`,
+            // Downloading a document's bytes is bounded by its size rather than by
+            // a round trip, so a large one legitimately outlasts the default
+            // deadline. Callers that expect that can raise it.
+            options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : undefined,
         );
     }
 

--- a/packages/spectron/src/errors.ts
+++ b/packages/spectron/src/errors.ts
@@ -87,6 +87,17 @@ export class ConnectionError extends SpectronError {
     override readonly name: string = "ConnectionError";
 }
 
+/**
+ * The caller aborted the request through the `signal` they supplied (status 0).
+ *
+ * Distinct from {@link ConnectionError} so a deliberate cancellation can be told
+ * apart from a timeout or a network failure: only the latter two describe
+ * something that went wrong, and only they are worth reporting to a user.
+ */
+export class CancelledError extends SpectronError {
+    override readonly name: string = "CancelledError";
+}
+
 type ErrorCtor = new (
     args: ConstructorParameters<typeof SpectronError>[0],
 ) => InstanceType<typeof SpectronError>;

--- a/packages/spectron/src/index.ts
+++ b/packages/spectron/src/index.ts
@@ -75,6 +75,7 @@ export {
 } from "./components/traces.js";
 export {
     AuthError,
+    CancelledError,
     ConnectionError,
     errorFromResponse,
     NotFoundError,

--- a/packages/spectron/src/transport.ts
+++ b/packages/spectron/src/transport.ts
@@ -1,9 +1,20 @@
-import { ConnectionError, errorFromResponse } from "./errors.js";
+import { CancelledError, ConnectionError, errorFromResponse } from "./errors.js";
 import { idempotencyKey } from "./idempotency.js";
 import { backoffSchedule, shouldRetry } from "./retry.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 3;
+
+/** Progress of a request body being sent, reported while an upload is in flight. */
+export interface UploadProgress {
+    /** Bytes handed to the network so far. */
+    loaded: number;
+    /** Total bytes to send, when the environment can determine it. */
+    total?: number;
+}
+
+/** Reports upload progress. Called repeatedly while the request body is sent. */
+export type UploadProgressListener = (progress: UploadProgress) => void;
 
 export interface TransportOptions {
     /** API endpoint origin without trailing slash. */
@@ -45,6 +56,104 @@ function decodeBody(text: string): unknown {
 
 function sleep(ms: number): Promise<void> {
     return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Combines a caller's abort signal with an internal one.
+ *
+ * The internal signal carries the request timeout, so it cannot simply be
+ * replaced by the caller's — both have to be able to abort the request.
+ *
+ * @returns A cleanup function that detaches the forwarding listener.
+ */
+function forwardAbort(from: AbortSignal | undefined, to: AbortController): () => void {
+    if (!from) return () => {};
+
+    if (from.aborted) {
+        to.abort();
+        return () => {};
+    }
+
+    const onAbort = () => to.abort();
+    from.addEventListener("abort", onAbort, { once: true });
+
+    return () => from.removeEventListener("abort", onAbort);
+}
+
+/**
+ * Sends a multipart body with `XMLHttpRequest` so its progress can be observed.
+ *
+ * `fetch` cannot report how much of a request body has been sent in any browser,
+ * which leaves a large upload indistinguishable from a stalled one. This path is
+ * used only when a caller asks for progress; everything else stays on `fetch`.
+ */
+function sendWithProgress(options: {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body: FormData;
+    signal: AbortSignal;
+    onProgress: UploadProgressListener;
+}): Promise<{ status: number; text: string; headers: Headers }> {
+    const { url, method, headers, body, signal, onProgress } = options;
+
+    return new Promise((resolve, reject) => {
+        const request = new XMLHttpRequest();
+        request.open(method, url, true);
+
+        for (const [name, value] of Object.entries(headers)) {
+            request.setRequestHeader(name, value);
+        }
+
+        request.upload.addEventListener("progress", (event) => {
+            onProgress({
+                loaded: event.loaded,
+                total: event.lengthComputable ? event.total : undefined,
+            });
+        });
+
+        request.addEventListener("load", () => {
+            resolve({
+                status: request.status,
+                text: request.responseText,
+                // `XMLHttpRequest` exposes headers as one CRLF-delimited string.
+                headers: parseRawHeaders(request.getAllResponseHeaders()),
+            });
+        });
+
+        request.addEventListener("error", () => reject(new TypeError("Network request failed")));
+
+        // Both aborts land here, so the caller's cancellation and the timeout are
+        // told apart by the caller's own signal rather than by the event.
+        request.addEventListener("abort", () => {
+            const error = new Error("Request aborted");
+            error.name = "AbortError";
+            reject(error);
+        });
+
+        const onAbort = () => request.abort();
+
+        if (signal.aborted) {
+            request.abort();
+        } else {
+            signal.addEventListener("abort", onAbort, { once: true });
+        }
+
+        request.addEventListener("loadend", () => signal.removeEventListener("abort", onAbort));
+        request.send(body);
+    });
+}
+
+function parseRawHeaders(raw: string): Headers {
+    const headers = new Headers();
+
+    for (const line of raw.trim().split(/[\r\n]+/)) {
+        const separator = line.indexOf(":");
+        if (separator === -1) continue;
+        headers.append(line.slice(0, separator).trim(), line.slice(separator + 1).trim());
+    }
+
+    return headers;
 }
 
 /**
@@ -117,6 +226,10 @@ export class Transport {
             body?: unknown;
             timeoutMs?: number;
             idempotent?: boolean;
+            /** Aborts the request. Rejects with {@link CancelledError}. */
+            signal?: AbortSignal;
+            /** Observes a multipart body being sent. Ignored for JSON bodies. */
+            onUploadProgress?: UploadProgressListener;
         },
     ): Promise<unknown | null> {
         const methodUpper = method.toUpperCase();
@@ -153,9 +266,26 @@ export class Transport {
             headerObj["Idempotency-Key"] = await idempotencyKey(methodUpper, path, serialisedBody);
         }
 
+        // Already cancelled before it began, so there is nothing worth sending.
+        if (init?.signal?.aborted) {
+            throw new CancelledError({
+                status: 0,
+                title: "Request cancelled",
+                detail: "The signal was already aborted",
+            });
+        }
+
+        // Progress can only be observed through `XMLHttpRequest`, so it is used
+        // for a multipart body when — and only when — a caller asks to observe one.
+        const withProgress =
+            isMultipart &&
+            init?.onUploadProgress !== undefined &&
+            typeof XMLHttpRequest !== "undefined";
+
         let attempt = 0;
         for (;;) {
             const controller = new AbortController();
+            const detachAbort = forwardAbort(init?.signal, controller);
             const timer =
                 timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
             const headersForFetch: HeadersInit = { ...headerObj };
@@ -165,14 +295,30 @@ export class Transport {
             }
 
             try {
-                const response = await this.fetchImpl(url, {
-                    method: methodUpper,
-                    headers: headersForFetch,
-                    body: methodUpper === "GET" || methodUpper === "HEAD" ? undefined : body,
-                    signal: controller.signal,
-                });
+                const response = withProgress
+                    ? await sendWithProgress({
+                          url,
+                          method: methodUpper,
+                          headers: headersForFetch as Record<string, string>,
+                          body: body as FormData,
+                          signal: controller.signal,
+                          // biome-ignore lint/style/noNonNullAssertion: guarded by `withProgress`.
+                          onProgress: init!.onUploadProgress!,
+                      }).then(({ status, text, headers }) => ({
+                          status,
+                          ok: status >= 200 && status < 300,
+                          headers,
+                          text: () => Promise.resolve(text),
+                      }))
+                    : await this.fetchImpl(url, {
+                          method: methodUpper,
+                          headers: headersForFetch,
+                          body: methodUpper === "GET" || methodUpper === "HEAD" ? undefined : body,
+                          signal: controller.signal,
+                      });
 
                 clearTimeout(timer);
+                detachAbort();
 
                 if (
                     response.status >= 400 &&
@@ -201,7 +347,19 @@ export class Transport {
                 return decodeBody(text);
             } catch (e) {
                 clearTimeout(timer);
+                detachAbort();
                 if (e instanceof Error && e.name === "AbortError") {
+                    // A caller's cancellation is not a failure, and must never be
+                    // retried: the request it would retry is the one being abandoned.
+                    if (init?.signal?.aborted) {
+                        throw new CancelledError({
+                            status: 0,
+                            title: "Request cancelled",
+                            detail: "The request was aborted by the caller",
+                            cause: e,
+                        });
+                    }
+
                     throw new ConnectionError({
                         status: 0,
                         title: "Request timed out",

--- a/packages/tests/spectron/unit/documents.test.ts
+++ b/packages/tests/spectron/unit/documents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { Spectron } from "@surrealdb/spectron";
+import { CancelledError, ConnectionError, Spectron } from "@surrealdb/spectron";
 
 function client(fetchImpl: unknown): Spectron {
     return new Spectron({
@@ -72,6 +72,42 @@ describe("documents.upload", () => {
         await s.documents.upload({ file: new Uint8Array([9]) });
         expect(body?.get("metadata")).toBeNull();
         expect(body?.get("file")).toBeInstanceOf(Blob);
+    });
+
+    // A fetch impl that never settles until its signal fires.
+    const stalledFetch = () =>
+        mock((_u: string | URL, init?: RequestInit) => {
+            return new Promise<Response>((_resolve, reject) => {
+                init?.signal?.addEventListener("abort", () =>
+                    reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+                );
+            });
+        });
+
+    test("forwards a caller's abort signal", async () => {
+        // A large upload is otherwise unstoppable: multipart sends carry no
+        // deadline, so without this the request runs until the network gives up.
+        const s = client(stalledFetch());
+        const controller = new AbortController();
+
+        const pending = s.documents.upload({
+            file: new Uint8Array([9]),
+            signal: controller.signal,
+        });
+        controller.abort();
+
+        await expect(pending).rejects.toBeInstanceOf(CancelledError);
+    });
+
+    test("bounds an upload when given an explicit timeout", async () => {
+        const s = client(stalledFetch());
+
+        const error = await s.documents
+            .upload({ file: new Uint8Array([9]), timeoutMs: 5 })
+            .catch((e) => e);
+
+        expect(error).toBeInstanceOf(ConnectionError);
+        expect(error).not.toBeInstanceOf(CancelledError);
     });
 });
 

--- a/packages/tests/spectron/unit/transport.test.ts
+++ b/packages/tests/spectron/unit/transport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { ConnectionError, ServerError, Transport } from "@surrealdb/spectron";
+import { CancelledError, ConnectionError, ServerError, Transport } from "@surrealdb/spectron";
 
 describe("Transport", () => {
     test("sends Authorization bearer and user-agent on JSON POST", async () => {
@@ -145,5 +145,107 @@ describe("Transport", () => {
         await expect(t.requestJson("POST", "/x", { body: { a: 1 } })).rejects.toBeInstanceOf(
             ConnectionError,
         );
+    });
+
+    test("a caller's signal cancels a multipart send", async () => {
+        const t = new Transport({
+            apiKey: "k",
+            endpoint: "https://example.test",
+            maxRetries: 0,
+            fetchImpl: slowFetch(100) as unknown as typeof fetch,
+        });
+        const controller = new AbortController();
+        const form = new FormData();
+        form.append("file", new Blob(["data"]), "f.bin");
+
+        const pending = t.requestJson("POST", "/documents", {
+            body: form,
+            signal: controller.signal,
+        });
+        controller.abort();
+
+        await expect(pending).rejects.toBeInstanceOf(CancelledError);
+    });
+
+    test("cancellation is reported apart from a timeout", async () => {
+        // Both arrive as an AbortError, so they can only be told apart by whose
+        // signal fired. Only a timeout describes something that went wrong.
+        const t = new Transport({
+            apiKey: "k",
+            endpoint: "https://example.test",
+            timeoutMs: 5,
+            maxRetries: 0,
+            fetchImpl: slowFetch(50) as unknown as typeof fetch,
+        });
+
+        const error = await t.requestJson("POST", "/x", { body: { a: 1 } }).catch((e) => e);
+
+        expect(error).toBeInstanceOf(ConnectionError);
+        expect(error).not.toBeInstanceOf(CancelledError);
+    });
+
+    test("an already-aborted signal cancels before the request is sent", async () => {
+        const fetchImpl = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+        const t = new Transport({
+            apiKey: "k",
+            endpoint: "https://example.test",
+            maxRetries: 0,
+            fetchImpl: fetchImpl as unknown as typeof fetch,
+        });
+
+        await expect(
+            t.requestJson("GET", "/x", { signal: AbortSignal.abort() }),
+        ).rejects.toBeInstanceOf(CancelledError);
+    });
+
+    test("a cancelled request is not retried", async () => {
+        // `shouldRetry` treats a null status as a transport failure worth retrying,
+        // so without the cancellation branch an aborted GET would be re-sent.
+        let calls = 0;
+        const fetchImpl = mock((_url: string | URL, init?: RequestInit) => {
+            calls += 1;
+            return new Promise<Response>((_resolve, reject) => {
+                init?.signal?.addEventListener("abort", () =>
+                    reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+                );
+            });
+        });
+        const t = new Transport({
+            apiKey: "k",
+            endpoint: "https://example.test",
+            maxRetries: 3,
+            fetchImpl: fetchImpl as unknown as typeof fetch,
+        });
+        const controller = new AbortController();
+
+        const pending = t.requestJson("GET", "/x", { signal: controller.signal });
+        controller.abort();
+
+        await expect(pending).rejects.toBeInstanceOf(CancelledError);
+        expect(calls).toBe(1);
+    });
+
+    test("a multipart send without a progress listener stays on fetch", async () => {
+        // The `XMLHttpRequest` path exists only to report progress; every other
+        // request keeps the transport's regular behaviour.
+        const fetchImpl = mock(() =>
+            Promise.resolve(
+                new Response(JSON.stringify({ id: "d1" }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            ),
+        );
+        const t = new Transport({
+            apiKey: "k",
+            endpoint: "https://example.test",
+            fetchImpl: fetchImpl as unknown as typeof fetch,
+        });
+        const form = new FormData();
+        form.append("file", new Blob(["data"]), "f.bin");
+
+        await t.requestJson("POST", "/documents", { body: form });
+
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Why

Multipart sends are deliberately given no deadline — a large body can legitimately outlast any fixed one — but that left a document upload with no way to stop it and no way to see it. A stalled request ran until the network gave up, and a caller could not tell it apart from one still making progress.

## What

`documents.upload()` and `documents.reprocess()` take three new options:

| Option | Purpose |
| --- | --- |
| `signal` | Aborts the upload. Composed with the internal timeout controller so both can cancel the request. |
| `onUploadProgress` | Reports `{ loaded, total? }` as the body is sent. |
| `timeoutMs` | Bounds a send explicitly. The no-deadline default is unchanged. |

`documents.raw()` also takes `timeoutMs`: downloading a document is bounded by its size rather than by a round trip, so the 30s default fails on large files.

### Cancellation is not a failure

A caller's abort rejects with a new `CancelledError` rather than the timeout's `ConnectionError`. Both arrive as an `AbortError`, so they are told apart by whose signal fired. This matters twice over:

- Consumers can distinguish "the user stopped this" from "this went wrong", and only report the latter.
- A cancelled request is never retried. `shouldRetry` treats a null status as a transport failure worth repeating, so without this an aborted request was re-sent — the very request being abandoned.

An already-aborted signal short-circuits before anything is sent, rather than relying on the transport to reject it.

### Progress needs XMLHttpRequest

`fetch` cannot observe a request body in any browser. Supplying `onUploadProgress` therefore routes that one send through `XMLHttpRequest`; every other request, including a multipart send without a progress listener, keeps the existing `fetch` path untouched. Header construction and `errorFromResponse` are shared between the two, so error shapes are identical either way.

## Tests

Nine new cases across `transport.test.ts` and `documents.test.ts`, covering: a signal cancelling a multipart send; cancellation reported apart from a timeout; an already-aborted signal; a cancelled request not being retried; and a multipart send without a listener staying on `fetch`.

`bun test packages/tests/spectron/unit` — 44 pass, 0 fail.

## Notes

No version bump here, since releases are their own PR in this repo. This needs publishing before consumers can pick the options up.