### PR TITLE
WebSocket query streaming for JavaScript

### DIFF
--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -9,6 +9,7 @@ import {
 } from "../errors";
 import { parseRpcError } from "../internal/parse-error";
 import {
+    type Abandonment,
     isQueryStreamFrame,
     type QueryStreamFrame,
     queryStreamChunks,
@@ -189,6 +190,10 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         this.#terminated = true;
         this.#socket?.close();
 
+        // No socket is coming now, so the streams waiting for one are settled here rather than
+        // when the reconnect cooldown they are waiting through happens to elapse.
+        this.failStreams(new CallTerminatedError());
+
         if (socketState === WebSocketImpl.OPEN || socketState === WebSocketImpl.CLOSING) {
             await this.#publisher.subscribeFirst("disconnected");
         } else {
@@ -240,7 +245,7 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         });
     }
 
-    override async *query<T>(
+    override query<T>(
         query: BoundQuery,
         session: Session,
         txn?: Uuid,
@@ -258,16 +263,52 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
             this._context.options.streaming === false ||
             !this.#socket
         ) {
-            yield* super.query<T>(query, session, txn);
-            return;
+            return super.query<T>(query, session, txn);
         }
 
+        // The frames are kept to hand so that leaving the chunks can act on them at once. An
+        // async generator defers a `return` until its body next wakes, and this body can be
+        // parked on a frame which is not coming - a consumer racing a read against a timeout
+        // would otherwise never be let go.
+        const frames: { current?: AsyncIterableIterator<QueryStreamFrame> } = {};
+        const abandonment: Abandonment = {};
+        const chunks = this.streamChunks<T>(query, session, txn, frames, abandonment);
+
+        return {
+            [Symbol.asyncIterator]: () => ({
+                next: () => chunks.next(),
+                throw: (error?: unknown) => chunks.throw(error),
+                return: (value?: QueryChunk<T>) => {
+                    // Recorded before the frames are closed, so that running out of them is read
+                    // as the consumer leaving rather than as a truncated answer.
+                    abandonment.requested = true;
+                    frames.current?.return?.(undefined);
+                    return chunks.return(value as QueryChunk<T>);
+                },
+                [Symbol.asyncIterator]() {
+                    return this;
+                },
+            }),
+        };
+    }
+
+    /**
+     * Streams a query, falling back to the buffered method if the server refuses it.
+     */
+    private async *streamChunks<T>(
+        query: BoundQuery,
+        session: Session,
+        txn: Uuid | undefined,
+        frames: { current?: AsyncIterableIterator<QueryStreamFrame> },
+        abandonment: Abandonment,
+    ): AsyncGenerator<QueryChunk<T>> {
         const probe: StreamProbe = { framed: false };
 
+        // Opened here rather than by `query`, so nothing is sent until the caller reads.
+        frames.current = this.streamFrames(query, session, probe);
+
         try {
-            for await (const chunk of queryStreamChunks<T>(
-                this.streamFrames(query, session, probe),
-            )) {
+            for await (const chunk of queryStreamChunks<T>(frames.current, abandonment)) {
                 yield chunk;
             }
         } catch (error) {
@@ -285,7 +326,9 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                 this.#streaming = false;
             }
 
-            yield* super.query<T>(query, session, txn);
+            for await (const chunk of super.query<T>(query, session, txn)) {
+                yield chunk;
+            }
         }
     }
 
@@ -641,7 +684,7 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
  * re-sent, because the second request would have to be started from a stream whose consumer may
  * be walking away at that very moment, leaving its rejection with nowhere to go.
  */
-function isRetriableAsBuffered(error: unknown): boolean {
+function isRetriableAsBuffered(error: unknown): error is ServerError {
     return error instanceof ServerError;
 }
 

--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -45,10 +45,14 @@ interface Call<T> {
  */
 interface Stream {
     channel: ChannelIterator<StreamEvent>;
+    /** The request which opened it, re-sent if a socket returns before it framed anything. */
+    request: object;
     /** Whether the terminal frame, or a failure standing in for it, has arrived. */
     settled: boolean;
     /** Whether the consumer stopped reading, leaving remaining frames to discard. */
     abandoned: boolean;
+    /** Whether any frame has been delivered, which is what makes a replay unsafe. */
+    probe: StreamProbe;
 }
 
 /**
@@ -129,10 +133,10 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                 // under fresh ids if the connection is re-established.
                 this.#live.clear();
 
-                // Streaming queries die with the socket. Unlike a buffered call
-                // they are never re-sent on reconnect: their consumer already
-                // holds part of the answer, which a replay would duplicate.
-                this.failStreams(new CallTerminatedError());
+                // A stream which had begun to answer dies with its socket: its consumer holds
+                // part of that answer already, which a replay would duplicate. One which framed
+                // nothing is left registered for `ready` to re-send.
+                this.failStreams(new CallTerminatedError(), { framedOnly: true });
 
                 if (error) {
                     this.#publisher.publish("error", error);
@@ -151,6 +155,9 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                             reject(new CallTerminatedError());
                         }
                     }
+
+                    // No socket is coming, so the streams held for a re-send are given up on too.
+                    this.failStreams(new CallTerminatedError());
 
                     this._state = undefined;
                     this.#active = false;
@@ -193,6 +200,19 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         for (const { request } of this.#calls.values()) {
             this.#socket?.send(
                 new Uint8Array(wrapSqonError(() => this._context.codecs.cbor.encode(request))),
+            );
+        }
+
+        // A stream which framed nothing never ran: the server sends its opening frame before
+        // execution begins, and whatever the old socket was doing died with it. So it is re-sent,
+        // exactly as a pending buffered call is, rather than failed.
+        for (const stream of this.#streams.values()) {
+            if (stream.settled || stream.abandoned || stream.probe.framed) continue;
+
+            this.#socket?.send(
+                new Uint8Array(
+                    wrapSqonError(() => this._context.codecs.cbor.encode(stream.request)),
+                ),
             );
         }
     }
@@ -251,21 +271,17 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                 yield chunk;
             }
         } catch (error) {
-            // A stream which failed before framing anything is asked for again in buffered form:
-            // nothing is framed until execution is about to begin, and a buffered call survives a
-            // lost connection where a stream cannot. That covers a server which does not serve the
-            // method, one where it is denied, one refusing another concurrent stream, and a socket
-            // which went away before the answer began.
+            // A stream the server refused before framing anything is asked for again in buffered
+            // form: nothing is framed until execution is about to begin, so the query never ran
+            // and cannot run twice. That covers a server which does not serve the method, one
+            // where it is denied, and one refusing another concurrent stream.
             if (probe.framed || !isRetriableAsBuffered(error)) {
                 throw error;
             }
 
             // Absent or denied is a property of the server rather than of this query, so it is
             // remembered for as long as the socket lasts.
-            if (
-                error instanceof ServerError &&
-                (error.code === METHOD_NOT_FOUND || error.code === METHOD_NOT_ALLOWED)
-            ) {
+            if (error.code === METHOD_NOT_FOUND || error.code === METHOD_NOT_ALLOWED) {
                 this.#streaming = false;
             }
 
@@ -290,13 +306,18 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
     }
 
     /**
-     * Sends a streaming query and yields the frames it is answered with, in order.
+     * Sends a streaming query and returns the frames it is answered with, in order.
+     *
+     * The iterator acts on abandonment the moment it is asked to, rather than
+     * when the frames next wake it: a stream can sit for a long time between
+     * frames - or produce none at all - and a consumer which has left must not
+     * wait on a frame to be let go, nor have an error delivered to it.
      */
-    private async *streamFrames(
+    private streamFrames(
         query: BoundQuery,
         session: Session,
         probe: StreamProbe,
-    ): AsyncGenerator<QueryStreamFrame> {
+    ): AsyncIterableIterator<QueryStreamFrame> {
         // Unlike a buffered call, a stream is never re-sent once a socket returns, so it cannot
         // be queued for one which is not there: it would wait for a request never written.
         if (!this.#active || !this.#socket) {
@@ -306,28 +327,49 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         const id = this._context.uniqueId();
         const stream: Stream = {
             channel: new ChannelIterator<StreamEvent>(),
+            request: {
+                id,
+                method: "query_stream",
+                params: [query.query, query.bindings],
+                session,
+            },
             settled: false,
             abandoned: false,
+            probe,
         };
 
         // Sent before the stream is registered, so a request which never reached the socket - an
         // unencodable binding, say - leaves no registration to drain and nothing to cancel. No
         // response can arrive in between: both steps are synchronous.
         this.#socket.send(
-            new Uint8Array(
-                wrapSqonError(() =>
-                    this._context.codecs.cbor.encode({
-                        id,
-                        method: "query_stream",
-                        params: [query.query, query.bindings],
-                        session,
-                    }),
-                ),
-            ),
+            new Uint8Array(wrapSqonError(() => this._context.codecs.cbor.encode(stream.request))),
         );
 
         this.#streams.set(id, stream);
 
+        const frames = this.readFrames(id, stream, probe);
+
+        return {
+            next: () => frames.next(),
+            throw: (error) => frames.throw(error),
+            return: (value?: QueryStreamFrame) => {
+                this.abandonStream(id, stream);
+                return frames.return(value as QueryStreamFrame);
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        };
+    }
+
+    /**
+     * Yields the frames of a registered stream until it ends.
+     */
+    private async *readFrames(
+        id: string,
+        stream: Stream,
+        probe: StreamProbe,
+    ): AsyncGenerator<QueryStreamFrame> {
         try {
             for await (const event of stream.channel) {
                 if (event.kind === "error") {
@@ -342,13 +384,28 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
             if (stream.settled) {
                 this.#streams.delete(id);
             } else {
-                // The consumer stopped reading before the stream ended. Cancelling it stops the
-                // server executing a query nothing will collect; its remaining frames are
-                // discarded until the terminal one settles the registration.
-                stream.abandoned = true;
-                this.cancelStream(id);
+                this.abandonStream(id, stream);
             }
         }
+    }
+
+    /**
+     * Gives up on a stream whose consumer has left.
+     *
+     * Cancelling stops the server executing a query nothing will collect, and
+     * closing the channel releases a read parked on a frame which may never
+     * come. The registration stays until the terminal frame settles it, so the
+     * frames still in flight are discarded rather than misrouted.
+     */
+    private abandonStream(id: string, stream: Stream): void {
+        if (stream.settled || stream.abandoned) {
+            stream.channel.cancel();
+            return;
+        }
+
+        stream.abandoned = true;
+        stream.channel.cancel();
+        this.cancelStream(id);
     }
 
     /**
@@ -367,10 +424,16 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
     }
 
     /**
-     * Fails every streaming query in flight, as a stream cannot outlive its socket.
+     * Fails the streaming queries in flight, as a stream cannot outlive its socket.
+     *
+     * With `framedOnly`, only those which have delivered a frame: they cannot be
+     * replayed, as their consumer holds part of the answer already. The rest are
+     * left registered for [`ready`](WebSocketEngine.ready) to re-send.
      */
-    private failStreams(error: Error): void {
+    private failStreams(error: Error, options: { framedOnly?: boolean } = {}): void {
         for (const [id, stream] of this.#streams) {
+            if (options.framedOnly && !stream.probe.framed) continue;
+
             stream.settled = true;
             this.#streams.delete(id);
 
@@ -572,16 +635,14 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
 /**
  * Whether a streaming query which framed nothing can be asked for again as a buffered one.
  *
- * A rejection by the server and a connection which went away both leave the query unexecuted, and
- * the buffered path answers or queues it. A failure of this SDK's own making - a binding it could
- * not encode - would only fail again, so it is reported instead.
+ * Only a rejection by the server: it leaves the query unexecuted and the connection intact, so
+ * the buffered path can answer it straight away. A connection which went away is reported as it
+ * is instead of being asked for again, even though a buffered call would have been queued and
+ * re-sent, because the second request would have to be started from a stream whose consumer may
+ * be walking away at that very moment, leaving its rejection with nowhere to go.
  */
 function isRetriableAsBuffered(error: unknown): boolean {
-    return (
-        error instanceof ServerError ||
-        error instanceof CallTerminatedError ||
-        error instanceof ConnectionUnavailableError
-    );
+    return error instanceof ServerError;
 }
 
 /** The wire code for a method a server does not serve. */

--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -3,14 +3,28 @@ import {
     CallTerminatedError,
     ConnectionUnavailableError,
     ReconnectExhaustionError,
+    ServerError,
     UnexpectedConnectionError,
     UnexpectedServerResponseError,
 } from "../errors";
 import { parseRpcError } from "../internal/parse-error";
+import {
+    isQueryStreamFrame,
+    type QueryStreamFrame,
+    queryStreamChunks,
+} from "../internal/query-stream";
 import { wrapSqonError } from "../internal/wrap-sqon-error";
-import type { LiveAction, LiveMessage, RpcRequest, RpcResponse } from "../types";
+import type {
+    LiveAction,
+    LiveMessage,
+    QueryChunk,
+    RpcRequest,
+    RpcResponse,
+    Session,
+} from "../types";
 import { LIVE_ACTIONS } from "../types/live";
 import type { ConnectionState, EngineEvents, SurrealEngine } from "../types/surreal";
+import type { BoundQuery } from "../utils";
 import { Features } from "../utils";
 import { ChannelIterator } from "../utils/channel-iterator";
 import { LiveDispatcher } from "../utils/live-dispatcher";
@@ -24,6 +38,31 @@ interface Call<T> {
     request: object;
     resolve: (value: T) => void;
     reject: (error: Error) => void;
+}
+
+/**
+ * One streaming query in flight, held under the request id its frames carry.
+ */
+interface Stream {
+    channel: ChannelIterator<StreamEvent>;
+    /** Whether the terminal frame, or a failure standing in for it, has arrived. */
+    settled: boolean;
+    /** Whether the consumer stopped reading, leaving remaining frames to discard. */
+    abandoned: boolean;
+}
+
+/**
+ * A frame of a streaming query answer, or the failure which ended it.
+ */
+type StreamEvent = { kind: "frame"; frame: QueryStreamFrame } | { kind: "error"; error: Error };
+
+/**
+ * Whether a streaming query framed anything before it failed. Nothing is framed
+ * until execution is about to begin, so a failure before the first frame means
+ * the query never ran and can safely be asked for again in buffered form.
+ */
+interface StreamProbe {
+    framed: boolean;
 }
 
 interface LivePayload {
@@ -40,10 +79,12 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
     #publisher = new Publisher<EngineEvents>();
     #socket: WebSocket | undefined;
     #calls = new Map<string, Call<unknown>>();
+    #streams = new Map<string, Stream>();
     #live = new LiveDispatcher();
     #pinger: Interval;
     #active = false;
     #terminated = false;
+    #streaming = true;
 
     features = new Set([
         Features.LiveQueries,
@@ -73,6 +114,9 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                 // Open a new socket and await until closure
                 const error = await this.createSocket(() => {
                     this.#active = true;
+                    // Whether streaming is served is a property of the server, and a reconnect
+                    // can land on a different one, so each socket is asked again.
+                    this.#streaming = this._context.options.streaming !== false;
                     reconnect.reset();
 
                     this.#publisher.publish("connected");
@@ -84,6 +128,11 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                 // queries registered on it are stale and will be re-registered
                 // under fresh ids if the connection is re-established.
                 this.#live.clear();
+
+                // Streaming queries die with the socket. Unlike a buffered call
+                // they are never re-sent on reconnect: their consumer already
+                // holds part of the answer, which a replay would duplicate.
+                this.failStreams(new CallTerminatedError());
 
                 if (error) {
                     this.#publisher.publish("error", error);
@@ -171,6 +220,59 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         });
     }
 
+    override async *query<T>(
+        query: BoundQuery,
+        session: Session,
+        txn?: Uuid,
+    ): AsyncIterable<QueryChunk<T>> {
+        // A query inside a client managed transaction is never streamed. The stream would execute
+        // on that transaction while a `commit` for it can arrive on the same connection at any
+        // time, which would commit a prefix of the query rather than the whole of it.
+        //
+        // Nor is one streamed with no socket to write to, which is where a reconnect cooldown
+        // leaves the engine: a buffered call is queued and re-sent once the connection returns,
+        // where a stream would be waiting on a request that was never written.
+        if (
+            txn !== undefined ||
+            !this.#streaming ||
+            this._context.options.streaming === false ||
+            !this.#socket
+        ) {
+            yield* super.query<T>(query, session, txn);
+            return;
+        }
+
+        const probe: StreamProbe = { framed: false };
+
+        try {
+            for await (const chunk of queryStreamChunks<T>(
+                this.streamFrames(query, session, probe),
+            )) {
+                yield chunk;
+            }
+        } catch (error) {
+            // A stream which failed before framing anything is asked for again in buffered form:
+            // nothing is framed until execution is about to begin, and a buffered call survives a
+            // lost connection where a stream cannot. That covers a server which does not serve the
+            // method, one where it is denied, one refusing another concurrent stream, and a socket
+            // which went away before the answer began.
+            if (probe.framed || !isRetriableAsBuffered(error)) {
+                throw error;
+            }
+
+            // Absent or denied is a property of the server rather than of this query, so it is
+            // remembered for as long as the socket lasts.
+            if (
+                error instanceof ServerError &&
+                (error.code === METHOD_NOT_FOUND || error.code === METHOD_NOT_ALLOWED)
+            ) {
+                this.#streaming = false;
+            }
+
+            yield* super.query<T>(query, session, txn);
+        }
+    }
+
     override liveQuery(id: Uuid): AsyncIterable<LiveMessage> {
         const channel = new ChannelIterator<LiveMessage>(() => {
             unsub1();
@@ -185,6 +287,131 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         });
 
         return channel;
+    }
+
+    /**
+     * Sends a streaming query and yields the frames it is answered with, in order.
+     */
+    private async *streamFrames(
+        query: BoundQuery,
+        session: Session,
+        probe: StreamProbe,
+    ): AsyncGenerator<QueryStreamFrame> {
+        // Unlike a buffered call, a stream is never re-sent once a socket returns, so it cannot
+        // be queued for one which is not there: it would wait for a request never written.
+        if (!this.#active || !this.#socket) {
+            throw new ConnectionUnavailableError();
+        }
+
+        const id = this._context.uniqueId();
+        const stream: Stream = {
+            channel: new ChannelIterator<StreamEvent>(),
+            settled: false,
+            abandoned: false,
+        };
+
+        // Sent before the stream is registered, so a request which never reached the socket - an
+        // unencodable binding, say - leaves no registration to drain and nothing to cancel. No
+        // response can arrive in between: both steps are synchronous.
+        this.#socket.send(
+            new Uint8Array(
+                wrapSqonError(() =>
+                    this._context.codecs.cbor.encode({
+                        id,
+                        method: "query_stream",
+                        params: [query.query, query.bindings],
+                        session,
+                    }),
+                ),
+            ),
+        );
+
+        this.#streams.set(id, stream);
+
+        try {
+            for await (const event of stream.channel) {
+                if (event.kind === "error") {
+                    throw event.error;
+                }
+
+                probe.framed = true;
+
+                yield event.frame;
+            }
+        } finally {
+            if (stream.settled) {
+                this.#streams.delete(id);
+            } else {
+                // The consumer stopped reading before the stream ended. Cancelling it stops the
+                // server executing a query nothing will collect; its remaining frames are
+                // discarded until the terminal one settles the registration.
+                stream.abandoned = true;
+                this.cancelStream(id);
+            }
+        }
+    }
+
+    /**
+     * Asks the server to stop a streaming query it is still executing.
+     */
+    private cancelStream(id: string): void {
+        if (!this.#active) {
+            this.#streams.delete(id);
+            return;
+        }
+
+        this.send({ method: "query_cancel", params: [id] }).catch(() => {
+            // The stream is already being abandoned; a cancel which cannot be delivered, or which
+            // names a stream that has since ended, changes nothing for the consumer.
+        });
+    }
+
+    /**
+     * Fails every streaming query in flight, as a stream cannot outlive its socket.
+     */
+    private failStreams(error: Error): void {
+        for (const [id, stream] of this.#streams) {
+            stream.settled = true;
+            this.#streams.delete(id);
+
+            if (!stream.abandoned) {
+                stream.channel.submit({ kind: "error", error });
+            }
+        }
+    }
+
+    /**
+     * Routes one response of a streaming query to the consumer waiting on it.
+     */
+    private handleStreamResponse(id: string, stream: Stream, response: RpcResponse<unknown>): void {
+        const frame = response.error ? undefined : response.result;
+
+        // A failure, or anything which is not a frame, is terminal: the request is answered by
+        // frames until its `end`, so there is nothing further to wait for.
+        if (response.error || !isQueryStreamFrame(frame)) {
+            stream.settled = true;
+            this.#streams.delete(id);
+
+            if (!stream.abandoned) {
+                stream.channel.submit({
+                    kind: "error",
+                    error: response.error
+                        ? parseRpcError(response.error)
+                        : new UnexpectedServerResponseError(frame),
+                });
+            }
+
+            return;
+        }
+
+        if (frame.stream === "end") {
+            stream.settled = true;
+            this.#streams.delete(id);
+        }
+
+        if (!stream.abandoned) {
+            stream.channel.submit({ kind: "frame", frame });
+        }
     }
 
     private async createSocket(onConnected: () => void): Promise<Error | null> {
@@ -298,6 +525,15 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
 
     private handleRpcResponse({ id, ...res }: Response) {
         if (typeof id === "string") {
+            // Frames are only ever decoded behind the id of a stream this engine started, never
+            // by the shape of a payload, which user data could imitate.
+            const stream = this.#streams.get(id);
+
+            if (stream) {
+                this.handleStreamResponse(id, stream, res as RpcResponse<unknown>);
+                return;
+            }
+
             try {
                 const response = res as RpcResponse<unknown>;
                 const { resolve, reject } = this.#calls.get(id) ?? {};
@@ -332,6 +568,27 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         this.#publisher.publish("error", new UnexpectedServerResponseError(res));
     }
 }
+
+/**
+ * Whether a streaming query which framed nothing can be asked for again as a buffered one.
+ *
+ * A rejection by the server and a connection which went away both leave the query unexecuted, and
+ * the buffered path answers or queues it. A failure of this SDK's own making - a binding it could
+ * not encode - would only fail again, so it is reported instead.
+ */
+function isRetriableAsBuffered(error: unknown): boolean {
+    return (
+        error instanceof ServerError ||
+        error instanceof CallTerminatedError ||
+        error instanceof ConnectionUnavailableError
+    );
+}
+
+/** The wire code for a method a server does not serve. */
+const METHOD_NOT_FOUND = -32601;
+
+/** The wire code for a method a server serves but does not allow. */
+const METHOD_NOT_ALLOWED = -32602;
 
 function isLiveMessage(v: unknown): v is LivePayload {
     if (typeof v !== "object") return false;

--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -157,8 +157,13 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                         }
                     }
 
-                    // No socket is coming, so the streams held for a re-send are given up on too.
-                    this.failStreams(new CallTerminatedError());
+                    // No socket is coming, so the streams held for a re-send are given up on
+                    // too - failed or dropped to match the calls above.
+                    if (this.#terminated) {
+                        this.#streams.clear();
+                    } else {
+                        this.failStreams(new CallTerminatedError());
+                    }
 
                     this._state = undefined;
                     this.#active = false;
@@ -190,9 +195,11 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
         this.#terminated = true;
         this.#socket?.close();
 
-        // No socket is coming now, so the streams waiting for one are settled here rather than
-        // when the reconnect cooldown they are waiting through happens to elapse.
-        this.failStreams(new CallTerminatedError());
+        // Dropped rather than failed, which is what closing does to the calls in flight: the
+        // caller has abandoned its pending work. A streamed query must not answer a `close`
+        // differently from a buffered one, and failing them here would turn a query nobody is
+        // holding into an unhandled rejection.
+        this.#streams.clear();
 
         if (socketState === WebSocketImpl.OPEN || socketState === WebSocketImpl.CLOSING) {
             await this.#publisher.subscribeFirst("disconnected");

--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -150,24 +150,11 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                         this.#publisher.publish("error", new ReconnectExhaustionError());
                     }
 
-                    // Optionally terminate pending calls
-                    if (!this.#terminated) {
-                        for (const { reject } of this.#calls.values()) {
-                            reject(new CallTerminatedError());
-                        }
-                    }
-
-                    // No socket is coming, so the streams held for a re-send are given up on
-                    // too - failed or dropped to match the calls above.
-                    if (this.#terminated) {
-                        this.#streams.clear();
-                    } else {
-                        this.failStreams(new CallTerminatedError());
-                    }
+                    // No socket is coming back, so nothing in flight can be answered.
+                    this.terminatePending(new CallTerminatedError());
 
                     this._state = undefined;
                     this.#active = false;
-                    this.#calls.clear();
                     this.#publisher.publish("disconnected");
 
                     break;
@@ -193,13 +180,14 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
 
         this._state = undefined;
         this.#terminated = true;
+        this.#active = false;
         this.#socket?.close();
 
-        // Dropped rather than failed, which is what closing does to the calls in flight: the
-        // caller has abandoned its pending work. A streamed query must not answer a `close`
-        // differently from a buffered one, and failing them here would turn a query nobody is
-        // holding into an unhandled rejection.
-        this.#streams.clear();
+        // Settled here rather than when the loop above next wakes, which a reconnect cooldown
+        // can hold off for as long as its backoff: a caller awaiting a query when the connection
+        // is closed under it learns that it died, instead of waiting on it for the life of the
+        // process.
+        this.terminatePending(new CallTerminatedError());
 
         if (socketState === WebSocketImpl.OPEN || socketState === WebSocketImpl.CLOSING) {
             await this.#publisher.subscribeFirst("disconnected");
@@ -474,6 +462,23 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
     }
 
     /**
+     * Fails everything in flight, for a connection which is not coming back.
+     *
+     * The calls and the streams are settled together: a query which reported a
+     * closed connection differently for having been streamed would make the
+     * two transports observably different, and one which reported nothing at
+     * all would leave its caller waiting on it for the life of the process.
+     */
+    private terminatePending(error: Error): void {
+        for (const { reject } of this.#calls.values()) {
+            reject(error);
+        }
+
+        this.#calls.clear();
+        this.failStreams(error);
+    }
+
+    /**
      * Fails the streaming queries in flight, as a stream cannot outlive its socket.
      *
      * With `framedOnly`, only those which have delivered a frame: they cannot be
@@ -557,7 +562,9 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
 
                     this.#pinger = setInterval(() => {
                         try {
-                            this.send({ method: "ping" });
+                            // A ping in flight is terminated with every other call when the
+                            // connection goes, and its rejection belongs to nobody.
+                            this.send({ method: "ping" }).catch(() => {});
                         } catch {
                             // we are not interested in the result
                         }

--- a/packages/sdk/src/internal/query-stream.ts
+++ b/packages/sdk/src/internal/query-stream.ts
@@ -1,0 +1,314 @@
+import { Duration } from "@surrealdb/sqon";
+import type { ServerError } from "../errors";
+import { CallTerminatedError, UnexpectedServerResponseError } from "../errors";
+import type { QueryChunk, QueryStats, QueryType } from "../types";
+import { parseRpcError, type RpcErrorObject } from "./parse-error";
+
+/**
+ * The key which tags a streaming query frame, holding the frame's kind.
+ *
+ * Frames are only ever sent in answer to a `query_stream` request, and every
+ * frame carries that request's id, so they are decoded by looking the id up in
+ * the engine's own stream registry - never by inspecting the shape of an
+ * arbitrary response payload, which user data could imitate.
+ */
+export const STREAM_FRAME_KEY = "stream";
+
+/**
+ * A single frame of a streaming query answer.
+ *
+ * A `query_stream` request is answered by a sequence of these instead of one
+ * response: a `begin` frame, the per-statement payload and `finished` frames
+ * as execution produces them, and exactly one terminal `end` frame.
+ */
+export type QueryStreamFrame =
+    | QueryStreamBeginFrame
+    | QueryStreamRowsFrame
+    | QueryStreamValueFrame
+    | QueryStreamFinishedFrame
+    | QueryStreamEndFrame;
+
+/**
+ * The stream is open. Sent before execution begins. `statements` is an upper
+ * bound on the statements which will finish, as control flow such as a `RETURN`
+ * inside a `BEGIN` block can skip the tail, so results are counted by
+ * `finished` frames instead.
+ */
+export interface QueryStreamBeginFrame {
+    stream: "begin";
+    statements: number;
+}
+
+/**
+ * Rows produced by a statement; more may follow. The statement's value is every
+ * row it emitted, in order.
+ */
+export interface QueryStreamRowsFrame {
+    stream: "rows";
+    index: number;
+    values?: unknown[];
+}
+
+/**
+ * A statement produced a single value which is not a list of rows, such as
+ * `SELECT ONLY`, `RETURN 1 + 2`, or a block.
+ */
+export interface QueryStreamValueFrame {
+    stream: "value";
+    index: number;
+    value?: unknown;
+}
+
+/**
+ * A statement is final. Terminal for that statement: no further frame carries
+ * it. An `error` means the statement failed and any rows already delivered for
+ * it must be discarded, while `single` distinguishes a statement whose value is
+ * one bare value from one whose value is a list.
+ */
+export interface QueryStreamFinishedFrame {
+    stream: "finished";
+    index: number;
+    time?: string;
+    type?: QueryType;
+    single?: boolean;
+    error?: RpcErrorObject;
+}
+
+/**
+ * The stream is complete and nothing follows. An `error` means either that
+ * execution stopped for a reason belonging to no single statement, retracting
+ * every statement without a `finished` frame, or that something a finished
+ * statement produced could not be kept after the fact.
+ */
+export interface QueryStreamEndFrame {
+    stream: "end";
+    results?: number;
+    time?: string;
+    error?: RpcErrorObject;
+}
+
+/**
+ * The error a frame reports, as the buffered protocol would have reported it.
+ *
+ * A statement's failure crosses the buffered protocol inside its query result,
+ * which carries no wire code, so `ServerError.code` is `0` there. A frame
+ * carries the full error object, code included, and letting it through would
+ * make the same failing query report a different code depending on whether the
+ * answer happened to be streamed. The kind, class, message, details and cause
+ * are all preserved; only the code the buffered path never had is dropped.
+ */
+function frameError(error: RpcErrorObject): ServerError {
+    // Without a kind there is nothing but the code to resolve the error's class from, so it is
+    // kept: a server old enough to omit the kind is not one that streams.
+    if (!error.kind) {
+        return parseRpcError(error);
+    }
+
+    // Zero is the code a query result error carries on the buffered protocol.
+    return parseRpcError({ ...error, code: 0 });
+}
+
+/**
+ * Returns whether the given response payload is a streaming query frame.
+ *
+ * Only ever applied to a payload which arrived under the request id of a
+ * streaming query this engine started.
+ */
+export function isQueryStreamFrame(value: unknown): value is QueryStreamFrame {
+    if (typeof value !== "object" || value === null) return false;
+    return typeof (value as Record<string, unknown>)[STREAM_FRAME_KEY] === "string";
+}
+
+/**
+ * Translates the frames of a streaming query answer into the query chunks the
+ * rest of the SDK consumes.
+ *
+ * The frame contract is preserved as it is translated:
+ *
+ * - Rows are provisional until their statement's `finished` frame. A `finished` frame carrying an
+ *   error becomes an error chunk, which is how the chunk consumers discard the rows already
+ *   delivered for that statement.
+ * - A statement contributes rows or one single value, never both, and only its `finished` frame
+ *   says which it was. A single value is therefore held back until then, as the chunk consumers
+ *   distinguish the two by the chunk kind.
+ * - An `end` frame carrying an error retracts every statement which never finished and fails the
+ *   whole query, so a stream which was stopped rather than answered is never mistaken for a
+ *   complete one.
+ * - The stream is only complete once its `end` frame arrives. Frames running out without one means
+ *   the answer was truncated, which fails the query rather than silently returning a prefix of it.
+ *
+ * @param frames The frames of a single streaming query answer, in the order they arrived.
+ * @returns The query chunks conveyed by those frames.
+ */
+export async function* queryStreamChunks<T>(
+    frames: AsyncIterable<QueryStreamFrame>,
+): AsyncGenerator<QueryChunk<T>> {
+    const batches = new Map<number, number>();
+    const singles = new Map<number, unknown>();
+    const unfinished = new Set<number>();
+    const finished = new Set<number>();
+    let ended = false;
+
+    for await (const frame of frames) {
+        // A statement's terminal frame is terminal: an outcome already delivered is never taken
+        // back, so nothing which arrives for that statement afterwards is acted on.
+        if (
+            (frame.stream === "rows" || frame.stream === "value" || frame.stream === "finished") &&
+            finished.has(frameIndex(frame.index))
+        ) {
+            continue;
+        }
+
+        switch (frame.stream) {
+            case "begin": {
+                break;
+            }
+
+            case "rows": {
+                const index = frameIndex(frame.index);
+
+                unfinished.add(index);
+
+                yield {
+                    query: index,
+                    batch: nextBatch(batches, index),
+                    kind: "batched",
+                    // A rows frame carries a list, as the buffered path also insists.
+                    result: (Array.isArray(frame.values) ? frame.values : []) as T[],
+                };
+
+                break;
+            }
+
+            case "value": {
+                const index = frameIndex(frame.index);
+
+                unfinished.add(index);
+                singles.set(index, frame.value);
+
+                break;
+            }
+
+            case "finished": {
+                const index = frameIndex(frame.index);
+                const stats = frameStats(frame.time);
+                const single = singles.has(index) ? [singles.get(index) as T] : undefined;
+
+                unfinished.delete(index);
+                singles.delete(index);
+                finished.add(index);
+
+                if (frame.error) {
+                    yield {
+                        query: index,
+                        batch: nextBatch(batches, index),
+                        kind: "batched-final",
+                        stats,
+                        error: frameError(frame.error),
+                    };
+
+                    break;
+                }
+
+                yield {
+                    query: index,
+                    batch: nextBatch(batches, index),
+                    kind: frame.single ? "single" : "batched-final",
+                    stats,
+                    // Carried exactly as the buffered path carries it, which leaves it unset for
+                    // an ordinary statement: the consumers of a chunk are what settle on a
+                    // default, and a streamed chunk must not differ from a buffered one.
+                    type: frame.type,
+                    // A single statement which sent no value frame produced NONE, and a statement
+                    // which streamed rows has already delivered them.
+                    result: frame.single ? (single ?? ([undefined] as T[])) : (single ?? []),
+                };
+
+                break;
+            }
+
+            case "end": {
+                ended = true;
+
+                if (frame.error) {
+                    const error = frameError(frame.error);
+                    const stats = frameStats(frame.time);
+                    const retracted = [...unfinished].sort((a, b) => a - b);
+
+                    unfinished.clear();
+
+                    for (const index of retracted) {
+                        yield {
+                            query: index,
+                            batch: nextBatch(batches, index),
+                            kind: "batched-final",
+                            stats,
+                            error,
+                        };
+                    }
+
+                    throw error;
+                }
+
+                return;
+            }
+
+            default: {
+                // An unrecognised frame kind belongs to a newer protocol than this SDK knows. The
+                // terminal frame still bounds the stream, so it is skipped rather than fatal.
+                break;
+            }
+        }
+    }
+
+    if (!ended) {
+        throw new CallTerminatedError();
+    }
+}
+
+/**
+ * The batch number of the next chunk for a statement.
+ */
+function nextBatch(batches: Map<number, number>, index: number): number {
+    const batch = batches.get(index) ?? 0;
+    batches.set(index, batch + 1);
+    return batch;
+}
+
+/**
+ * The statement a frame belongs to, which crosses the wire as an integer of a
+ * width the codec is free to widen.
+ *
+ * An index this SDK cannot represent fails the stream rather than defaulting:
+ * attributing a frame to the wrong statement would silently corrupt an answer.
+ */
+function frameIndex(index: number): number {
+    const value = Number(index);
+
+    if (!Number.isSafeInteger(value) || value < 0) {
+        throw new UnexpectedServerResponseError(index);
+    }
+
+    return value;
+}
+
+/**
+ * The statistics conveyed by a frame. Only the duration is reported over the
+ * streaming protocol, matching the buffered protocol.
+ */
+function frameStats(time: string | undefined): QueryStats | undefined {
+    if (typeof time !== "string") return undefined;
+
+    try {
+        return {
+            bytesReceived: -1,
+            bytesScanned: -1,
+            recordsReceived: -1,
+            recordsScanned: -1,
+            duration: Duration.parseFloat(time),
+        };
+    } catch {
+        // A duration this SDK cannot parse is not worth failing a query over.
+        return undefined;
+    }
+}

--- a/packages/sdk/src/internal/query-stream.ts
+++ b/packages/sdk/src/internal/query-stream.ts
@@ -135,13 +135,15 @@ export function isQueryStreamFrame(value: unknown): value is QueryStreamFrame {
  *   whole query, so a stream which was stopped rather than answered is never mistaken for a
  *   complete one.
  * - The stream is only complete once its `end` frame arrives. Frames running out without one means
- *   the answer was truncated, which fails the query rather than silently returning a prefix of it.
+ *   the answer was truncated, which fails the query rather than silently returning a prefix of it -
+ *   unless the consumer asked to leave, in which case there is nobody the failure belongs to.
  *
  * @param frames The frames of a single streaming query answer, in the order they arrived.
  * @returns The query chunks conveyed by those frames.
  */
 export async function* queryStreamChunks<T>(
     frames: AsyncIterable<QueryStreamFrame>,
+    abandonment: Abandonment = {},
 ): AsyncGenerator<QueryChunk<T>> {
     const batches = new Map<number, number>();
     const singles = new Map<number, unknown>();
@@ -261,9 +263,19 @@ export async function* queryStreamChunks<T>(
         }
     }
 
-    if (!ended) {
+    // Frames stopping short of the terminal one means the answer was truncated, which fails the
+    // query rather than returning a prefix of it. Unless the consumer is the reason they stopped:
+    // it has left, and there is no one to tell.
+    if (!ended && !abandonment.requested) {
         throw new CallTerminatedError();
     }
+}
+
+/**
+ * Whether the consumer of a chunk stream has asked to leave it.
+ */
+export interface Abandonment {
+    requested?: boolean;
 }
 
 /**

--- a/packages/sdk/src/query/create.ts
+++ b/packages/sdk/src/query/create.ts
@@ -5,7 +5,7 @@ import { _only, _output, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
 import type { AnyRecordId, Mutation, Output, Patch, RetryValue, Session, Values } from "../types";
 import { type BoundQuery, raw, surql } from "../utils";
-import type { Frame } from "../utils/frame";
+import type { Frame, StreamedRow } from "../utils/frame";
 import { Query } from "./query";
 
 interface CreateOptions {
@@ -142,9 +142,9 @@ export class CreatePromise<T, I, J extends boolean = false> extends DispatchedPr
      *
      * @returns An async iterable of query frames.
      */
-    async *stream(): AsyncIterable<Frame<T, J>> {
+    async *stream(): AsyncIterable<Frame<StreamedRow<T>, J>> {
         await this.#connection.ready();
-        const query = this.#build().stream<T>();
+        const query = this.#build().stream<StreamedRow<T>>();
 
         for await (const frame of query) {
             yield frame;

--- a/packages/sdk/src/query/delete.ts
+++ b/packages/sdk/src/query/delete.ts
@@ -5,7 +5,7 @@ import { _only, _output, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
 import type { AnyRecordId, Output, RetryValue, Session } from "../types";
 import { type BoundQuery, surql } from "../utils";
-import type { Frame } from "../utils/frame";
+import type { Frame, StreamedRow } from "../utils/frame";
 import { Query } from "./query";
 
 interface DeleteOptions {
@@ -116,9 +116,9 @@ export class DeletePromise<T, J extends boolean = false> extends DispatchedPromi
      *
      * @returns An async iterable of query frames.
      */
-    async *stream(): AsyncIterable<Frame<T, J>> {
+    async *stream(): AsyncIterable<Frame<StreamedRow<T>, J>> {
         await this.#connection.ready();
-        const query = this.#build().stream<T>();
+        const query = this.#build().stream<StreamedRow<T>>();
 
         for await (const frame of query) {
             yield frame;

--- a/packages/sdk/src/query/insert.ts
+++ b/packages/sdk/src/query/insert.ts
@@ -5,7 +5,7 @@ import { _output, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
 import type { Output, RetryValue, Session } from "../types";
 import { type BoundQuery, surql } from "../utils";
-import type { Frame } from "../utils/frame";
+import type { Frame, StreamedRow } from "../utils/frame";
 import { Query } from "./query";
 
 interface InsertOptions {
@@ -139,9 +139,9 @@ export class InsertPromise<T, J extends boolean = false> extends DispatchedPromi
      *
      * @returns An async iterable of query frames.
      */
-    async *stream(): AsyncIterable<Frame<T, J>> {
+    async *stream(): AsyncIterable<Frame<StreamedRow<T>, J>> {
         await this.#connection.ready();
-        const query = this.#build().stream<T>();
+        const query = this.#build().stream<StreamedRow<T>>();
 
         for await (const frame of query) {
             yield frame;

--- a/packages/sdk/src/query/query.ts
+++ b/packages/sdk/src/query/query.ts
@@ -154,9 +154,9 @@ export class Query<
      * Stream the response frames of the query as they are received as an AsyncIterable.
      *
      * Each iteration yields a **value**, **error**, or **done** frame. The provided
-     * `isValue`, `isError`, and `isDone` methods can be used to check the type of frame.
-     * You can pass a query index to these functions to check if the frame is associated with a
-     * specific query.
+     * `isValue`, `isError`, and `isDone` methods can be used to check the type of frame, and
+     * `isValueOf`, `isErrorOf`, and `isDoneOf` to check the type and that the frame belongs to
+     * a specific statement, by its index.
      *
      * Values are provisional until the **done** frame for their statement arrives: an **error**
      * frame for a statement retracts every value already yielded for it, and the stream itself

--- a/packages/sdk/src/query/query.ts
+++ b/packages/sdk/src/query/query.ts
@@ -136,7 +136,10 @@ export class Query<
                 let records = responses[index] as unknown[];
 
                 if (!records) {
-                    records = additions;
+                    // Copied rather than adopted: a statement streamed in batches would otherwise
+                    // have the rows of every later batch pushed into the first chunk's own array,
+                    // which its emitter still holds.
+                    records = [...additions];
                     responses[index] = records;
                 } else {
                     records.push(...additions);
@@ -154,6 +157,14 @@ export class Query<
      * `isValue`, `isError`, and `isDone` methods can be used to check the type of frame.
      * You can pass a query index to these functions to check if the frame is associated with a
      * specific query.
+     *
+     * Values are provisional until the **done** frame for their statement arrives: an **error**
+     * frame for a statement retracts every value already yielded for it, and the stream itself
+     * throws when the query as a whole could not be completed. Statements are therefore counted
+     * by their **done** frames.
+     *
+     * Abandoning the stream, such as by breaking out of the loop, stops the query on servers
+     * which support it, so results which are no longer wanted are no longer produced.
      *
      * @example
      * ```ts
@@ -264,7 +275,8 @@ export class Query<
             let records = collections[index] as unknown[];
 
             if (!records) {
-                records = additions;
+                // Copied rather than adopted, for the reason given in `collect`.
+                records = [...additions];
                 collections[index] = records;
             } else {
                 records.push(...additions);

--- a/packages/sdk/src/query/relate.ts
+++ b/packages/sdk/src/query/relate.ts
@@ -6,7 +6,7 @@ import { _output, _timeout } from "../internal/internal-expressions";
 import type { MaybeJsonify } from "../internal/maybe-jsonify";
 import type { AnyRecordId, Output, RetryValue, Session } from "../types";
 import { type BoundQuery, surql } from "../utils";
-import type { Frame } from "../utils/frame";
+import type { Frame, StreamedRow } from "../utils/frame";
 import { Query } from "./query";
 
 interface RelateOptions {
@@ -131,9 +131,9 @@ export class RelatePromise<T, J extends boolean = false> extends DispatchedPromi
      *
      * @returns An async iterable of query frames.
      */
-    async *stream(): AsyncIterable<Frame<T, J>> {
+    async *stream(): AsyncIterable<Frame<StreamedRow<T>, J>> {
         await this.#connection.ready();
-        const query = this.#build().stream<T>();
+        const query = this.#build().stream<StreamedRow<T>>();
 
         for await (const frame of query) {
             yield frame;

--- a/packages/sdk/src/query/select.ts
+++ b/packages/sdk/src/query/select.ts
@@ -6,7 +6,7 @@ import type { MaybeJsonify } from "../internal/maybe-jsonify";
 import type { AnyRecordId, Expr, ExprLike, Session } from "../types";
 import type { Field, Selection } from "../types/internal";
 import { type BoundQuery, surql } from "../utils";
-import type { Frame } from "../utils/frame";
+import type { Frame, StreamedRow } from "../utils/frame";
 import { Query } from "./query";
 
 interface SelectOptions {
@@ -153,9 +153,9 @@ export class SelectPromise<T, I, J extends boolean = false> extends DispatchedPr
      *
      * @returns An async iterable of query frames.
      */
-    async *stream(): AsyncIterable<Frame<T, J>> {
+    async *stream(): AsyncIterable<Frame<StreamedRow<T>, J>> {
         await this.#connection.ready();
-        const query = this.#build().stream<T>();
+        const query = this.#build().stream<StreamedRow<T>>();
 
         for await (const frame of query) {
             yield frame;

--- a/packages/sdk/src/query/update.ts
+++ b/packages/sdk/src/query/update.ts
@@ -15,7 +15,7 @@ import type {
     Values,
 } from "../types";
 import { type BoundQuery, raw, surql } from "../utils";
-import type { Frame } from "../utils/frame";
+import type { Frame, StreamedRow } from "../utils/frame";
 import { Query } from "./query";
 
 interface UpdateOptions {
@@ -178,9 +178,9 @@ export class UpdatePromise<T, I, J extends boolean = false> extends DispatchedPr
      *
      * @returns An async iterable of query frames.
      */
-    async *stream(): AsyncIterable<Frame<T, J>> {
+    async *stream(): AsyncIterable<Frame<StreamedRow<T>, J>> {
         await this.#connection.ready();
-        const query = this.#build().stream<T>();
+        const query = this.#build().stream<StreamedRow<T>>();
 
         for await (const frame of query) {
             yield frame;

--- a/packages/sdk/src/query/upsert.ts
+++ b/packages/sdk/src/query/upsert.ts
@@ -15,7 +15,7 @@ import type {
     Values,
 } from "../types";
 import { type BoundQuery, raw, surql } from "../utils";
-import type { Frame } from "../utils/frame";
+import type { Frame, StreamedRow } from "../utils/frame";
 import { Query } from "./query";
 
 interface UpsertOptions {
@@ -178,9 +178,9 @@ export class UpsertPromise<T, I, J extends boolean = false> extends DispatchedPr
      *
      * @returns An async iterable of query frames.
      */
-    async *stream(): AsyncIterable<Frame<T, J>> {
+    async *stream(): AsyncIterable<Frame<StreamedRow<T>, J>> {
         await this.#connection.ready();
-        const query = this.#build().stream<T>();
+        const query = this.#build().stream<StreamedRow<T>>();
 
         for await (const frame of query) {
             yield frame;

--- a/packages/sdk/src/types/surreal.ts
+++ b/packages/sdk/src/types/surreal.ts
@@ -104,6 +104,18 @@ export interface DriverOptions {
     codecOptions?: CodecOptions;
     websocketImpl?: typeof WebSocket;
     fetchImpl?: typeof fetch;
+    /**
+     * Stream query results from the server as they are produced, instead of receiving
+     * them in a single response, on engines and servers which support it.
+     *
+     * Streaming lowers the time until the first result and avoids decoding one large
+     * response, and is transparent: results, errors, and statistics are the same either
+     * way. Queries sent inside a transaction created with `.begin()` are never streamed,
+     * and a server without support for streaming is detected and used as before.
+     *
+     * @default true
+     */
+    streaming?: boolean;
 }
 
 /**

--- a/packages/sdk/src/utils/channel-iterator.ts
+++ b/packages/sdk/src/utils/channel-iterator.ts
@@ -1,10 +1,12 @@
+type Waiter<T> = (result: IteratorResult<T>) => void;
+
 /**
  * The channel iterator is a utility class that allows you to submit values to an async iterator.
  */
 export class ChannelIterator<T> implements AsyncIterable<T>, AsyncIterator<T> {
     #cancelled = false;
     #queue: T[] = [];
-    #waiter?: (r: IteratorResult<T>) => void;
+    #waiters: Waiter<T>[] = [];
     #cleanup?: () => void;
 
     constructor(cleanup?: () => void) {
@@ -26,18 +28,15 @@ export class ChannelIterator<T> implements AsyncIterable<T>, AsyncIterator<T> {
             });
         }
 
+        // Every reader is remembered, in the order it asked. A single slot would leave an earlier
+        // reader's promise unsettled forever the moment a second one arrived.
         return new Promise<IteratorResult<T>>((resolve) => {
-            this.#waiter = resolve;
+            this.#waiters.push(resolve);
         });
     }
 
     return(): Promise<IteratorResult<T>> {
-        this.#cancelled = true;
-        this.#cleanup?.();
-        this.#waiter?.({
-            value: undefined,
-            done: true,
-        });
+        this.#end();
 
         return Promise.resolve({
             value: undefined,
@@ -47,14 +46,7 @@ export class ChannelIterator<T> implements AsyncIterable<T>, AsyncIterator<T> {
 
     throw(error?: unknown): Promise<IteratorResult<T>> {
         // Cancel the iterator immediately - protocol errors should terminate the stream
-        this.#cancelled = true;
-        this.#cleanup?.();
-
-        // If there's a waiter, resolve it with the error
-        if (this.#waiter) {
-            this.#waiter({ value: undefined, done: true });
-            this.#waiter = undefined;
-        }
+        this.#end();
 
         // Propagate the error to the consumer
         return Promise.reject(error);
@@ -65,10 +57,15 @@ export class ChannelIterator<T> implements AsyncIterable<T>, AsyncIterator<T> {
     }
 
     submit(value: T): void {
-        if (this.#cancelled) this.return;
+        if (this.#cancelled) return;
 
-        if (this.#waiter) {
-            this.#waiter({ value, done: false });
+        const waiter = this.#waiters.shift();
+
+        if (waiter) {
+            // Taken out of the queue before it is resolved. A second value submitted before the
+            // consumer asks for the next one would otherwise resolve this same, already settled
+            // promise, and every value but the first of a burst would be lost.
+            waiter({ value, done: false });
             return;
         }
 
@@ -76,8 +73,21 @@ export class ChannelIterator<T> implements AsyncIterable<T>, AsyncIterator<T> {
     }
 
     cancel(): void {
+        this.#end();
+    }
+
+    /**
+     * Ends the channel, settling every reader still waiting on it.
+     */
+    #end(): void {
+        const waiters = this.#waiters;
+
         this.#cancelled = true;
+        this.#waiters = [];
         this.#cleanup?.();
-        this.#waiter?.({ value: undefined, done: true });
+
+        for (const waiter of waiters) {
+            waiter({ value: undefined, done: true });
+        }
     }
 }

--- a/packages/sdk/src/utils/frame.ts
+++ b/packages/sdk/src/utils/frame.ts
@@ -11,6 +11,16 @@ import {
 } from "../utils/symbols";
 
 /**
+ * The value a frame carries for a statement whose result is `T`.
+ *
+ * A statement which answers with a list of records is streamed a record at a
+ * time, so each frame carries one of them; a statement which answers with a
+ * single value - `SELECT ... FROM ONLY`, `CREATE ONLY`, a `RETURN` - is one
+ * frame carrying that value. The result type is what distinguishes the two.
+ */
+export type StreamedRow<T> = T extends readonly (infer U)[] ? U : T;
+
+/**
  * Represents a single query result frame frame
  */
 export class Frame<T, J extends boolean> {

--- a/packages/sdk/src/utils/live.ts
+++ b/packages/sdk/src/utils/live.ts
@@ -107,6 +107,11 @@ export class ManagedLiveSubscription extends LiveSubscription {
 
         if (this.#controller.status === "connected") {
             this.#ready = this.#listen();
+
+            // Awaiting `ready()` is optional, and the registration fails with the connection it
+            // was made on - which `#listen` has already reported on the error channel - so the
+            // promise is kept from going unhandled. Callers who do await it still see it fail.
+            this.#ready.catch(() => {});
         }
     }
 

--- a/packages/tests/surrealdb/integration/query/live.test.ts
+++ b/packages/tests/surrealdb/integration/query/live.test.ts
@@ -261,7 +261,10 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
             const subscription = await surreal.live(personTable);
             const messages: LiveMessage[] = [];
 
-            (async () => {
+            // Kept so it can be awaited below: killing the subscription ends the iteration
+            // before this has finished, and work still in flight when the test returns is torn
+            // down with the connection.
+            const writes = (async () => {
                 await Bun.sleep(100);
 
                 await surreal.create(new RecordId("person", 5)).content({
@@ -283,6 +286,8 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
             for await (const message of subscription) {
                 messages.push(message);
             }
+
+            await writes;
 
             expect(messages[0].action).toEqual("CREATE");
             expect(messages[1].action).toEqual("UPDATE");

--- a/packages/tests/surrealdb/integration/query/live.test.ts
+++ b/packages/tests/surrealdb/integration/query/live.test.ts
@@ -306,7 +306,10 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
 
                 expect(subscription.isAlive).toBeTrue();
 
-                (async () => {
+                // Kept so it can be awaited below: the KILLED notification ends the iteration
+                // before this has finished, and a query still in flight when the test returns
+                // is failed with the connection the harness then closes.
+                const removal = (async () => {
                     await Bun.sleep(100);
                     // Removing the subscribed table terminates the live query
                     // server-side, which emits a KILLED notification.
@@ -316,6 +319,8 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
                 for await (const message of subscription) {
                     messages.push(message);
                 }
+
+                await removal;
 
                 // The final message is the server-side KILLED (which carries no
                 // record), and the subscription is no longer alive afterwards.
@@ -337,7 +342,9 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
 
             let latestId: Uuid = initialId;
 
-            (async () => {
+            // Kept so it can be awaited below, like the tests above: work still in flight when
+            // the test returns is failed with the connection the harness closes.
+            const restart = (async () => {
                 await Bun.sleep(100);
 
                 // Restart server and wait for reconnection
@@ -365,6 +372,8 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
             for await (const message of subscription) {
                 messages.push(message);
             }
+
+            await restart;
 
             expect(latestId).not.toEqual(initialId);
 

--- a/packages/tests/surrealdb/integration/query/streaming.test.ts
+++ b/packages/tests/surrealdb/integration/query/streaming.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "bun:test";
+import type { LiveMessage, QueryChunk, Uuid } from "surrealdb";
+import {
+    createSurreal,
+    getEngines,
+    SURREAL_PASS,
+    SURREAL_PORT,
+    SURREAL_PROTOCOL,
+    SURREAL_USER,
+} from "../__helpers__";
+
+/**
+ * Query results are streamed from the server when both sides support it, and
+ * buffered into a single response when they do not. Which of the two happened
+ * is deliberately invisible, so every test here holds either way: what is under
+ * test is that a streamed answer is the buffered answer, delivered piecewise.
+ */
+describe.if(SURREAL_PROTOCOL === "ws")("query streaming", () => {
+    // The range is exclusive of its end, so this many records exist.
+    const RECORDS = 119;
+
+    const MULTI = `
+        SELECT * FROM wide ORDER BY id;
+        RETURN 42;
+        SELECT count() FROM wide GROUP ALL;
+        SELECT * FROM ONLY wide ORDER BY id LIMIT 1;
+    `;
+
+    async function seeded() {
+        const surreal = await createSurreal();
+
+        await surreal.query("CREATE |wide:1..120| RETURN NONE").collect();
+
+        return surreal;
+    }
+
+    test("a streamed answer is the buffered answer", async () => {
+        const streamed = await seeded();
+        const buffered = await createSurreal({ driverOptions: { streaming: false } });
+
+        expect(await streamed.query(MULTI).collect()).toEqual(
+            await buffered.query(MULTI).collect(),
+        );
+    });
+
+    test("the statistics and types of every statement survive", async () => {
+        const surreal = await seeded();
+        const responses = await surreal.query(MULTI).responses();
+
+        expect(responses).toHaveLength(4);
+
+        for (const response of responses) {
+            expect(response.success).toBe(true);
+            expect(response.stats?.duration).toBeDefined();
+        }
+
+        expect(responses[0]?.success && responses[0].result).toBeArrayOfSize(RECORDS);
+        expect(responses[1]?.success && responses[1].result).toBe(42);
+        expect(responses[2]?.success && responses[2].result).toEqual([{ count: RECORDS }]);
+        expect(responses[3]?.success && responses[3].result).toHaveProperty("id");
+    });
+
+    test("frames rebuild the results the statements produced", async () => {
+        const surreal = await seeded();
+        const rebuilt: unknown[][] = [];
+        const finished: number[] = [];
+
+        for await (const frame of surreal.query(MULTI).stream()) {
+            if (frame.isError()) throw frame.error;
+
+            if (frame.isValue()) {
+                rebuilt[frame.query] ??= [];
+                rebuilt[frame.query]?.push(frame.value);
+            }
+
+            if (frame.isDone()) finished.push(frame.query);
+        }
+
+        // Statements are counted by their terminal frames, and each one is terminal once.
+        expect(finished.sort()).toEqual([0, 1, 2, 3]);
+        expect(rebuilt[0]).toBeArrayOfSize(RECORDS);
+        expect(rebuilt[1]).toEqual([42]);
+        expect(rebuilt[3]).toBeArrayOfSize(1);
+    });
+
+    test("a failing statement is reported without disturbing the others", async () => {
+        const surreal = await seeded();
+        const [first, second, third] = await surreal
+            .query(`SELECT * FROM wide LIMIT 2; THROW "nope"; RETURN 7;`)
+            .responses();
+
+        expect(first?.success).toBe(true);
+        expect(second?.success).toBe(false);
+        expect(second?.success === false && second.error.message).toContain("nope");
+        expect(third?.success).toBe(true);
+    });
+
+    test("a failure is the same failure either way", async () => {
+        const FAILING = `SELECT * FROM wide LIMIT 1; THROW "nope"; CREATE wide:1;`;
+
+        const streamed = await seeded();
+        const buffered = await createSurreal({ driverOptions: { streaming: false } });
+
+        const shape = (
+            responses: Awaited<ReturnType<ReturnType<typeof streamed.query>["responses"]>>,
+        ) =>
+            responses.map((response) =>
+                response.success
+                    ? { success: true }
+                    : {
+                          success: false,
+                          name: response.error.name,
+                          kind: response.error.kind,
+                          code: response.error.code,
+                          message: response.error.message,
+                      },
+            );
+
+        expect(shape(await streamed.query(FAILING).responses())).toEqual(
+            shape(await buffered.query(FAILING).responses()),
+        );
+    });
+
+    test("collecting a query which fails rejects rather than returning part of it", async () => {
+        const surreal = await seeded();
+
+        await expect(surreal.query(`SELECT * FROM wide; THROW "nope";`).collect()).rejects.toThrow(
+            "nope",
+        );
+    });
+
+    test("abandoning a query part way leaves the connection usable", async () => {
+        const surreal = await seeded();
+
+        for await (const frame of surreal.query("SELECT * FROM wide ORDER BY id").stream()) {
+            if (frame.isValue()) break;
+        }
+
+        const [count] = await surreal.query("SELECT count() FROM wide GROUP ALL").collect();
+
+        expect(count).toEqual([{ count: RECORDS }]);
+    });
+
+    test("results really are streamed in batches, when the server serves them that way", async () => {
+        const chunks: QueryChunk<unknown>[] = [];
+        const engines = await getEngines((diagnostic) => {
+            if (diagnostic.type !== "query" || diagnostic.phase !== "progress") return;
+            if (diagnostic.result.chunk) chunks.push(diagnostic.result.chunk);
+        });
+
+        const surreal = await createSurreal({ driverOptions: { engines } });
+
+        await surreal.query("CREATE |wide:1..120| RETURN NONE").collect();
+
+        chunks.length = 0;
+
+        const [rows] = await surreal.query("SELECT * FROM wide ORDER BY id").collect();
+
+        expect(rows).toBeArrayOfSize(RECORDS);
+        expect(chunks.at(-1)?.kind).toBe("batched-final");
+
+        if (await serverStreams()) {
+            // The server ramps its batches, so a result this size arrives in several frames and
+            // the rows reach the SDK before the statement is finished.
+            expect(chunks.filter((chunk) => chunk.kind === "batched")).not.toBeEmpty();
+            expect(chunks.length).toBeGreaterThan(2);
+        } else {
+            // Buffered: one response, one chunk carrying the whole statement.
+            expect(chunks).toHaveLength(1);
+        }
+    });
+
+    test("a live query registered through a query still delivers notifications", async () => {
+        const surreal = await createSurreal();
+        const writer = await createSurreal();
+
+        await surreal.query("DEFINE TABLE thing").collect();
+
+        const [id] = await surreal.query<[Uuid]>("LIVE SELECT * FROM thing").collect();
+        const subscription = await surreal.liveOf(id);
+        const received = new Promise<LiveMessage>((resolve) => {
+            subscription.subscribe(resolve);
+        });
+
+        await writer.query("CREATE thing:1 SET x = 1").collect();
+
+        const message = await received;
+
+        expect(message.action).toBe("CREATE");
+    });
+});
+
+let support: Promise<boolean> | undefined;
+
+/**
+ * Whether the server under test serves the streaming query method.
+ *
+ * Asked over a raw socket rather than through the SDK, whose whole point is to
+ * make the difference invisible: a test which wants to know that streaming
+ * actually happened cannot ask the thing it is testing.
+ */
+function serverStreams(): Promise<boolean> {
+    support ??= probeQueryStream();
+    return support;
+}
+
+async function probeQueryStream(): Promise<boolean> {
+    const socket = new WebSocket(`ws://127.0.0.1:${SURREAL_PORT}/rpc`, "json");
+
+    try {
+        await new Promise<void>((resolve, reject) => {
+            socket.addEventListener("open", () => resolve());
+            socket.addEventListener("error", () =>
+                reject(new Error("the probe could not connect")),
+            );
+        });
+
+        await probeRequest(socket, {
+            id: "probe-signin",
+            method: "signin",
+            params: [{ user: SURREAL_USER, pass: SURREAL_PASS }],
+        });
+
+        const answer = await probeRequest(socket, {
+            id: "probe-stream",
+            method: "query_stream",
+            params: ["RETURN 1"],
+        });
+
+        // A server without the method answers the request with Method not found; one with it
+        // answers with the first frame of the stream instead.
+        return answer.error?.code !== -32601;
+    } finally {
+        socket.close();
+    }
+}
+
+interface ProbeResponse {
+    id?: string;
+    result?: unknown;
+    error?: { code?: number; message?: string };
+}
+
+function probeRequest(
+    socket: WebSocket,
+    body: { id: string; method: string; params: unknown[] },
+): Promise<ProbeResponse> {
+    return new Promise<ProbeResponse>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            socket.removeEventListener("message", listener);
+            reject(new Error(`the probe request ${body.id} went unanswered`));
+        }, 10_000);
+
+        const listener = (event: MessageEvent) => {
+            const response = JSON.parse(event.data as string) as ProbeResponse;
+
+            if (response.id !== body.id) return;
+
+            clearTimeout(timer);
+            socket.removeEventListener("message", listener);
+            resolve(response);
+        };
+
+        socket.addEventListener("message", listener);
+        socket.send(JSON.stringify(body));
+    });
+}

--- a/packages/tests/surrealdb/integration/query/streaming.test.ts
+++ b/packages/tests/surrealdb/integration/query/streaming.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { LiveMessage, QueryChunk, Uuid } from "surrealdb";
+import { type LiveMessage, type QueryChunk, RecordId, type Surreal, type Uuid } from "surrealdb";
 import {
     createSurreal,
     getEngines,
@@ -16,8 +16,9 @@ import {
  * test is that a streamed answer is the buffered answer, delivered piecewise.
  */
 describe.if(SURREAL_PROTOCOL === "ws")("query streaming", () => {
-    // The range is exclusive of its end, so this many records exist.
-    const RECORDS = 119;
+    // Seeded explicitly rather than with a record range, whose bounds are not the same on every
+    // server version this suite runs against.
+    const RECORDS = 120;
 
     const MULTI = `
         SELECT * FROM wide ORDER BY id;
@@ -29,9 +30,18 @@ describe.if(SURREAL_PROTOCOL === "ws")("query streaming", () => {
     async function seeded() {
         const surreal = await createSurreal();
 
-        await surreal.query("CREATE |wide:1..120| RETURN NONE").collect();
+        await seed(surreal);
 
         return surreal;
+    }
+
+    async function seed(surreal: Surreal): Promise<void> {
+        await surreal.insert(
+            Array.from({ length: RECORDS }, (_, index) => ({
+                id: new RecordId("wide", index + 1),
+                n: index + 1,
+            })),
+        );
     }
 
     test("a streamed answer is the buffered answer", async () => {
@@ -150,7 +160,7 @@ describe.if(SURREAL_PROTOCOL === "ws")("query streaming", () => {
 
         const surreal = await createSurreal({ driverOptions: { engines } });
 
-        await surreal.query("CREATE |wide:1..120| RETURN NONE").collect();
+        await seed(surreal);
 
         chunks.length = 0;
 

--- a/packages/tests/surrealdb/typecheck/check.ts
+++ b/packages/tests/surrealdb/typecheck/check.ts
@@ -56,6 +56,33 @@ async function _main() {
         .query("SELECT * FROM $table WHERE age > $age", { table, age: 25 })
         .collect<[Person[]]>();
 
+    // Streamed results: a frame of a statement which answers with a list of records carries one
+    // of those records, and one which answers with a single value carries that value.
+    for await (const frame of db.select<Person>(table).stream()) {
+        if (frame.isValue()) {
+            const _row: Person = frame.value;
+        }
+    }
+
+    for await (const frame of db.select<Person>(_stringId).stream()) {
+        if (frame.isValue()) {
+            const _only: Person | undefined = frame.value;
+        }
+    }
+
+    for await (const frame of db.insert<Person>(table, [{ name: "Tobie", age: 30 }]).stream()) {
+        if (frame.isValue()) {
+            const _inserted: Person = frame.value;
+        }
+    }
+
+    for await (const frame of db.run<number>("fn::count").stream()) {
+        if (frame.isValue()) {
+            // A `RETURN` is one value, so the frame carries the whole result.
+            const _returned: number = frame.value;
+        }
+    }
+
     // Live queries
     const stream = await db.live(table);
     for await (const { action, value } of stream) {

--- a/packages/tests/surrealdb/unit/__helpers__/mock-socket.ts
+++ b/packages/tests/surrealdb/unit/__helpers__/mock-socket.ts
@@ -139,7 +139,9 @@ export function mockContext(options: { streaming?: boolean } = {}): DriverContex
  * about what happens across sockets, as a mocked socket only ever closes
  * because a test closed it.
  */
-export function mockState(reconnect: boolean | { retryDelay?: number } = false): ConnectionState {
+export function mockState(
+    reconnect: boolean | { retryDelay?: number; retryDelayMax?: number } = false,
+): ConnectionState {
     return {
         url: new URL("ws://localhost:8000/rpc"),
         reconnect: new ReconnectContext(

--- a/packages/tests/surrealdb/unit/__helpers__/mock-socket.ts
+++ b/packages/tests/surrealdb/unit/__helpers__/mock-socket.ts
@@ -1,0 +1,163 @@
+import { CborCodec } from "@surrealdb/sqon";
+import type { ConnectionState, DriverContext } from "surrealdb";
+import { ReconnectContext } from "../../../../sdk/src/internal/reconnect";
+import { DEFAULT_RETRY_OPTIONS } from "../../../../sdk/src/internal/retry";
+
+/** A request as it arrived over the mocked socket. */
+export interface MockRequest {
+    id: string;
+    method: string;
+    params?: unknown[];
+    txn?: unknown;
+    session?: unknown;
+}
+
+type Listener = (event: unknown) => void;
+
+const codec = new CborCodec({});
+
+/**
+ * A `WebSocket` implementation which hands every request to a test provided
+ * handler and lets it answer with any number of responses.
+ *
+ * The engine is driven over its real transport this way: requests are encoded
+ * and responses decoded by the same codec a server would use, so frame
+ * ordering, correlation by request id and cancellation are all exercised.
+ */
+export class MockSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    /** Every socket opened since the last `reset`, newest last. */
+    static sockets: MockSocket[] = [];
+
+    /** Answers each request. Assigned per test. */
+    static handler: ((socket: MockSocket, request: MockRequest) => void) | undefined;
+
+    static reset(): void {
+        MockSocket.sockets = [];
+        MockSocket.handler = undefined;
+    }
+
+    /** The socket most recently opened. */
+    static get current(): MockSocket {
+        const socket = MockSocket.sockets.at(-1);
+        if (!socket) throw new Error("No socket has been opened");
+        return socket;
+    }
+
+    readyState: number = MockSocket.CONNECTING;
+    binaryType = "arraybuffer";
+
+    /** Every request received, in order. */
+    readonly requests: MockRequest[] = [];
+
+    #listeners = new Map<string, Set<Listener>>();
+
+    constructor(
+        readonly url: string,
+        readonly protocol?: string,
+    ) {
+        MockSocket.sockets.push(this);
+
+        queueMicrotask(() => {
+            if (this.readyState !== MockSocket.CONNECTING) return;
+            this.readyState = MockSocket.OPEN;
+            this.#emit("open", {});
+        });
+    }
+
+    addEventListener(type: string, listener: Listener): void {
+        const listeners = this.#listeners.get(type) ?? new Set();
+        listeners.add(listener);
+        this.#listeners.set(type, listeners);
+    }
+
+    removeEventListener(type: string, listener: Listener): void {
+        this.#listeners.get(type)?.delete(listener);
+    }
+
+    send(data: Uint8Array): void {
+        const request = codec.decode<MockRequest>(new Uint8Array(data));
+        this.requests.push(request);
+        MockSocket.handler?.(this, request);
+    }
+
+    close(): void {
+        if (this.readyState === MockSocket.CLOSED) return;
+        this.readyState = MockSocket.CLOSED;
+        this.#emit("close", {});
+    }
+
+    /** Delivers one response to the engine, as an arraybuffer socket would. */
+    respond(response: object): void {
+        const encoded = new Uint8Array(codec.encode(response));
+        const buffer = encoded.buffer.slice(
+            encoded.byteOffset,
+            encoded.byteOffset + encoded.byteLength,
+        );
+
+        this.#emit("message", { data: buffer });
+    }
+
+    /** The requests received for a given method. */
+    requestsFor(method: string): MockRequest[] {
+        return this.requests.filter((request) => request.method === method);
+    }
+
+    #emit(type: string, event: object): void {
+        for (const listener of this.#listeners.get(type) ?? []) {
+            listener(event);
+        }
+    }
+}
+
+/**
+ * A driver context wired to the mocked socket.
+ */
+export function mockContext(options: { streaming?: boolean } = {}): DriverContext {
+    let id = 0;
+
+    return {
+        options: {
+            websocketImpl: MockSocket as unknown as typeof WebSocket,
+            ...options,
+        },
+        uniqueId: () => `req-${++id}`,
+        codecs: {
+            cbor: codec,
+            flatbuffer: undefined as never,
+            json: undefined as never,
+        },
+    };
+}
+
+/**
+ * A connection state for the mocked socket. Reconnect is off unless a test is
+ * about what happens across sockets, as a mocked socket only ever closes
+ * because a test closed it.
+ */
+export function mockState(reconnect: boolean | { retryDelay?: number } = false): ConnectionState {
+    return {
+        url: new URL("ws://localhost:8000/rpc"),
+        reconnect: new ReconnectContext(
+            typeof reconnect === "boolean"
+                ? reconnect
+                : { enabled: true, retryDelay: 1, retryDelayMax: 1, ...reconnect },
+        ),
+        retry: DEFAULT_RETRY_OPTIONS,
+        rootSession: {
+            id: undefined,
+            namespace: "test",
+            database: "test",
+            accessToken: undefined,
+            refreshToken: undefined,
+            variables: {},
+            authRenewal: undefined,
+            authOverriden: false,
+        },
+        sessions: new Map(),
+    };
+}

--- a/packages/tests/surrealdb/unit/streaming/engine.test.ts
+++ b/packages/tests/surrealdb/unit/streaming/engine.test.ts
@@ -20,7 +20,10 @@ afterEach(async () => {
 
 /** Opens an engine against the mocked socket and waits until it is connected. */
 async function openEngine(
-    options: { streaming?: boolean; reconnect?: boolean } = {},
+    options: {
+        streaming?: boolean;
+        reconnect?: boolean | { retryDelay?: number; retryDelayMax?: number };
+    } = {},
 ): Promise<WebSocketEngine> {
     const opened = new WebSocketEngine(mockContext({ streaming: options.streaming }));
 
@@ -424,6 +427,38 @@ describe("websocket query streaming", () => {
         expect(cancel?.params).toEqual([stream?.id]);
     });
 
+    test("abandoning a read parked on a frame lets go of the consumer at once", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, [
+                    { stream: "begin", statements: 1 },
+                    { stream: "rows", index: 0, values: [{ n: 1 }] },
+                ]);
+            }
+        };
+
+        const iterator = started
+            .query(new BoundQuery("SELECT * FROM person"), undefined)
+            [Symbol.asyncIterator]();
+
+        await iterator.next();
+
+        // A consumer which races a read against a timeout leaves while that read is still
+        // parked on a frame the server is not going to send.
+        const parked = iterator.next();
+        const returned = iterator.return?.();
+
+        const outcome = await Promise.race([
+            Promise.all([parked, returned]).then(() => "let go"),
+            Bun.sleep(2_000).then(() => "still waiting"),
+        ]);
+
+        expect(outcome).toBe("let go");
+        expect(MockSocket.current.requestsFor("query_cancel")).toHaveLength(1);
+    });
+
     test("a stream which ran to its end is not cancelled", async () => {
         const started = await openEngine();
 
@@ -517,6 +552,34 @@ describe("websocket query streaming", () => {
 
         expect(ids).toHaveLength(2);
         expect(new Set(ids).size).toBe(1);
+    });
+
+    test("closing during a reconnect cooldown settles a stream waiting for a socket", async () => {
+        // A cooldown long enough that the close below lands inside it.
+        const started = await openEngine({
+            reconnect: { retryDelay: 5_000, retryDelayMax: 5_000 },
+        });
+
+        MockSocket.handler = (socket, request) => {
+            // The request is written and the socket dies with nothing framed, so the stream is
+            // held for the next socket - which closing means will never come.
+            if (request.method === "query_stream") {
+                queueMicrotask(() => socket.close());
+            }
+        };
+
+        const attempt = collect(started.query(new BoundQuery("SELECT * FROM person"), undefined))
+            .then(() => "resolved")
+            .catch((error: Error) => error.constructor.name);
+
+        await Bun.sleep(50);
+        await started.close();
+
+        // Raced rather than awaited: an unsettled stream would otherwise hang the run rather
+        // than fail it.
+        const outcome = await Promise.race([attempt, Bun.sleep(2_000).then(() => "still waiting")]);
+
+        expect(outcome).toBe("CallTerminatedError");
     });
 
     test("a query which lost its socket part way through is failed, never replayed", async () => {

--- a/packages/tests/surrealdb/unit/streaming/engine.test.ts
+++ b/packages/tests/surrealdb/unit/streaming/engine.test.ts
@@ -394,6 +394,36 @@ describe("websocket query streaming", () => {
         expect(second.flatMap((chunk) => chunk.result ?? [])).toEqual(["two-a", "two-b"]);
     });
 
+    test("a stream abandoned between frames lets go of its consumer at once", async () => {
+        const started = await openEngine();
+
+        // One frame and then silence: a real stream can sit for a long time between frames, or
+        // produce none at all, and leaving it must not wait for the next one.
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, [
+                    { stream: "begin", statements: 1 },
+                    { stream: "rows", index: 0, values: [{ n: 1 }] },
+                ]);
+            }
+        };
+
+        for await (const chunk of started.query(
+            new BoundQuery("SELECT * FROM person"),
+            undefined,
+        )) {
+            expect(chunk.kind).toBe("batched");
+            break;
+        }
+
+        // Reaching here at all is the assertion: the loop would otherwise be parked on a frame
+        // the server is never going to send.
+        const [stream] = MockSocket.current.requestsFor("query_stream");
+        const [cancel] = MockSocket.current.requestsFor("query_cancel");
+
+        expect(cancel?.params).toEqual([stream?.id]);
+    });
+
     test("a stream which ran to its end is not cancelled", async () => {
         const started = await openEngine();
 
@@ -449,40 +479,44 @@ describe("websocket query streaming", () => {
         await expect(attempt).rejects.toBeInstanceOf(UnexpectedServerResponseError);
     });
 
-    test("a query which lost its socket before any frame is answered after reconnecting", async () => {
+    test("a query which lost its socket before any frame is re-sent on the next one", async () => {
         const started = await openEngine({ reconnect: true });
         const first = MockSocket.current;
 
-        // The connection controller re-sends the calls still pending once a new socket is up.
+        // The connection controller re-sends what is still pending once a new socket is up.
         const controller = started.subscribe("connected", () => started.ready());
 
         MockSocket.handler = (socket, request) => {
-            if (request.method === "query_stream") {
-                // The socket dies with the request written and nothing framed.
+            if (request.method !== "query_stream") return;
+
+            // The first socket dies with the request written and nothing framed; the second
+            // answers it.
+            if (socket === first) {
                 queueMicrotask(() => socket.close());
                 return;
             }
 
-            if (request.method === "query") {
-                queueMicrotask(() => socket.respond(bufferedResponse(request, [{ n: 1 }])));
-            }
+            respondWithFrames(socket, request, ROWS_THEN_VALUE);
         };
 
-        const reconnected = nextConnection(started);
         const chunks = await collect(
             started.query(new BoundQuery("SELECT * FROM person"), undefined),
         );
 
-        await reconnected;
-
         controller();
 
-        // The buffered call was queued while the socket was gone and re-sent on the new one.
-        expect(chunks).toHaveLength(1);
-        expect(chunks[0]?.result).toEqual([{ n: 1 }]);
+        // Nothing had been framed, so the query never ran and the same request is simply asked
+        // again - not turned into a buffered query, and not answered twice.
+        expect(chunks.map((chunk) => chunk.kind)).toEqual(["batched", "batched-final", "single"]);
         expect(MockSocket.sockets.length).toBeGreaterThan(1);
-        expect(first.requestsFor("query_stream")).toHaveLength(1);
-        expect(MockSocket.current.requestsFor("query")).toHaveLength(1);
+        expect(MockSocket.current.requestsFor("query")).toBeEmpty();
+
+        const ids = MockSocket.sockets.flatMap((socket) =>
+            socket.requestsFor("query_stream").map((request) => request.id),
+        );
+
+        expect(ids).toHaveLength(2);
+        expect(new Set(ids).size).toBe(1);
     });
 
     test("a query which lost its socket part way through is failed, never replayed", async () => {

--- a/packages/tests/surrealdb/unit/streaming/engine.test.ts
+++ b/packages/tests/surrealdb/unit/streaming/engine.test.ts
@@ -1,0 +1,577 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+    BoundQuery,
+    CallTerminatedError,
+    type QueryChunk,
+    RecordId,
+    UnexpectedServerResponseError,
+    Uuid,
+    WebSocketEngine,
+} from "surrealdb";
+import { type MockRequest, MockSocket, mockContext, mockState } from "../__helpers__/mock-socket";
+
+let engine: WebSocketEngine | undefined;
+
+afterEach(async () => {
+    await engine?.close();
+    engine = undefined;
+    MockSocket.reset();
+});
+
+/** Opens an engine against the mocked socket and waits until it is connected. */
+async function openEngine(
+    options: { streaming?: boolean; reconnect?: boolean } = {},
+): Promise<WebSocketEngine> {
+    const opened = new WebSocketEngine(mockContext({ streaming: options.streaming }));
+
+    engine = opened;
+
+    const connected = nextConnection(opened);
+
+    opened.open(mockState(options.reconnect ?? false));
+
+    await connected;
+
+    return opened;
+}
+
+/** Resolves the next time the engine reports itself connected. */
+function nextConnection(target: WebSocketEngine): Promise<void> {
+    return new Promise<void>((resolve) => {
+        const unsubscribe = target.subscribe("connected", () => {
+            unsubscribe();
+            resolve();
+        });
+    });
+}
+
+/** Answers a `query_stream` request with a script of frames, one response each. */
+function respondWithFrames(socket: MockSocket, request: MockRequest, frames: object[]): void {
+    for (const frame of frames) {
+        queueMicrotask(() => socket.respond({ id: request.id, result: frame }));
+    }
+}
+
+/** The buffered answer to a `query` request, for a single statement. */
+function bufferedResponse(request: MockRequest, result: unknown): object {
+    return {
+        id: request.id,
+        result: [{ status: "OK", time: "1ms", result, type: "other" }],
+    };
+}
+
+const ROWS_THEN_VALUE = [
+    { stream: "begin", statements: 2 },
+    { stream: "rows", index: 0, values: [{ n: 1 }, { n: 2 }] },
+    { stream: "finished", index: 0, time: "1ms", type: "other", single: false },
+    { stream: "value", index: 1, value: 42 },
+    { stream: "finished", index: 1, time: "1ms", type: "other", single: true },
+    { stream: "end", results: 2, time: "2ms" },
+];
+
+async function collect<T>(chunks: AsyncIterable<QueryChunk<T>>): Promise<QueryChunk<T>[]> {
+    const collected: QueryChunk<T>[] = [];
+
+    for await (const chunk of chunks) {
+        collected.push(chunk);
+    }
+
+    return collected;
+}
+
+describe("websocket query streaming", () => {
+    test("a query is sent as a streaming request and answered by its frames", async () => {
+        const started = await openEngine();
+        const session = Uuid.v4();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, ROWS_THEN_VALUE);
+            }
+        };
+
+        const chunks = await collect(
+            started.query(
+                new BoundQuery("SELECT * FROM person WHERE age > $age", { age: 18 }),
+                session,
+            ),
+        );
+
+        const [stream] = MockSocket.current.requestsFor("query_stream");
+
+        expect(stream?.params).toEqual(["SELECT * FROM person WHERE age > $age", { age: 18 }]);
+        expect(stream?.session?.toString()).toBe(session.toString());
+        expect(MockSocket.current.requestsFor("query")).toBeEmpty();
+        expect(chunks.map((chunk) => chunk.kind)).toEqual(["batched", "batched-final", "single"]);
+        expect(chunks[0]?.result).toEqual([{ n: 1 }, { n: 2 }]);
+        expect(chunks[2]?.result).toEqual([42]);
+    });
+
+    test("abandoning a stream cancels it and discards the frames still in flight", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, [
+                    { stream: "begin", statements: 1 },
+                    { stream: "rows", index: 0, values: [{ n: 1 }] },
+                ]);
+            }
+
+            if (request.method === "query_cancel") {
+                queueMicrotask(() => socket.respond({ id: request.id, result: null }));
+            }
+        };
+
+        for await (const chunk of started.query(
+            new BoundQuery("SELECT * FROM person"),
+            undefined,
+        )) {
+            expect(chunk.kind).toBe("batched");
+            break;
+        }
+
+        const [stream] = MockSocket.current.requestsFor("query_stream");
+        const [cancel] = MockSocket.current.requestsFor("query_cancel");
+
+        expect(cancel?.params).toEqual([stream?.id]);
+
+        // The frames the server had already sent arrive after the consumer left, and are discarded
+        // without disturbing the connection.
+        let failure: Error | undefined;
+
+        started.subscribe("error", (error) => {
+            failure = error;
+        });
+
+        MockSocket.current.respond({
+            id: stream?.id,
+            result: {
+                stream: "end",
+                results: 0,
+                time: "1ms",
+                error: { code: -32005, message: "stopped", kind: "Query" },
+            },
+        });
+
+        await Bun.sleep(1);
+
+        expect(failure).toBeUndefined();
+    });
+
+    test.each([
+        [-32601, "Method not found"],
+        [-32602, "Method not allowed"],
+    ])(
+        "a server which answers %p for the streaming method is used as before",
+        async (code, message) => {
+            const started = await openEngine();
+
+            MockSocket.handler = (socket, request) => {
+                if (request.method === "query_stream") {
+                    queueMicrotask(() =>
+                        socket.respond({
+                            id: request.id,
+                            error: { code, message },
+                        }),
+                    );
+                }
+
+                if (request.method === "query") {
+                    queueMicrotask(() => socket.respond(bufferedResponse(request, [{ n: 1 }])));
+                }
+            };
+
+            const first = await collect(
+                started.query(new BoundQuery("SELECT * FROM person"), undefined),
+            );
+
+            expect(first).toHaveLength(1);
+            expect(first[0]).toMatchObject({ kind: "batched-final", result: [{ n: 1 }] });
+
+            // The absence is remembered, so the next query does not ask again.
+            const second = await collect(
+                started.query(new BoundQuery("SELECT * FROM person"), undefined),
+            );
+
+            expect(second).toHaveLength(1);
+            expect(MockSocket.current.requestsFor("query_stream")).toHaveLength(1);
+            expect(MockSocket.current.requestsFor("query")).toHaveLength(2);
+        },
+    );
+
+    test("a stream refused for want of capacity falls back only for that query", async () => {
+        const started = await openEngine();
+
+        let refused = false;
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                if (!refused) {
+                    refused = true;
+
+                    queueMicrotask(() =>
+                        socket.respond({
+                            id: request.id,
+                            error: {
+                                code: -32603,
+                                message: "Too many concurrent streaming queries",
+                                kind: "Validation",
+                            },
+                        }),
+                    );
+
+                    return;
+                }
+
+                respondWithFrames(socket, request, ROWS_THEN_VALUE);
+            }
+
+            if (request.method === "query") {
+                queueMicrotask(() => socket.respond(bufferedResponse(request, [{ n: 1 }])));
+            }
+        };
+
+        const first = await collect(started.query(new BoundQuery("SELECT 1"), undefined));
+        const second = await collect(started.query(new BoundQuery("SELECT 2"), undefined));
+
+        expect(first[0]).toMatchObject({ kind: "batched-final", result: [{ n: 1 }] });
+        expect(second).toHaveLength(3);
+        expect(MockSocket.current.requestsFor("query_stream")).toHaveLength(2);
+        expect(MockSocket.current.requestsFor("query")).toHaveLength(1);
+    });
+
+    test("a stream which failed after framing is never replayed as a buffered query", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, [
+                    { stream: "begin", statements: 1 },
+                    {
+                        stream: "end",
+                        results: 0,
+                        time: "1ms",
+                        error: { code: -32004, message: "The query timed out", kind: "Query" },
+                    },
+                ]);
+            }
+        };
+
+        const attempt = collect(started.query(new BoundQuery("SELECT * FROM person"), undefined));
+
+        await expect(attempt).rejects.toThrow("timed out");
+
+        await Bun.sleep(1);
+
+        expect(MockSocket.current.requestsFor("query")).toBeEmpty();
+    });
+
+    test("a stream is failed rather than replayed when its socket goes away", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, [{ stream: "begin", statements: 1 }]);
+            }
+        };
+
+        const chunks = started.query(new BoundQuery("SELECT * FROM person"), undefined);
+        const iterator = chunks[Symbol.asyncIterator]();
+        const first = iterator.next();
+
+        await Bun.sleep(1);
+
+        MockSocket.current.close();
+
+        await expect(first).rejects.toBeInstanceOf(CallTerminatedError);
+    });
+
+    test("a query inside a transaction is never streamed", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query") {
+                queueMicrotask(() => socket.respond(bufferedResponse(request, [{ n: 1 }])));
+            }
+        };
+
+        const chunks = await collect(
+            started.query(new BoundQuery("SELECT * FROM person"), undefined, Uuid.v4()),
+        );
+
+        expect(chunks).toHaveLength(1);
+        expect(MockSocket.current.requestsFor("query_stream")).toBeEmpty();
+        expect(MockSocket.current.requestsFor("query")).toHaveLength(1);
+    });
+
+    test("streaming can be turned off for the driver", async () => {
+        const started = await openEngine({ streaming: false });
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query") {
+                queueMicrotask(() => socket.respond(bufferedResponse(request, [{ n: 1 }])));
+            }
+        };
+
+        await collect(started.query(new BoundQuery("SELECT * FROM person"), undefined));
+
+        expect(MockSocket.current.requestsFor("query_stream")).toBeEmpty();
+        expect(MockSocket.current.requestsFor("query")).toHaveLength(1);
+    });
+
+    test("a long burst of frames arrives complete and in order", async () => {
+        const started = await openEngine();
+
+        // Frames as the server ramps its batches: 16, 32, 64, 128, then 256 at a time.
+        const batches: number[] = [16, 32, 64, 128];
+        while (batches.reduce((total, size) => total + size, 0) < 2000) batches.push(256);
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method !== "query_stream") return;
+
+            let next = 0;
+            const frames: object[] = [{ stream: "begin", statements: 1 }];
+
+            for (const size of batches) {
+                frames.push({
+                    stream: "rows",
+                    index: 0,
+                    values: Array.from({ length: size }, () => next++),
+                });
+            }
+
+            frames.push({
+                stream: "finished",
+                index: 0,
+                time: "1ms",
+                type: "other",
+                single: false,
+            });
+            frames.push({ stream: "end", results: 1, time: "1ms" });
+
+            respondWithFrames(socket, request, frames);
+        };
+
+        const rows: number[] = [];
+
+        for await (const chunk of started.query<number>(
+            new BoundQuery("SELECT * FROM wide"),
+            undefined,
+        )) {
+            rows.push(...(chunk.result ?? []));
+        }
+
+        const expected = batches.reduce((total, size) => total + size, 0);
+
+        expect(rows).toHaveLength(expected);
+        expect(rows).toEqual(Array.from({ length: expected }, (_, index) => index));
+    });
+
+    test("two streams on one connection keep their own frames", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method !== "query_stream") return;
+
+            const marker = request.params?.[0] === "SELECT 1" ? "one" : "two";
+
+            respondWithFrames(socket, request, [
+                { stream: "begin", statements: 1 },
+                { stream: "rows", index: 0, values: [`${marker}-a`] },
+                { stream: "rows", index: 0, values: [`${marker}-b`] },
+                { stream: "finished", index: 0, time: "1ms", type: "other", single: false },
+                { stream: "end", results: 1, time: "1ms" },
+            ]);
+        };
+
+        const [first, second] = await Promise.all([
+            collect(started.query<string>(new BoundQuery("SELECT 1"), undefined)),
+            collect(started.query<string>(new BoundQuery("SELECT 2"), undefined)),
+        ]);
+
+        expect(first.flatMap((chunk) => chunk.result ?? [])).toEqual(["one-a", "one-b"]);
+        expect(second.flatMap((chunk) => chunk.result ?? [])).toEqual(["two-a", "two-b"]);
+    });
+
+    test("a stream which ran to its end is not cancelled", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, ROWS_THEN_VALUE);
+            }
+        };
+
+        await collect(started.query(new BoundQuery("SELECT * FROM person"), undefined));
+        await Bun.sleep(1);
+
+        expect(MockSocket.current.requestsFor("query_cancel")).toBeEmpty();
+    });
+
+    test("every streaming request carries its own id", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, ROWS_THEN_VALUE);
+            }
+        };
+
+        await Promise.all([
+            collect(started.query(new BoundQuery("SELECT 1"), undefined)),
+            collect(started.query(new BoundQuery("SELECT 2"), undefined)),
+        ]);
+
+        const ids = MockSocket.current.requestsFor("query_stream").map((request) => request.id);
+
+        expect(ids).toHaveLength(2);
+        expect(new Set(ids).size).toBe(2);
+
+        for (const id of ids) {
+            expect(id).toBeString();
+            expect(id).not.toBeEmpty();
+        }
+    });
+
+    test("a response which is not a frame fails the stream", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                // A payload of the shape any other method would answer with.
+                queueMicrotask(() => socket.respond({ id: request.id, result: [{ n: 1 }] }));
+            }
+        };
+
+        const attempt = collect(started.query(new BoundQuery("SELECT * FROM person"), undefined));
+
+        await expect(attempt).rejects.toBeInstanceOf(UnexpectedServerResponseError);
+    });
+
+    test("a query which lost its socket before any frame is answered after reconnecting", async () => {
+        const started = await openEngine({ reconnect: true });
+        const first = MockSocket.current;
+
+        // The connection controller re-sends the calls still pending once a new socket is up.
+        const controller = started.subscribe("connected", () => started.ready());
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                // The socket dies with the request written and nothing framed.
+                queueMicrotask(() => socket.close());
+                return;
+            }
+
+            if (request.method === "query") {
+                queueMicrotask(() => socket.respond(bufferedResponse(request, [{ n: 1 }])));
+            }
+        };
+
+        const reconnected = nextConnection(started);
+        const chunks = await collect(
+            started.query(new BoundQuery("SELECT * FROM person"), undefined),
+        );
+
+        await reconnected;
+
+        controller();
+
+        // The buffered call was queued while the socket was gone and re-sent on the new one.
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0]?.result).toEqual([{ n: 1 }]);
+        expect(MockSocket.sockets.length).toBeGreaterThan(1);
+        expect(first.requestsFor("query_stream")).toHaveLength(1);
+        expect(MockSocket.current.requestsFor("query")).toHaveLength(1);
+    });
+
+    test("a query which lost its socket part way through is failed, never replayed", async () => {
+        const started = await openEngine({ reconnect: true });
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method === "query_stream") {
+                respondWithFrames(socket, request, [
+                    { stream: "begin", statements: 1 },
+                    { stream: "rows", index: 0, values: [{ n: 1 }] },
+                ]);
+                queueMicrotask(() => socket.close());
+            }
+        };
+
+        const attempt = collect(started.query(new BoundQuery("SELECT * FROM person"), undefined));
+
+        await expect(attempt).rejects.toBeInstanceOf(CallTerminatedError);
+
+        const requests = MockSocket.sockets.flatMap((socket) => socket.requests);
+
+        expect(requests.filter((request) => request.method === "query")).toBeEmpty();
+    });
+
+    test("a second query and live notifications flow while a stream is open", async () => {
+        const started = await openEngine();
+
+        const live = Uuid.v4();
+        let held: MockRequest | undefined;
+
+        MockSocket.handler = (socket, request) => {
+            if (request.method !== "query_stream") return;
+
+            // The long running query is left open; anything else is answered in full.
+            if (request.params?.[0] === "SLEEP 5s") {
+                held = request;
+                respondWithFrames(socket, request, [{ stream: "begin", statements: 1 }]);
+                return;
+            }
+
+            respondWithFrames(socket, request, [
+                { stream: "begin", statements: 1 },
+                { stream: "value", index: 0, value: 7 },
+                { stream: "finished", index: 0, time: "1ms", type: "other", single: true },
+                { stream: "end", results: 1, time: "1ms" },
+            ]);
+        };
+
+        const iterator = started
+            .query(new BoundQuery("SLEEP 5s"), undefined)
+            [Symbol.asyncIterator]();
+        const pending = iterator.next();
+
+        await Bun.sleep(1);
+
+        // A second query answers while the first stream occupies the connection.
+        const notifications = started.liveQuery(live)[Symbol.asyncIterator]();
+        const notification = notifications.next();
+        const second = await collect(started.query(new BoundQuery("RETURN 7"), undefined));
+
+        expect(second.at(-1)?.result).toEqual([7]);
+
+        // A live notification carries no request id, and is dispatched as usual.
+        MockSocket.current.respond({
+            result: {
+                id: live,
+                action: "CREATE",
+                record: new RecordId("thing", 1),
+                result: { n: 1 },
+            },
+        });
+
+        expect((await notification).value).toMatchObject({ action: "CREATE" });
+
+        // And the held stream still completes on its own terms.
+        MockSocket.current.respond({
+            id: held?.id,
+            result: { stream: "value", index: 0, value: "slept" },
+        });
+        MockSocket.current.respond({
+            id: held?.id,
+            result: { stream: "finished", index: 0, time: "5s", type: "other", single: true },
+        });
+        MockSocket.current.respond({
+            id: held?.id,
+            result: { stream: "end", results: 1, time: "5s" },
+        });
+
+        expect((await pending).value).toMatchObject({ kind: "single", result: ["slept"] });
+        expect((await iterator.next()).done).toBe(true);
+    });
+});

--- a/packages/tests/surrealdb/unit/streaming/engine.test.ts
+++ b/packages/tests/surrealdb/unit/streaming/engine.test.ts
@@ -554,32 +554,52 @@ describe("websocket query streaming", () => {
         expect(new Set(ids).size).toBe(1);
     });
 
-    test("closing answers a stream the way it answers a buffered call", async () => {
-        // Closing abandons the work in flight rather than failing it, for both kinds of query.
-        // A streamed query which answered a `close` differently - by rejecting - would turn a
-        // query nobody is holding into an unhandled rejection, which a buffered one never does.
+    test("closing fails a query in flight, streamed or buffered alike", async () => {
         for (const streaming of [true, false]) {
             MockSocket.reset();
 
             const started = await openEngine({ streaming });
 
             MockSocket.handler = () => {
-                // Answer nothing: the query is still in flight when the engine is closed.
+                // Answer nothing: the query is in flight when the connection is closed.
             };
 
-            const outcomes: string[] = [];
-            const attempt = collect(started.query(new BoundQuery("SLEEP 5s"), undefined))
-                .then(() => outcomes.push("resolved"))
-                .catch((error: Error) => outcomes.push(`rejected: ${error.constructor.name}`));
+            const attempt = collect(started.query(new BoundQuery("SLEEP 5s"), undefined));
+            const outcome = attempt.then(
+                () => "resolved",
+                (error: Error) => error.constructor.name,
+            );
 
             await Bun.sleep(10);
             await started.close();
-            await Promise.race([attempt, Bun.sleep(500)]);
 
-            expect(outcomes).toBeEmpty();
+            // Raced, so a promise which never settles fails this rather than hanging the run.
+            expect(
+                await Promise.race([outcome, Bun.sleep(1_000).then(() => "still waiting")]),
+            ).toBe("CallTerminatedError");
 
             engine = undefined;
         }
+    });
+
+    test("a query issued after closing is refused rather than queued", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = () => {};
+
+        await started.close();
+
+        const attempt = collect(started.query(new BoundQuery("RETURN 1"), undefined));
+        const outcome = attempt.then(
+            () => "resolved",
+            (error: Error) => error.constructor.name,
+        );
+
+        expect(await Promise.race([outcome, Bun.sleep(1_000).then(() => "still waiting")])).toBe(
+            "ConnectionUnavailableError",
+        );
+
+        engine = undefined;
     });
 
     test("a query which lost its socket part way through is failed, never replayed", async () => {

--- a/packages/tests/surrealdb/unit/streaming/engine.test.ts
+++ b/packages/tests/surrealdb/unit/streaming/engine.test.ts
@@ -554,32 +554,32 @@ describe("websocket query streaming", () => {
         expect(new Set(ids).size).toBe(1);
     });
 
-    test("closing during a reconnect cooldown settles a stream waiting for a socket", async () => {
-        // A cooldown long enough that the close below lands inside it.
-        const started = await openEngine({
-            reconnect: { retryDelay: 5_000, retryDelayMax: 5_000 },
-        });
+    test("closing answers a stream the way it answers a buffered call", async () => {
+        // Closing abandons the work in flight rather than failing it, for both kinds of query.
+        // A streamed query which answered a `close` differently - by rejecting - would turn a
+        // query nobody is holding into an unhandled rejection, which a buffered one never does.
+        for (const streaming of [true, false]) {
+            MockSocket.reset();
 
-        MockSocket.handler = (socket, request) => {
-            // The request is written and the socket dies with nothing framed, so the stream is
-            // held for the next socket - which closing means will never come.
-            if (request.method === "query_stream") {
-                queueMicrotask(() => socket.close());
-            }
-        };
+            const started = await openEngine({ streaming });
 
-        const attempt = collect(started.query(new BoundQuery("SELECT * FROM person"), undefined))
-            .then(() => "resolved")
-            .catch((error: Error) => error.constructor.name);
+            MockSocket.handler = () => {
+                // Answer nothing: the query is still in flight when the engine is closed.
+            };
 
-        await Bun.sleep(50);
-        await started.close();
+            const outcomes: string[] = [];
+            const attempt = collect(started.query(new BoundQuery("SLEEP 5s"), undefined))
+                .then(() => outcomes.push("resolved"))
+                .catch((error: Error) => outcomes.push(`rejected: ${error.constructor.name}`));
 
-        // Raced rather than awaited: an unsettled stream would otherwise hang the run rather
-        // than fail it.
-        const outcome = await Promise.race([attempt, Bun.sleep(2_000).then(() => "still waiting")]);
+            await Bun.sleep(10);
+            await started.close();
+            await Promise.race([attempt, Bun.sleep(500)]);
 
-        expect(outcome).toBe("CallTerminatedError");
+            expect(outcomes).toBeEmpty();
+
+            engine = undefined;
+        }
     });
 
     test("a query which lost its socket part way through is failed, never replayed", async () => {

--- a/packages/tests/surrealdb/unit/streaming/frames.test.ts
+++ b/packages/tests/surrealdb/unit/streaming/frames.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from "bun:test";
+import type { QueryChunk } from "surrealdb";
+import { CallTerminatedError, ThrownError, UnexpectedServerResponseError } from "surrealdb";
+import {
+    type QueryStreamFrame,
+    queryStreamChunks,
+} from "../../../../sdk/src/internal/query-stream";
+
+/** Feeds a fixed script of frames to the translator. */
+async function collectChunks(frames: QueryStreamFrame[]): Promise<QueryChunk<unknown>[]> {
+    const chunks: QueryChunk<unknown>[] = [];
+
+    for await (const chunk of queryStreamChunks(script(frames))) {
+        chunks.push(chunk);
+    }
+
+    return chunks;
+}
+
+async function* script(frames: QueryStreamFrame[]): AsyncGenerator<QueryStreamFrame> {
+    for (const frame of frames) {
+        yield frame;
+    }
+}
+
+describe("query stream frames", () => {
+    test("rows are chunked as they arrive and closed by their finished frame", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "rows", index: 0, values: [1, 2] },
+            { stream: "rows", index: 0, values: [3] },
+            { stream: "finished", index: 0, time: "1.5ms", type: "other", single: false },
+            { stream: "end", results: 1, time: "2ms" },
+        ]);
+
+        expect(chunks).toHaveLength(3);
+        expect(chunks[0]).toMatchObject({ query: 0, batch: 0, kind: "batched", result: [1, 2] });
+        expect(chunks[1]).toMatchObject({ query: 0, batch: 1, kind: "batched", result: [3] });
+        expect(chunks[2]).toMatchObject({
+            query: 0,
+            batch: 2,
+            kind: "batched-final",
+            result: [],
+            type: "other",
+        });
+        expect(chunks[2]?.stats?.duration.nanoseconds).toBe(1_500_000n);
+    });
+
+    test("a single value is held back until its finished frame names it as one", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "value", index: 0, value: 42 },
+            { stream: "finished", index: 0, time: "1ms", type: "other", single: true },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0]).toMatchObject({ query: 0, kind: "single", result: [42] });
+    });
+
+    test("a single statement which sent no value produced NONE", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "finished", index: 0, time: "1ms", type: "other", single: true },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0]?.kind).toBe("single");
+        expect(chunks[0]?.result).toEqual([undefined]);
+    });
+
+    test("statements keep their own batch numbering while interleaved", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 2 },
+            { stream: "rows", index: 0, values: ["a"] },
+            { stream: "rows", index: 1, values: ["b"] },
+            { stream: "rows", index: 0, values: ["c"] },
+            { stream: "finished", index: 1, time: "1ms", type: "other", single: false },
+            { stream: "finished", index: 0, time: "1ms", type: "other", single: false },
+            { stream: "end", results: 2, time: "1ms" },
+        ]);
+
+        expect(chunks.map((chunk) => [chunk.query, chunk.batch])).toEqual([
+            [0, 0],
+            [1, 0],
+            [0, 1],
+            [1, 1],
+            [0, 2],
+        ]);
+    });
+
+    test("a failed statement is reported as an error rather than a result", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "rows", index: 0, values: [1] },
+            {
+                stream: "finished",
+                index: 0,
+                time: "1ms",
+                error: { code: -32000, message: "it broke", kind: "Internal" },
+            },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks).toHaveLength(2);
+        expect(chunks[0]).toMatchObject({ query: 0, kind: "batched", result: [1] });
+        expect(chunks[1]?.error?.message).toBe("it broke");
+        expect(chunks[1]?.result).toBeUndefined();
+    });
+
+    test("a statement's failure is reported as the buffered protocol reports it", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            {
+                stream: "finished",
+                index: 0,
+                time: "1ms",
+                error: {
+                    code: -32006,
+                    message: "An error occurred: nope",
+                    kind: "Thrown",
+                    details: null,
+                },
+            },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        const error = chunks[0]?.error;
+
+        expect(error).toBeInstanceOf(ThrownError);
+        expect(error?.kind).toBe("Thrown");
+        expect(error?.message).toBe("An error occurred: nope");
+        // A statement's failure carries no wire code on the buffered protocol, so it carries
+        // none here either: the same failing query must not report a different code because
+        // its answer happened to be streamed.
+        expect(error?.code).toBe(0);
+    });
+
+    test("a failed stream retracts every statement which never finished, then throws", async () => {
+        const chunks: QueryChunk<unknown>[] = [];
+        let thrown: unknown;
+
+        try {
+            for await (const chunk of queryStreamChunks(
+                script([
+                    { stream: "begin", statements: 2 },
+                    { stream: "rows", index: 0, values: [1] },
+                    { stream: "finished", index: 0, time: "1ms", type: "other", single: false },
+                    { stream: "rows", index: 1, values: [2] },
+                    {
+                        stream: "end",
+                        results: 1,
+                        time: "1ms",
+                        error: { code: -32000, message: "stopped", kind: "Internal" },
+                    },
+                ]),
+            )) {
+                chunks.push(chunk);
+            }
+        } catch (error) {
+            thrown = error;
+        }
+
+        // The statement which finished stands; the one which did not is retracted.
+        expect(chunks.filter((chunk) => chunk.error).map((chunk) => chunk.query)).toEqual([1]);
+        expect((thrown as Error | undefined)?.message).toBe("stopped");
+    });
+
+    test("a failed stream also retracts a statement which had sent a single value", async () => {
+        const chunks: QueryChunk<unknown>[] = [];
+        let thrown: unknown;
+
+        try {
+            for await (const chunk of queryStreamChunks(
+                script([
+                    { stream: "begin", statements: 1 },
+                    { stream: "value", index: 0, value: "d5b7c0ee" },
+                    {
+                        stream: "end",
+                        results: 0,
+                        time: "1ms",
+                        error: { code: -32000, message: "stopped", kind: "Internal" },
+                    },
+                ]),
+            )) {
+                chunks.push(chunk);
+            }
+        } catch (error) {
+            thrown = error;
+        }
+
+        // The value was never final, so it is retracted rather than delivered.
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0]).toMatchObject({ query: 0, kind: "batched-final" });
+        expect(chunks[0]?.error?.message).toBe("stopped");
+        expect(chunks[0]?.result).toBeUndefined();
+        expect((thrown as Error | undefined)?.message).toBe("stopped");
+    });
+
+    test("the statement count on the begin frame is only an upper bound", async () => {
+        // Control flow such as a RETURN inside a BEGIN block skips the tail, so fewer statements
+        // finish than were announced, and the stream still ended cleanly.
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 3 },
+            { stream: "value", index: 0, value: 1 },
+            { stream: "finished", index: 0, time: "1ms", type: "other", single: true },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks).toHaveLength(1);
+        expect(chunks.map((chunk) => chunk.query)).toEqual([0]);
+    });
+
+    test("a statement index this SDK cannot represent fails the query", async () => {
+        const attempt = collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "rows", index: -1, values: [1] },
+        ]);
+
+        await expect(attempt).rejects.toBeInstanceOf(UnexpectedServerResponseError);
+    });
+
+    test("frames running out without a terminal frame fails the query", async () => {
+        const attempt = collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "rows", index: 0, values: [1] },
+        ]);
+
+        await expect(attempt).rejects.toBeInstanceOf(CallTerminatedError);
+    });
+
+    test("nothing which arrives after a statement finished is acted on", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "rows", index: 0, values: [1] },
+            { stream: "finished", index: 0, time: "1ms", type: "other", single: false },
+            { stream: "rows", index: 0, values: [2] },
+            {
+                stream: "finished",
+                index: 0,
+                time: "1ms",
+                error: { code: -32000, message: "too late", kind: "Internal" },
+            },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks).toHaveLength(2);
+        expect(chunks[0]?.result).toEqual([1]);
+        expect(chunks[1]).toMatchObject({ kind: "batched-final" });
+        expect(chunks.some((chunk) => chunk.error)).toBe(false);
+    });
+
+    test("an unrecognised frame kind is skipped rather than fatal", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "hypothetical" } as unknown as QueryStreamFrame,
+            { stream: "finished", index: 0, time: "1ms", type: "other", single: false },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0]?.kind).toBe("batched-final");
+    });
+
+    test("an unreadable duration leaves the statistics out instead of failing", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "finished", index: 0, time: "later", type: "other", single: false },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks[0]?.stats).toBeUndefined();
+    });
+
+    test("a statement with no type of its own leaves the chunk's type unset", async () => {
+        // The buffered protocol leaves it unset for an ordinary statement, and the chunks the two
+        // paths produce have to be the same chunks.
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "finished", index: 0, time: "1ms", single: false },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks[0]).not.toHaveProperty("type", "other");
+        expect(chunks[0]?.type).toBeUndefined();
+    });
+
+    test("the live query type of a statement is carried through", async () => {
+        const chunks = await collectChunks([
+            { stream: "begin", statements: 1 },
+            { stream: "value", index: 0, value: "d5b7c0ee" },
+            { stream: "finished", index: 0, time: "1ms", type: "live", single: true },
+            { stream: "end", results: 1, time: "1ms" },
+        ]);
+
+        expect(chunks[0]?.type).toBe("live");
+    });
+});

--- a/packages/tests/surrealdb/unit/streaming/results.test.ts
+++ b/packages/tests/surrealdb/unit/streaming/results.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import type { QueryChunk } from "surrealdb";
+import type { ConnectionController } from "../../../../sdk/src/controller";
+import {
+    type QueryStreamFrame,
+    queryStreamChunks,
+} from "../../../../sdk/src/internal/query-stream";
+import { DEFAULT_RETRY_OPTIONS } from "../../../../sdk/src/internal/retry";
+import { Query } from "../../../../sdk/src/query/query";
+import { BoundQuery } from "../../../../sdk/src/utils/bound-query";
+
+/**
+ * A query whose chunks come from a fixed script of frames, so the results the
+ * SDK builds out of a streamed answer can be compared against the answer the
+ * same statements would have produced buffered.
+ */
+function streamedQuery(frames: QueryStreamFrame[], seen?: QueryChunk<unknown>[]): Query {
+    const connection = {
+        retry: DEFAULT_RETRY_OPTIONS,
+        ready: async () => {},
+        query: () => record(frames, seen),
+    } as unknown as ConnectionController;
+
+    return new Query(connection, {
+        query: new BoundQuery("IRRELEVANT"),
+        transaction: undefined,
+        session: undefined,
+        json: false,
+    });
+}
+
+// Built afresh per query: the result collectors adopt the arrays a chunk carries, so a shared
+// script would be rewritten by the first query which read it.
+const twoStatements = (): QueryStreamFrame[] => [
+    { stream: "begin", statements: 2 },
+    { stream: "rows", index: 0, values: [{ n: 1 }, { n: 2 }] },
+    { stream: "rows", index: 0, values: [{ n: 3 }] },
+    { stream: "finished", index: 0, time: "1ms", type: "other", single: false },
+    { stream: "value", index: 1, value: 42 },
+    { stream: "finished", index: 1, time: "1ms", type: "other", single: true },
+    { stream: "end", results: 2, time: "2ms" },
+];
+
+/** The chunks of a streamed answer, noting each one as it is handed over. */
+async function* record(
+    frames: QueryStreamFrame[],
+    seen?: QueryChunk<unknown>[],
+): AsyncGenerator<QueryChunk<unknown>> {
+    const chunks = queryStreamChunks(
+        (async function* () {
+            for (const frame of frames) yield frame;
+        })(),
+    );
+
+    for await (const chunk of chunks) {
+        seen?.push(chunk);
+        yield chunk;
+    }
+}
+
+const failingStatement = (): QueryStreamFrame[] => [
+    { stream: "begin", statements: 2 },
+    { stream: "rows", index: 0, values: [{ n: 1 }] },
+    {
+        stream: "finished",
+        index: 0,
+        time: "1ms",
+        error: { code: -32006, message: "An error occurred: nope", kind: "Thrown" },
+    },
+    { stream: "value", index: 1, value: 7 },
+    { stream: "finished", index: 1, time: "1ms", type: "other", single: true },
+    { stream: "end", results: 2, time: "2ms" },
+];
+
+describe("streamed query results", () => {
+    test("collected results are the results the statements produced", async () => {
+        const results = await streamedQuery(twoStatements()).collect();
+
+        expect(results).toEqual([[{ n: 1 }, { n: 2 }, { n: 3 }], 42]);
+    });
+
+    test("collecting specific statements picks them out of the stream", async () => {
+        const results = await streamedQuery(twoStatements()).collect(1);
+
+        expect(results).toEqual([42]);
+    });
+
+    test("a failed statement rejects the collected results", async () => {
+        await expect(streamedQuery(failingStatement()).collect()).rejects.toThrow("nope");
+    });
+
+    test("responses report the failure and drop the rows it retracted", async () => {
+        const [first, second] = await streamedQuery(failingStatement()).responses();
+
+        expect(first?.success).toBe(false);
+        expect(first).not.toHaveProperty("result");
+        expect(second).toMatchObject({ success: true, result: 7 });
+    });
+
+    test("streamed frames arrive per value and are closed per statement", async () => {
+        const seen: string[] = [];
+
+        for await (const frame of streamedQuery(twoStatements()).stream()) {
+            if (frame.isValue()) seen.push(`value:${frame.query}:${frame.isSingle}`);
+            if (frame.isDone()) seen.push(`done:${frame.query}`);
+            if (frame.isError()) seen.push(`error:${frame.query}`);
+        }
+
+        expect(seen).toEqual([
+            "value:0:false",
+            "value:0:false",
+            "value:0:false",
+            "done:0",
+            "value:1:true",
+            "done:1",
+        ]);
+    });
+
+    test("a failed statement is an error frame after the values it retracts", async () => {
+        const seen: string[] = [];
+
+        for await (const frame of streamedQuery(failingStatement()).stream()) {
+            if (frame.isValue()) seen.push(`value:${frame.query}`);
+            if (frame.isDone()) seen.push(`done:${frame.query}`);
+            if (frame.isError()) seen.push(`error:${frame.query}`);
+        }
+
+        expect(seen).toEqual(["value:0", "error:0", "value:1", "done:1"]);
+    });
+
+    test("collecting a statement does not rewrite the chunks it was built from", async () => {
+        const seen: QueryChunk<unknown>[] = [];
+        const results = await streamedQuery(twoStatements(), seen).collect();
+
+        expect(results[0]).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+
+        // Each chunk still carries what it carried when it was handed over, so a consumer which
+        // was given one - a diagnostics subscriber, say - is not shown a growing accumulator.
+        expect(seen.map((chunk) => chunk.result?.length ?? 0)).toEqual([2, 1, 0, 1]);
+    });
+
+    test("a stream which was stopped rather than answered rejects", async () => {
+        const stopped = streamedQuery([
+            { stream: "begin", statements: 1 },
+            { stream: "rows", index: 0, values: [{ n: 1 }] },
+            {
+                stream: "end",
+                results: 0,
+                time: "1ms",
+                error: { code: -32005, message: "The query was cancelled", kind: "Query" },
+            },
+        ]);
+
+        await expect(stopped.collect()).rejects.toThrow("cancelled");
+    });
+
+    test("a truncated stream rejects rather than returning a prefix", async () => {
+        const truncated = streamedQuery([
+            { stream: "begin", statements: 1 },
+            { stream: "rows", index: 0, values: [{ n: 1 }] },
+            { stream: "finished", index: 0, time: "1ms", type: "other", single: false },
+        ]);
+
+        await expect(truncated.collect()).rejects.toThrow("terminated");
+    });
+});

--- a/packages/tests/surrealdb/unit/utilities/channel-iterator.test.ts
+++ b/packages/tests/surrealdb/unit/utilities/channel-iterator.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { ChannelIterator } from "surrealdb";
+
+describe("ChannelIterator", () => {
+    test("a burst of values delivers every one of them, in order", async () => {
+        const channel = new ChannelIterator<number>();
+        const first = channel.next();
+
+        // The consumer is waiting on the first value only; the rest arrive before it can ask
+        // again, which is how a stream of frames or a burst of notifications arrives.
+        channel.submit(1);
+        channel.submit(2);
+        channel.submit(3);
+
+        expect((await first).value).toBe(1);
+        expect((await channel.next()).value).toBe(2);
+        expect((await channel.next()).value).toBe(3);
+    });
+
+    test("values submitted before anyone asks are queued", async () => {
+        const channel = new ChannelIterator<string>();
+
+        channel.submit("a");
+        channel.submit("b");
+
+        const received: string[] = [];
+
+        for await (const value of channel) {
+            received.push(value);
+            if (received.length === 2) channel.cancel();
+        }
+
+        expect(received).toEqual(["a", "b"]);
+    });
+
+    test("two readers waiting at once are both answered", async () => {
+        const channel = new ChannelIterator<number>();
+        const first = channel.next();
+        const second = channel.next();
+
+        channel.submit(1);
+        channel.submit(2);
+
+        expect((await first).value).toBe(1);
+        expect((await second).value).toBe(2);
+    });
+
+    test("cancelling settles every reader still waiting", async () => {
+        const channel = new ChannelIterator<number>();
+        const first = channel.next();
+        const second = channel.next();
+
+        channel.cancel();
+
+        expect(await first).toEqual({ value: undefined, done: true });
+        expect(await second).toEqual({ value: undefined, done: true });
+    });
+
+    test("cancelling ends a pending read and drops what follows", async () => {
+        const channel = new ChannelIterator<number>();
+        const pending = channel.next();
+
+        channel.cancel();
+        channel.submit(1);
+
+        expect(await pending).toEqual({ value: undefined, done: true });
+        expect(await channel.next()).toEqual({ value: undefined, done: true });
+    });
+
+    test("leaving the iteration runs the cleanup and ends it", async () => {
+        let cleaned = 0;
+        const channel = new ChannelIterator<number>(() => {
+            cleaned++;
+        });
+
+        channel.submit(1);
+        channel.submit(2);
+
+        for await (const value of channel) {
+            expect(value).toBe(1);
+            break;
+        }
+
+        expect(cleaned).toBe(1);
+        expect(await channel.next()).toEqual({ value: undefined, done: true });
+    });
+});


### PR DESCRIPTION
## What is the motivation?

The server can now answer a query with a sequence of frames instead of one response ([surrealdb-private#812](https://github.com/surrealdb/surrealdb-private/pull/812), following #790's gRPC work), so the first rows can reach a client while the query is still running. That PR's own closing note is this change: the SDK can adopt it invisibly — send `query_stream`, accumulate frames, resolve the same promise, and fall back to `query` when the server does not know the method.

Users get a lower time to first result and no single enormous response to decode, with no API change. The visible `for await (const row of …)` API is a later, thin layer over frames the SDK now already parses.

## What does this change do?

The WebSocket engine asks for queries with `query_stream` and translates the frames into the `QueryChunk` stream that `collect()`, `responses()` and `.stream()` already consume. Nothing above the engine changed.

**Adoption is invisible.** The streamed answer is the buffered answer — same chunks, same errors, same statistics. Three things make that true rather than hoped for:

- A server which does not serve the method answers `-32601`, and the query is asked for again in buffered form. Same for a denial (`-32602`), for a stream refused because the connection is at its concurrency cap, and for one whose socket went away before anything was framed. Nothing is framed until execution is about to begin, so in every one of those cases the query never ran and re-asking cannot execute it twice. Absent-or-denied is remembered for the life of the socket; a capacity refusal is not, since it is transient.
- Queries inside a transaction from `.begin()` are never streamed: a `commit` can arrive on the same connection mid-stream, and would commit a prefix of the query rather than the whole of it.
- `DriverOptions.streaming` turns it off entirely.

**The frame contract is preserved as it is translated.** Rows are provisional until their statement's terminal frame; a statement's failure becomes the error chunk that retracts the rows already delivered for it; a stream stopped rather than answered fails the query, so a truncated answer is never mistaken for a whole one; results are counted by terminal frames, never by the statement count on `begin`, which is only an upper bound. Abandoning a stream — breaking out of a `for await` — cancels it on the server instead of leaving it to produce results nothing will read.

### How is it used?

Nothing changes for a caller who wants the whole answer. The query below is streamed on a server
which serves it and buffered on one which does not, and returns the same 300 records either way:

```ts
const [people] = await db.query<[Person[]]>("SELECT * FROM person").collect();
```

`.stream()` is what the streaming is for: the rows arrive as the server produces them, so a
statement's first row does not wait on the rest of the query. Each frame belongs to a statement,
by index, and `isValueOf` / `isDoneOf` check both the kind of frame and which statement it is for:

```ts
for await (const frame of db.query("SELECT * FROM person; SLEEP 500ms;").stream()) {
    if (frame.isValueOf<Person>(0)) {
        console.log(frame.value.age);       // a row of the first statement
    }

    if (frame.isDoneOf(0)) {
        console.log("that statement is complete");
    }

    if (frame.isErrorOf(0)) {
        // The statement failed. Every row above for statement 0 is retracted.
    }
}
```

Against a server with #812 that prints the first row **11ms** in, while the query itself completes
at **512ms** - the `SLEEP` is the rest of the query, and the rows no longer wait behind it.

Note that the `<Person>` on `isValueOf` asserts the row type rather than checking it: `query()`
takes a tuple of statement types and the frame API does not derive from it, so it is on the caller
to keep the two in agreement. Deriving it, and a row-level `for await (const person of ...)` view
over these frames, are both worth having and are deliberately not in this change - see the
discussion on this PR.

The builders need no such annotation, because each is a single statement and its result type says
what its frames carry:

```ts
for await (const frame of db.select<Person>(person).stream()) {
    if (frame.isValue()) console.log(frame.value.age);   // Person, inferred
}
```

That was typed by the statement's result rather than the row until this change, so a frame of a
`select` over a table declared `Person[]` while carrying one `Person` - `frame.value.age` did not
compile and `frame.value[0]` did. `select`, `create`, `update`, `upsert`, `delete`, `insert` and
`relate` now read the row off their result type; `run`, `auth` and `api` are single-value
statements and keep carrying their result whole. The public API typecheck fixture pins all four
shapes.

Leaving the stream stops the query rather than letting the server produce results nothing will
read, and the connection is immediately usable again:

```ts
for await (const frame of db.query("SELECT * FROM person; SLEEP 30s;").stream()) {
    if (frame.isValue<Person>()) break;      // sends `query_cancel` for this query
}

await db.query("RETURN 1").collect();        // answers straight away
```

And it can be turned off for the whole driver, which puts every query back on the buffered path:

```ts
const db = new Surreal({ streaming: false });
```

### Two fixes this depends on

- **`ChannelIterator` lost values.** A value submitted before the consumer asked for the next one resolved the same, already settled promise, so every value but the first of a burst vanished. This was dropping **live query notifications** too, not only frames. Readers are now queued, which also settles a reader that a second reader used to abandon forever.
- **`collect()` and `responses()` rewrote the chunks they were built from.** They adopted the array a chunk carried and pushed later batches into it. Harmless while every statement arrived as one chunk; with batches, a diagnostics subscriber holding a chunk that carried 16 rows would later find 499 in it.

### One deliberate non-change

A frame carries the full error object, wire code included, where a buffered query result carries none and `ServerError.code` is `0`. The code a frame carries is dropped, so the same failing query does not report a different code depending on whether its answer happened to be streamed. `QueryChunk.type` is likewise left unset for an ordinary statement, exactly as the buffered path leaves it — the consumers of a chunk are what settle on a default.

## What is your testing strategy?

Verified against a build of the server **with** #812 and, separately, against one **without** it, so both the streaming path and the fallback are covered by the whole suite.

| Gate | Result |
|---|---|
| `bun test` (WebSocket, server **with** #812) | 618 pass, 0 fail |
| `bun test` (WebSocket, server **without** #812 — fallback) | 618 pass, 0 fail |
| `SURREAL_PROTOCOL=http bun test` (server with #812) | 583 pass, 0 fail |
| `bun run qc`, `bun run qts`, `bun run build:sdk` | clean |
| `tsc --project packages/tests/surrealdb/typecheck` (public API, against the built `.d.ts`) | clean |

Reproduce the streaming run with `SURREAL_EXECUTABLE_PATH=<surreal with #812> bun test --preload ./global.ts` from `packages/tests/surrealdb`. On a debug build add `--timeout 30000`: `sessions > restore state after reconnect` restarts the database inside bun's 5s default and cascades when it cannot.

**New tests**, chosen so they cannot pass for the wrong reason:

- `unit/streaming/frames.test.ts` — the translator against a scripted sequence of frames: batching and per-statement batch numbering, a single value held back until its statement says it was one, `NONE`, statement failure, stream failure retracting only the statements that never finished, a truncated stream, terminal-once, `begin.statements` as an upper bound, an unrepresentable index, an unreadable duration, and the error-code and type parity described above.
- `unit/streaming/results.test.ts` — the same scripts through `collect()`, `responses()` and `.stream()`, which is where retraction has to be observable: an errored statement drops the rows it delivered while its neighbours stand.
- `unit/streaming/engine.test.ts` — the engine over a mock `WebSocket` speaking the real CBOR protocol, so frame ordering, correlation by request id and cancellation are exercised for real: the request shape, a 2000-row burst arriving complete and in order, two concurrent streams keeping their own frames, cancel on abandonment and no cancel after a clean end, both fallback codes, a capacity refusal falling back for one query only, a non-frame payload, a stream never replayed once it has framed anything, and both reconnect paths.
- `integration/query/streaming.test.ts` — against a real server, including a differential test asserting a streamed answer equals the same query on a `streaming: false` connection, and one asserting that the failures of a mixed query match across the two paths field for field. A test which needs to know streaming actually happened asks a raw socket rather than the SDK, whose whole point is to hide the difference — so it hard-fails if streaming ever silently degrades to the fallback on a capable server.
- `unit/utilities/channel-iterator.test.ts` — pins the lost-value fix directly rather than by the mass timeout it used to cause.

The usage above was run against the #812 build as written, and the timings quoted in it are from that run. Beyond the suite, the streaming path was driven end to end against the same build: frames arrive as `begin{2} → rows(16) → rows(23) → finished → value → finished{single} → end`; a 499 row result reaches the SDK as chunks of 16, 32, 64, 128, 256, 3; the first row lands 5.9ms in against a query that completes at 1008ms; abandoning a `SLEEP 30s` stream returns in 6.7ms with the connection immediately reusable; and a `LIVE SELECT` registered through a stream delivers its notifications.

## Is this related to any issues?

Implements the JS SDK side of surrealdb-private#812 (WebSocket streaming), which follows surrealdb-private#790 (gRPC end-to-end streaming).

Not in scope here: the `for await (const row of …)` API this makes possible, and a `Features.QueryStreaming` version gate — with the release that ships #812 known, the SDK could skip the one probe it currently spends per connection against older servers.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)



