### PR TITLE
feat(spectron): follow the API's keyset cursor pagination

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
     },
     "packages/spectron": {
       "name": "@surrealdb/spectron",
-      "version": "1.0.0-alpha.6",
+      "version": "1.0.0-alpha.8",
       "devDependencies": {
         "@types/bun": "^1.2.21",
         "openapi-typescript": "^7.10.0",

--- a/packages/spectron/README.md
+++ b/packages/spectron/README.md
@@ -65,7 +65,7 @@ await client.reflect("What changed this week?", { persist: true });
 await client.forget("Remove old project notes", { purge: true });
 
 // Snapshots and maintenance.
-await client.state();
+await client.state({ limit: 500 }); // bounded per table; check `truncated`
 await client.profile();
 await client.whoami();
 await client.consolidate({ dryRun: true });
@@ -76,7 +76,7 @@ await client.audit({ limit: 50 });
 
 // Self-service API keys.
 const minted = await client.keys.create({ name: "ci", ttlSeconds: 3600 });
-await client.keys.list();
+await client.keys.list(); // one page; `keys.listAll()` walks them all
 await client.keys.rotate("ci");
 await client.keys.delete("ci");
 ```
@@ -94,14 +94,60 @@ for await (const chunk of stream) {
 
 | Namespace | Highlights |
 | --- | --- |
-| `client.documents` | `upload`, `reprocess`, `get`, `raw`, `chunks`, `list`, `delete`, `query`, `recomputeLinks`, `keywords.*` |
-| `client.entities` | `list`, `get`, `history`, `delete` |
-| `client.sessions` | `create` → `Session` (`turns`, `context`, `close`) |
+| `client.documents` | `upload`, `reprocess`, `get`, `raw`, `chunks`, `allChunks`, `list`, `listAll`, `count`, `delete`, `query`, `recomputeLinks`, `keywords.*` |
+| `client.entities` | `list`, `listAll`, `count`, `get`, `history`, `delete` |
+| `client.sessions` | `create` → `Session` (`turns`, `allTurns`, `context`, `close`) |
 | `client.lifecycle` | `expire`, `decay` |
-| `client.traces` | `list`, `get`, `stats` |
-| `client.principals` | `list`, `get`, `effective`, `grant`, `revoke` |
-| `client.scopes` | `list`, `register`, `delete`, `forget` |
-| `client.keys` | `create`, `list`, `delete`, `rotate` |
+| `client.traces` | `list`, `listAll`, `get`, `stats` |
+| `client.principals` | `list`, `listAll`, `get`, `effective`, `grant`, `revoke` |
+| `client.scopes` | `list`, `listAll`, `register`, `delete`, `forget` |
+| `client.keys` | `create`, `list`, `listAll`, `delete`, `rotate` |
+
+## Pagination
+
+Every list surface pages the same way. `list` returns one page — the rows under
+their collection key, plus a `page` block — and takes `limit` (default 100, max
+500), `cursor`, and `count`:
+
+```ts
+const first = await client.entities.list({ limit: 50 });
+first.entities; // the rows
+first.page; // { hasMore, nextCursor?, totalSize? }
+
+// Walk by hand: follow `nextCursor` until it is absent.
+let cursor: string | undefined;
+do {
+  const page = await client.entities.list({ limit: 50, cursor });
+  handle(page.entities);
+  cursor = page.page.nextCursor ?? undefined;
+} while (cursor);
+```
+
+Terminate on the cursor, never on a short page. A page is bounded in the
+database and then filtered for visibility, so `/scopes` and `/keys` can return
+fewer rows than `limit` while more pages remain.
+
+Every listing also has a `listAll` that does the walk for you, and the ones
+worth counting have a `count` that reads `page.totalSize` from a single
+one-row request:
+
+```ts
+await client.scopes.listAll(); // ScopeNodeJson[], cursors followed to exhaustion
+await client.documents.count(); // number, without fetching the documents
+```
+
+`listAll` is an unbounded read by construction — reach for it when the
+collection is a tree or a filter source, not a screenful. `documents.allChunks`
+takes a `max` for the bounded case.
+
+`totalSize` is opt-in (`count: true`) because it costs a full count of the
+filtered set. `/documents`, `/documents/{id}/chunks`, and `/documents/keywords`
+also still accept the pre-cursor `page`/`pageSize` parameters, for callers with
+numbered page controls; they cannot be combined with `cursor`.
+
+Pagination helpers are exported for wrapping other paginated surfaces:
+`walkPages`, `collectPages`, `addPageParams`, and the `PageMeta` / `PageOptions`
+types.
 
 ## Delegation
 

--- a/packages/spectron/README.md
+++ b/packages/spectron/README.md
@@ -107,7 +107,7 @@ for await (const chunk of stream) {
 
 Every list surface pages the same way. `list` returns one page — the rows under
 their collection key, plus a `page` block — and takes `limit` (default 100, max
-500), `cursor`, and `count`:
+500) and `cursor`, plus `count` on the endpoints that offer a total:
 
 ```ts
 const first = await client.entities.list({ limit: 50 });
@@ -141,13 +141,19 @@ collection is a tree or a filter source, not a screenful. `documents.allChunks`
 takes a `max` for the bounded case.
 
 `totalSize` is opt-in (`count: true`) because it costs a full count of the
-filtered set. `/documents`, `/documents/{id}/chunks`, and `/documents/keywords`
-also still accept the pre-cursor `page`/`pageSize` parameters, for callers with
-numbered page controls; they cannot be combined with `cursor`.
+filtered set. Two endpoints do not offer it at all — `scopes.list` and
+`client.audit` take `limit` and `cursor` only, typed as `CursorOptions`, so
+asking them for a count is a type error rather than a rejected request.
+
+`/documents`, `/documents/{id}/chunks`, and `/documents/keywords` also still
+accept the pre-cursor `page`/`pageSize` parameters, for callers with numbered
+page controls that need a page index and a total. The server rejects `cursor`
+sent together with `page`, so those options are an exclusive union
+(`CursorOrOffsetOptions`): picking both fails to compile.
 
 Pagination helpers are exported for wrapping other paginated surfaces:
-`walkPages`, `collectPages`, `addPageParams`, and the `PageMeta` / `PageOptions`
-types.
+`walkPages`, `collectPages`, `addPageParams`, and the `PageMeta`, `PageOptions`
+and `CursorOptions` types.
 
 ## Delegation
 

--- a/packages/spectron/package.json
+++ b/packages/spectron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@surrealdb/spectron",
-    "version": "1.0.0-alpha.7",
+    "version": "1.0.0-alpha.8",
     "type": "module",
     "license": "Apache-2.0",
     "description": "The official Spectron client for JavaScript.",

--- a/packages/spectron/spec/openapi.json
+++ b/packages/spectron/spec/openapi.json
@@ -7,7 +7,7 @@
             "name": "BUSL-1.1",
             "identifier": "BUSL-1.1"
         },
-        "version": "0.0.0"
+        "version": "0.2.1"
     },
     "paths": {
         "/api/v1/health": {
@@ -21,6 +21,282 @@
                         "description": ""
                     }
                 }
+            }
+        },
+        "/api/v1/{context_id}/actions": {
+            "get": {
+                "description": "List live actions (dated events), newest first by write time. `since`/`until` bound the event time. Paginated: follow `page.nextCursor`. Ordered on write time rather than event time because event time is revisable, and a revision under an event-time ordering would move a row across page boundaries mid-walk.",
+                "operationId": "list_actions",
+                "parameters": [
+                    {
+                        "name": "context_id",
+                        "in": "path",
+                        "description": "Spectron context id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "actor",
+                        "in": "query",
+                        "description": "Filter by acting entity, as `<type>/<name>` (e.g. `person/alice`)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "verb",
+                        "in": "query",
+                        "description": "Filter by action verb",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "since",
+                        "in": "query",
+                        "description": "Inclusive lower bound on occurred_at (RFC 3339)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "until",
+                        "in": "query",
+                        "description": "Inclusive upper bound on occurred_at (RFC 3339)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max rows to return (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the filtered set)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ActionListResponseJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pagination parameter, entity ref, or time bound",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/{context_id}/attributes": {
+            "get": {
+                "description": "List live attributes, newest first. Live means not superseded and inside its validity window; superseded values are reachable through the entity history endpoint. Paginated: follow `page.nextCursor`.",
+                "operationId": "list_attributes",
+                "parameters": [
+                    {
+                        "name": "context_id",
+                        "in": "path",
+                        "description": "Spectron context id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "entity",
+                        "in": "query",
+                        "description": "Filter to one entity's attributes, as `<type>/<name>` (e.g. `person/alice`)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "key",
+                        "in": "query",
+                        "description": "Filter by attribute key",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max rows to return (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the filtered set)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AttributeListResponseJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pagination parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
             }
         },
         "/api/v1/{context_id}/audit": {
@@ -85,12 +361,21 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Max rows to return (default 50, max 500)",
+                        "description": "Max rows to return (default 100, max 500)",
                         "required": false,
                         "schema": {
                             "type": "integer",
                             "format": "int32",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ],
@@ -134,6 +419,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -145,7 +448,7 @@
         },
         "/api/v1/{context_id}/chat": {
             "post": {
-                "description": "Phase 7.5 — Spectron-as-agent chat endpoint. Stores the user message via /facts, retrieves context via the unified /query router, calls the configured LLM provider, stores the assistant response via /facts, and emits a response_trace. Set `stream=true` for SSE.",
+                "description": "Phase 7.5 — Spectron-as-agent chat endpoint. Resolves the session, retrieves context via the unified /query router, and calls the configured LLM provider; then, only after a successful synthesis (or a tier-2 cache hit), stores the user message and the assistant response via /facts and emits a response_trace. A failed synthesis writes no turn, fact, or response_trace (a retrieval_trace recording the query may still be written). Set `stream=true` for SSE.",
                 "operationId": "chat",
                 "parameters": [
                     {
@@ -208,6 +511,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -219,7 +540,7 @@
         },
         "/api/v1/{context_id}/consolidate": {
             "post": {
-                "description": "Phase 11b: pool recent facts and consolidate into observations",
+                "description": "Phase 11b: pool recent facts and consolidate into observations. Scope-gated: only facts in the caller's `memory:read` region are pooled, and only groups in the caller's `memory:write` region are persisted (others are returned as dry-run previews).",
                 "operationId": "consolidate",
                 "parameters": [
                     {
@@ -265,6 +586,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -346,6 +685,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -388,9 +745,38 @@
                         }
                     },
                     {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max documents to return (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the filtered set)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "name": "page",
                         "in": "query",
-                        "description": "Page number (0-indexed)",
+                        "description": "Deprecated: zero-based page index. Use `cursor`.",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -401,7 +787,7 @@
                     {
                         "name": "pageSize",
                         "in": "query",
-                        "description": "Page size, max 100",
+                        "description": "Deprecated: page size. Use `limit`.",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -443,6 +829,24 @@
                     },
                     "500": {
                         "description": "Unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -562,6 +966,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -614,9 +1036,38 @@
                         }
                     },
                     {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max keywords to return (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`. Only valid for the `sort` it was minted under.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the filtered set)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "name": "page",
                         "in": "query",
-                        "description": "Page number (0-indexed)",
+                        "description": "Deprecated: zero-based page index. Use `cursor`.",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -627,7 +1078,7 @@
                     {
                         "name": "pageSize",
                         "in": "query",
-                        "description": "Page size, max 100",
+                        "description": "Deprecated: page size. Use `limit`.",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -659,6 +1110,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -740,6 +1209,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -806,6 +1293,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -897,6 +1402,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -954,6 +1477,24 @@
                     },
                     "500": {
                         "description": "Unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1037,6 +1578,24 @@
                     },
                     "500": {
                         "description": "Unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1155,6 +1714,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1229,6 +1806,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1262,9 +1857,38 @@
                         }
                     },
                     {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max chunks to return (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the document's chunks)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "name": "page",
                         "in": "query",
-                        "description": "Page number (0-indexed)",
+                        "description": "Deprecated: zero-based page index. Use `cursor`.",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -1275,7 +1899,7 @@
                     {
                         "name": "pageSize",
                         "in": "query",
-                        "description": "Page size, max 100",
+                        "description": "Deprecated: page size. Use `limit`.",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -1327,6 +1951,24 @@
                     },
                     "500": {
                         "description": "Unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1400,6 +2042,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1483,6 +2143,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1557,6 +2235,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1568,7 +2264,7 @@
         },
         "/api/v1/{context_id}/entities": {
             "get": {
-                "description": "List entities (optionally filtered by type), ordered by type then name. Unpaginated by default; pass `limit` (capped at 500) and `offset` to page.",
+                "description": "List entities (optionally filtered by type), ordered by type then name. Paginated: `limit` defaults to 100 and is capped at 500; follow `page.nextCursor` to walk the Context.",
                 "operationId": "list_entities",
                 "parameters": [
                     {
@@ -1592,7 +2288,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Max entities to return (default: all, capped at 500)",
+                        "description": "Max entities to return (default 100, max 500)",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -1601,9 +2297,27 @@
                         }
                     },
                     {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the filtered set)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "name": "offset",
                         "in": "query",
-                        "description": "Number of entities to skip (default 0)",
+                        "description": "Deprecated: rows to skip. Use `cursor`.",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -1623,6 +2337,16 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Invalid pagination parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Unauthorized",
                         "content": {
@@ -1635,6 +2359,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1724,6 +2466,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1780,6 +2540,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1859,8 +2637,36 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "Entity not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1952,6 +2758,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2036,6 +2860,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2110,6 +2952,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2177,6 +3037,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2313,6 +3191,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2324,7 +3220,7 @@
         },
         "/api/v1/{context_id}/keys": {
             "get": {
-                "description": "List the caller's own data-plane keys (id, name, timestamps, attenuating grants). Never returns the secret. Gated by the Context's `allow_self_service_keys` flag.",
+                "description": "List the key the caller authenticated with (id, name, timestamps, attenuating grants); a context administrator (`grant:manage` over `/`) lists every key in the Context. Never returns the secret. Gated by the Context's `allow_self_service_keys` flag. Paginated: follow `page.nextCursor`.",
                 "operationId": "list_self_keys",
                 "parameters": [
                     {
@@ -2335,6 +3231,35 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max keys to return (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize`",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ],
                 "responses": {
@@ -2343,10 +3268,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/KeyDetailJson"
-                                    }
+                                    "$ref": "#/components/schemas/KeyListResponseJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pagination parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
                                 }
                             }
                         }
@@ -2373,6 +3305,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2489,6 +3439,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2500,7 +3468,7 @@
         },
         "/api/v1/{context_id}/keys/{key_name}": {
             "delete": {
-                "description": "Delete one of the caller's own keys by name. A name that does not belong to the caller surfaces as 404 (no cross-principal leakage). Gated by `allow_self_service_keys`; rejects legacy / delegated callers.",
+                "description": "Delete the caller's own key by name (or, for a context administrator holding `grant:manage` over `/`, any key). A key that is not the caller's own and that it may not manage surfaces as 404 (no cross-key leakage). Gated by `allow_self_service_keys`; rejects legacy / delegated callers.",
                 "operationId": "delete_self_key",
                 "parameters": [
                     {
@@ -2565,6 +3533,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2576,7 +3562,7 @@
         },
         "/api/v1/{context_id}/keys/{key_name}/rotate": {
             "post": {
-                "description": "Rotate the secret on one of the caller's own keys. The id stays stable (preserving the principal binding and attenuating grants); the previous secret stops validating immediately. `ttlSeconds` is reset-or-inherit, matching the management rotate path.",
+                "description": "Rotate the secret on the caller's own key (or, for a context administrator holding `grant:manage` over `/`, any key). The id stays stable (preserving the principal binding and attenuating grants); the previous secret stops validating immediately. A key the caller may not manage surfaces as 404. `ttlSeconds` is reset-or-inherit, matching the management rotate path.",
                 "operationId": "rotate_self_key",
                 "parameters": [
                     {
@@ -2659,6 +3645,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2706,6 +3710,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2767,6 +3789,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2821,6 +3861,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2832,7 +3890,7 @@
         },
         "/api/v1/{context_id}/principals": {
             "get": {
-                "description": "List the Context's principals (requires the `grant:manage` grant)",
+                "description": "List the Context's principals (requires the `grant:manage` grant). Paginated: follow `page.nextCursor`.",
                 "operationId": "list_principals",
                 "parameters": [
                     {
@@ -2843,6 +3901,35 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max principals to return (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize`",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ],
                 "responses": {
@@ -2851,10 +3938,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/PrincipalJson"
-                                    }
+                                    "$ref": "#/components/schemas/PrincipalListResponseJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pagination parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
                                 }
                             }
                         }
@@ -2881,6 +3975,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2964,6 +4076,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3082,6 +4212,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -3178,6 +4326,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3286,6 +4452,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -3333,6 +4517,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3414,6 +4616,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -3488,6 +4708,162 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/{context_id}/relations": {
+            "get": {
+                "description": "List live relation edges, newest first. Paginated: follow `page.nextCursor`.",
+                "operationId": "list_relations",
+                "parameters": [
+                    {
+                        "name": "context_id",
+                        "in": "path",
+                        "description": "Spectron context id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "src",
+                        "in": "query",
+                        "description": "Filter by subject entity, as `<type>/<name>` (e.g. `person/alice`)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "dst",
+                        "in": "query",
+                        "description": "Filter by object entity, as `<type>/<name>` (e.g. `company/techco`)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "label",
+                        "in": "query",
+                        "description": "Filter by relation label",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max rows to return (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the filtered set)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RelationListResponseJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pagination parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -3552,6 +4928,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -3563,7 +4957,7 @@
         },
         "/api/v1/{context_id}/scopes": {
             "get": {
-                "description": "List the Context's registered scope nodes (live and tombstoned). Only nodes the caller has a grant over are returned (`scope:read`, or any other verb in the region); a `grant:manage` holder over `/` sees the whole tree.",
+                "description": "List the Context's registered scope nodes (live and tombstoned). Only nodes the caller has a grant over are returned (`scope:read`, or any other verb in the region); a `grant:manage` holder over `/` sees the whole tree. Paginated: follow `page.nextCursor`. Visibility filtering happens after the page bound, so a page can be short while `page.hasMore` is still true.",
                 "operationId": "list_scopes",
                 "parameters": [
                     {
@@ -3571,6 +4965,26 @@
                         "in": "path",
                         "description": "Spectron context id",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max nodes to scan per page (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
                         "schema": {
                             "type": "string"
                         }
@@ -3582,10 +4996,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ScopeNodeJson"
-                                    }
+                                    "$ref": "#/components/schemas/ScopeListResponseJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pagination parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
                                 }
                             }
                         }
@@ -3602,6 +5023,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3681,6 +5120,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -3690,7 +5147,7 @@
                 ]
             },
             "delete": {
-                "description": "Tombstone a scope node (soft-delete: sets tombstoned_at = time::now())",
+                "description": "Tombstone a scope node (soft-delete: sets tombstoned_at = time::now()). The root scope `/` is reserved and cannot be tombstoned.",
                 "operationId": "delete_scope",
                 "parameters": [
                     {
@@ -3736,8 +5193,36 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Caller lacks the `scope:delete` grant over the region, or the target is the reserved root scope `/`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3829,6 +5314,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -3886,6 +5389,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3952,6 +5473,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4042,6 +5581,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -4053,7 +5610,7 @@
         },
         "/api/v1/{context_id}/sessions/{session_id}/turns": {
             "get": {
-                "description": "List turns in a session, oldest first. Paginated: `limit` defaults to 100 and is capped at 500; use `offset` to page.",
+                "description": "List turns in a session, oldest first. Paginated: `limit` defaults to 100 and is capped at 500; follow `page.nextCursor` to walk the session.",
                 "operationId": "list_turns",
                 "parameters": [
                     {
@@ -4086,9 +5643,27 @@
                         }
                     },
                     {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the session's turns)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "name": "offset",
                         "in": "query",
-                        "description": "Number of turns to skip (default 0)",
+                        "description": "Deprecated: rows to skip. Use `cursor`.",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -4104,6 +5679,16 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/TurnListResponseJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pagination parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
                                 }
                             }
                         }
@@ -4137,6 +5722,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -4148,7 +5751,7 @@
         },
         "/api/v1/{context_id}/state": {
             "get": {
-                "description": "Get the full structured memory state grouped by category",
+                "description": "Get the structured memory state grouped by category. This is a composite read over six tables, each bounded by `limit` (default 100, max 500); `truncated` reports which tables had more rows. It is a snapshot, not an export: to enumerate a table completely, walk `/entities`, `/attributes`, `/relations`, or `/actions` instead.",
                 "operationId": "get_state",
                 "parameters": [
                     {
@@ -4158,6 +5761,17 @@
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max rows per table (default 100, max 500)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
                         }
                     }
                 ],
@@ -4191,6 +5805,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -4217,12 +5849,30 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Max traces to return (default 50, max 500)",
+                        "description": "Max traces to return (default 100, max 500)",
                         "required": false,
                         "schema": {
                             "type": "integer",
                             "format": "int32",
                             "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Continuation token from the previous page's `page.nextCursor`",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Also return `page.totalSize` (costs a full count of the visible traces)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ],
@@ -4249,6 +5899,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4303,6 +5971,24 @@
                     },
                     "422": {
                         "description": "Invalid context id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4383,6 +6069,24 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header.",
+                        "headers": {
+                            "Retry-After": {
+                                "schema": {
+                                    "type": "integer"
+                                },
+                                "description": "Seconds to wait before retrying."
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -4395,6 +6099,112 @@
     },
     "components": {
         "schemas": {
+            "ActionDetailJson": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "actor",
+                    "verb",
+                    "summary",
+                    "memoryCategory",
+                    "confidence",
+                    "createdAt"
+                ],
+                "properties": {
+                    "actor": {
+                        "type": "string",
+                        "description": "Navigable ref of the acting entity, `entity:<type>/<name>`."
+                    },
+                    "confidence": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "memoryCategory": {
+                        "$ref": "#/components/schemas/MemoryCategory"
+                    },
+                    "object": {
+                        "type": ["string", "null"],
+                        "description": "Navigable ref (`entity:<type>/<name>`) of the acted-on entity, when\nthe object resolved to a graph entity."
+                    },
+                    "objectText": {
+                        "type": ["string", "null"],
+                        "description": "The acted-on thing's verbatim name, when it did not resolve to an\nentity. At most one of `object` / `objectText` is set."
+                    },
+                    "occurredAt": {
+                        "type": ["string", "null"],
+                        "description": "Event time, distinct from assertion validity and learn time. Absent\nwhen the source stated no resolvable time."
+                    },
+                    "source": {
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SourceRefJson"
+                            }
+                        ]
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "validFrom": {
+                        "type": ["string", "null"]
+                    },
+                    "validUntil": {
+                        "type": ["string", "null"]
+                    },
+                    "verb": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ActionListResponseJson": {
+                "type": "object",
+                "required": ["actions", "page"],
+                "properties": {
+                    "actions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ActionDetailJson"
+                        }
+                    },
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    }
+                }
+            },
+            "ActionSummaryJson": {
+                "type": "object",
+                "required": ["actor", "verb", "summary", "memoryCategory"],
+                "properties": {
+                    "actor": {
+                        "type": "string"
+                    },
+                    "memoryCategory": {
+                        "$ref": "#/components/schemas/MemoryCategory"
+                    },
+                    "object": {
+                        "type": ["string", "null"],
+                        "description": "The acted-on thing as the extraction named it, whether or not it\nresolved to a graph entity."
+                    },
+                    "occurredAt": {
+                        "type": ["string", "null"]
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "verb": {
+                        "type": "string"
+                    }
+                }
+            },
             "ApiErrorResponse": {
                 "type": "object",
                 "description": "Unified error response type for all REST endpoints.",
@@ -4421,7 +6231,8 @@
                         "type": "string"
                     },
                     "entity": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Navigable ref of the owning entity, `entity:<type>/<name>` — resolvable\nvia `GET /entities/{type}/{name}` or the `inspect` ref grammar."
                     },
                     "id": {
                         "type": "string"
@@ -4463,6 +6274,22 @@
                     }
                 }
             },
+            "AttributeListResponseJson": {
+                "type": "object",
+                "required": ["attributes", "page"],
+                "properties": {
+                    "attributes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AttributeDetailJson"
+                        }
+                    },
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    }
+                }
+            },
             "AttributeSummaryJson": {
                 "type": "object",
                 "required": ["id", "entityId", "key", "value", "memoryCategory"],
@@ -4486,8 +6313,12 @@
             },
             "AuditResponseJson": {
                 "type": "object",
-                "required": ["rows"],
+                "required": ["rows", "page"],
                 "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    },
                     "rows": {
                         "type": "array",
                         "items": {
@@ -4539,6 +6370,14 @@
                 "description": "One message in a `/facts/batch` payload.",
                 "required": ["role", "content"],
                 "properties": {
+                    "addressees": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Who this message is addressed to, as entity-surface names, when the\ncaller knows. Grounds the second person at extraction: one addressee\nresolves \"you\"/\"your\" (and the ownership of reacted-to events), several\nground only \"we\"/\"us\". Empty keeps extraction byte-identical to the\naddressee-less form. Declared by the caller, never inferred. Only the\n`per_message` extraction mode reads this; `whole_conversation` runs one\nextraction over the transcript, where per-message addressees vary line\nby line, so it ignores the field. Names are Unicode-normalized (NFC)\non receipt. When consumed, each name must be name-like: at most 8\nnames of at most 128 characters and 8 words each, letters/digits in\nany script (with the combining marks scripts build names from) plus\nspaces and ' - . _, at least one alphanumeric\ncharacter, and never the reserved alias `self`; requests outside\nthese rules are rejected. Modes that ignore the field do not check\nit.",
+                        "maxItems": 8
+                    },
                     "content": {
                         "type": "string"
                     },
@@ -4553,8 +6392,14 @@
             },
             "CategoryStateJson": {
                 "type": "object",
-                "required": ["entities", "attributes", "relations"],
+                "required": ["entities", "attributes", "relations", "actions"],
                 "properties": {
+                    "actions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ActionDetailJson"
+                        }
+                    },
                     "attributes": {
                         "type": "array",
                         "items": {
@@ -4605,13 +6450,24 @@
                     },
                     "stream": {
                         "type": "boolean"
+                    },
+                    "suppressMarkers": {
+                        "type": "boolean",
+                        "description": "When `true`, the reply text carries no inline citation marker in\neither form (`[S1]` or bare `S1`); `citations` still names every\nsource the reply cited before the markers were removed. Defaults to\n`false`."
                     }
                 }
             },
             "ChatResponseJson": {
                 "type": "object",
-                "required": ["reply", "memoryUpdates", "traceId", "sessionId"],
+                "required": ["reply", "memoryUpdates", "traceId", "sessionId", "citations"],
                 "properties": {
+                    "citations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CitationJson"
+                        },
+                        "description": "Sources the reply cited, one per `[S1]`-style marker."
+                    },
                     "memoryUpdates": {
                         "$ref": "#/components/schemas/ExtractionResultJson"
                     },
@@ -4662,7 +6518,7 @@
             },
             "ChunkPageJson": {
                 "type": "object",
-                "required": ["chunks", "total", "page", "pageSize"],
+                "required": ["chunks", "page"],
                 "properties": {
                     "chunks": {
                         "type": "array",
@@ -4671,25 +6527,52 @@
                         }
                     },
                     "page": {
-                        "type": "integer",
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    }
+                }
+            },
+            "CitationJson": {
+                "type": "object",
+                "description": "A source the reply cited, resolving an inline `[S1]` marker to the\nunderlying row plus a human-friendly locator (document title + approximate\npercentage through the document, when it's a document passage).",
+                "required": ["marker", "id", "kind", "snippet", "score"],
+                "properties": {
+                    "documentTitle": {
+                        "type": ["string", "null"]
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "type": "string"
+                    },
+                    "marker": {
+                        "type": "string"
+                    },
+                    "occurredAt": {
+                        "type": ["string", "null"]
+                    },
+                    "positionPercent": {
+                        "type": ["integer", "null"],
                         "format": "int32",
                         "minimum": 0
                     },
-                    "pageSize": {
-                        "type": "integer",
-                        "format": "int32",
-                        "minimum": 0
+                    "role": {
+                        "type": ["string", "null"],
+                        "description": "Conversational role of a cited conversational row (`user` / `assistant` /\n`system` / `tool`), so callers can tell a cited assistant reply (derived\ntext) from a user-asserted turn. Carried by `memory_chunk` and `turn`\ncitations; absent for non-conversational rows and legacy rows with no\nrecorded role."
                     },
-                    "total": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
+                    "score": {
+                        "type": "number",
+                        "format": "float"
+                    },
+                    "snippet": {
+                        "type": "string"
                     }
                 }
             },
             "ConsolidateOutcomeJson": {
                 "type": "object",
-                "required": ["kind", "entityName", "key", "value", "proofCount"],
+                "required": ["kind", "entityName", "key", "value", "proofCount", "persisted"],
                 "properties": {
                     "entityName": {
                         "type": "string"
@@ -4702,6 +6585,10 @@
                     },
                     "observationId": {
                         "type": ["string", "null"]
+                    },
+                    "persisted": {
+                        "type": "boolean",
+                        "description": "`false` marks a preview that was not committed: a dry-run request, or a\nscope group the caller can read but not write. Committed observations are\n`true`."
                     },
                     "proofCount": {
                         "type": "integer",
@@ -4954,6 +6841,11 @@
                     "mimeType": {
                         "type": "string"
                     },
+                    "observedAt": {
+                        "type": ["string", "null"],
+                        "format": "date-time",
+                        "description": "Known/observed time of the content (explicit or front-matter-detected at\nupload); facts extracted from the document carry it as their known-time."
+                    },
                     "processingCompletedAt": {
                         "type": ["string", "null"],
                         "format": "date-time"
@@ -5018,7 +6910,7 @@
             },
             "DocumentPageJson": {
                 "type": "object",
-                "required": ["documents", "total", "page", "pageSize"],
+                "required": ["documents", "page"],
                 "properties": {
                     "documents": {
                         "type": "array",
@@ -5027,19 +6919,8 @@
                         }
                     },
                     "page": {
-                        "type": "integer",
-                        "format": "int32",
-                        "minimum": 0
-                    },
-                    "pageSize": {
-                        "type": "integer",
-                        "format": "int32",
-                        "minimum": 0
-                    },
-                    "total": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next.\n`totalSize` is present only when the request passed `count=true`, which\nscans the whole filtered set."
                     }
                 }
             },
@@ -5247,13 +7128,17 @@
             },
             "EntityListResponseJson": {
                 "type": "object",
-                "required": ["entities"],
+                "required": ["entities", "page"],
                 "properties": {
                     "entities": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/EntityDetailJson"
                         }
+                    },
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
                     }
                 }
             },
@@ -5306,11 +7191,18 @@
                     "entities",
                     "attributes",
                     "relations",
+                    "actions",
                     "instructions",
                     "uncertainties",
                     "corrections"
                 ],
                 "properties": {
+                    "actions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ActionSummaryJson"
+                        }
+                    },
                     "attributes": {
                         "type": "array",
                         "items": {
@@ -5358,7 +7250,8 @@
                 "required": ["messages"],
                 "properties": {
                     "extract": {
-                        "$ref": "#/components/schemas/BatchExtractionMode"
+                        "$ref": "#/components/schemas/BatchExtractionMode",
+                        "description": "Bulk extraction strategy. `per_message` runs one extraction per\nmessage, role-gating the caller's first person and reading each\nmessage's `addressees`. `whole_conversation` (default) runs one\nextraction over the full transcript, ignores per-message addressees,\nand binds the caller's first person only when every message is\nuser-role - a single grounding line cannot be true for a transcript\nwith lines the caller did not speak."
                     },
                     "infer": {
                         "$ref": "#/components/schemas/InferMode"
@@ -5410,6 +7303,14 @@
                 "type": "object",
                 "description": "Request body for `POST /api/v1/{ctx}/facts`.",
                 "properties": {
+                    "addressees": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Who the turn is addressed to, as entity-surface names, when the\ncaller knows. Grounds the second person at extraction: one addressee\nresolves \"you\"/\"your\" (and the ownership of reacted-to events), several\nground only \"we\"/\"us\". Empty keeps extraction byte-identical to the\naddressee-less form. Declared by the caller, never inferred. Names are\nUnicode-normalized (NFC) on receipt. When consumed (the `full` and\n`preview` infer modes; `none` and `triples` ignore the field), each\nname must be name-like: at most 8 names of at most 128 characters and\n8 words each, letters/digits in any script (with the combining marks\nscripts build names from) plus spaces and ' - . _, at least one\nalphanumeric character, and never the reserved alias\n`self`; requests outside these rules are rejected.",
+                        "maxItems": 8
+                    },
                     "infer": {
                         "$ref": "#/components/schemas/InferMode",
                         "description": "Inference mode (`full` is the default)."
@@ -5866,6 +7767,23 @@
                     }
                 }
             },
+            "KeyListResponseJson": {
+                "type": "object",
+                "description": "The `GET /{ctx}/keys` response.\n\nAn envelope rather than a bare array: a top-level JSON array has nowhere to\ncarry the pagination block, and every list surface returns the same shape.",
+                "required": ["keys", "page"],
+                "properties": {
+                    "keys": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/KeyDetailJson"
+                        }
+                    },
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    }
+                }
+            },
             "KeywordDetailJson": {
                 "type": "object",
                 "required": ["id", "text", "normalised", "documentCount", "documents"],
@@ -5928,7 +7846,7 @@
             },
             "KeywordPageJson": {
                 "type": "object",
-                "required": ["keywords", "total", "page", "pageSize"],
+                "required": ["keywords", "page"],
                 "properties": {
                     "keywords": {
                         "type": "array",
@@ -5937,19 +7855,8 @@
                         }
                     },
                     "page": {
-                        "type": "integer",
-                        "format": "int32",
-                        "minimum": 0
-                    },
-                    "pageSize": {
-                        "type": "integer",
-                        "format": "int32",
-                        "minimum": 0
-                    },
-                    "total": {
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
                     }
                 }
             },
@@ -6036,8 +7943,27 @@
                 "type": "object",
                 "required": ["id", "text", "source", "score"],
                 "properties": {
+                    "dateNotes": {
+                        "type": ["string", "null"],
+                        "description": "Day-precise relative-date notes stored beside a memory chunk at write\ntime (\"last friday = Friday 2023-05-19\"): deterministic resolutions of\nthe chunk text's own relative expressions against its source timestamp.\nAbsent for non-chunk rows and text with no day-precise mentions."
+                    },
                     "id": {
                         "type": "string"
+                    },
+                    "occurredAt": {
+                        "type": ["string", "null"],
+                        "description": "Known-time the hit's fact/turn carries (ISO string), so a caller can date\nthe evidence and resolve relative time in the source text. Absent when the\nrow carries no resolvable date."
+                    },
+                    "resource": {
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ResourceRef",
+                                "description": "Typed reference to the row behind the hit, tagged by `kind`: the owning\ndocument + position for a passage, the entity `{type, name}` (+ `key`)\nfor graph facts, or the session/turn for a conversational chunk — so a\ncaller can navigate to the source without parsing the raw `id`. Absent\nwhen the row could not be resolved."
+                            }
+                        ]
                     },
                     "score": {
                         "type": "number",
@@ -6099,6 +8025,27 @@
                     }
                 }
             },
+            "PageMeta": {
+                "type": "object",
+                "description": "The pagination block returned beside a page's rows.",
+                "required": ["hasMore"],
+                "properties": {
+                    "hasMore": {
+                        "type": "boolean",
+                        "description": "Whether a further page exists."
+                    },
+                    "nextCursor": {
+                        "type": ["string", "null"],
+                        "description": "Token for the next page; absent on the last page."
+                    },
+                    "totalSize": {
+                        "type": ["integer", "null"],
+                        "format": "int64",
+                        "description": "Total rows matching the filters, present only when the request asked for\nit with `count=true`.",
+                        "minimum": 0
+                    }
+                }
+            },
             "PrincipalJson": {
                 "type": "object",
                 "description": "A principal in the `GET /{ctx}/principals` / `…/{id}` responses.",
@@ -6122,10 +8069,33 @@
                     }
                 }
             },
+            "PrincipalListResponseJson": {
+                "type": "object",
+                "description": "The `GET /{ctx}/principals` response.\n\nAn envelope rather than a bare array: a top-level JSON array has nowhere to\ncarry the pagination block, and every list surface returns the same shape.",
+                "required": ["principals", "page"],
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    },
+                    "principals": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PrincipalJson"
+                        }
+                    }
+                }
+            },
             "ProfileEntryJson": {
                 "type": "object",
                 "required": ["key", "value"],
                 "properties": {
+                    "entity": {
+                        "type": ["string", "null"]
+                    },
+                    "entityType": {
+                        "type": ["string", "null"]
+                    },
                     "key": {
                         "type": "string"
                     },
@@ -6136,7 +8106,7 @@
             },
             "ProfileResponseJson": {
                 "type": "object",
-                "required": ["static", "dynamic", "preferences", "instructions"],
+                "required": ["selfFacts", "static", "dynamic", "preferences", "instructions"],
                 "properties": {
                     "dynamic": {
                         "type": "array",
@@ -6151,6 +8121,12 @@
                         }
                     },
                     "preferences": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ProfileEntryJson"
+                        }
+                    },
+                    "selfFacts": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/ProfileEntryJson"
@@ -6275,7 +8251,7 @@
                     },
                     "includeDuplicates": {
                         "type": ["boolean", "null"],
-                        "description": "When `false` (the default), chunks flagged as near-duplicates of an older\nchunk are excluded from the fused ranker's chunk recall so the same text\ndoes not occupy several ranks. Set `true` to include them (parity with the\ndocuments `/query` opt-in)."
+                        "description": "When `false` (the default), document chunks and memory turns flagged as\nnear-duplicates of an older row are excluded from the fused ranker's\nrecall so the same text does not occupy several ranks. Set `true` to\ninclude them (parity with the documents `/query` opt-in)."
                     },
                     "k": {
                         "type": "integer",
@@ -6355,6 +8331,13 @@
                         "$ref": "#/components/schemas/QueryKind",
                         "description": "Phase 7 — query-understanding output. `kind` is one of\n`direct_lookup` / `hybrid` / `full_context`; `seed_entities`\nis the (possibly empty) set of entity surface forms extracted\nfrom the query."
                     },
+                    "contextHits": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MemoryHitJson"
+                        },
+                        "description": "Synthesis-context rows, **separate from `hits`** and **not** counted\nagainst `k`: `hits` is the ranked answer set, these are the extra rows\nthe synthesis layer reads alongside it. Sources: same-section sibling\nchunks from section expansion, the neighbouring conversation chunks of\nranked memory hits from turn expansion, structured attribute/relation\nrows gathered by the tier-1 seed reads for direct-lookup queries, and\n(opt-in) entity fact cards summarising a ranked entity's attributes and\nrelationships, and - when the ranked-overflow depth is configured - the\nfused candidates at ranks `k+1..k+N` that the answer truncation would\notherwise discard. Each row's `source` names its family. Empty when no\nexpansion contributed. A UI can render them as an \"expanded context\"\ngroup distinct from the ranked hits."
+                    },
                     "hits": {
                         "type": "array",
                         "items": {
@@ -6365,6 +8348,17 @@
                         "type": "integer",
                         "format": "int64",
                         "minimum": 0
+                    },
+                    "queryWindow": {
+                        "oneOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "$ref": "#/components/schemas/QueryWindowJson",
+                                "description": "The time window the router derived from a time reference in the query\ntext (\"last week\", \"in March 2023\") and applied as a bounded ranking\nre-weight. Observability only, never a filter the caller must honour;\nabsent for queries with no derived window."
+                            }
+                        ]
                     },
                     "seedEntities": {
                         "type": "array",
@@ -6522,6 +8516,25 @@
                     }
                 }
             },
+            "QueryWindowJson": {
+                "type": "object",
+                "description": "Wire echo of the derived query window: RFC3339 bounds, the resolver's\nprecision label (`day`/`week`/`month`/`season`/`year`), and the phrase it\nmatched.",
+                "required": ["start", "end", "precision", "phrase"],
+                "properties": {
+                    "end": {
+                        "type": "string"
+                    },
+                    "phrase": {
+                        "type": "string"
+                    },
+                    "precision": {
+                        "type": "string"
+                    },
+                    "start": {
+                        "type": "string"
+                    }
+                }
+            },
             "RecomputeLinksResponse": {
                 "type": "object",
                 "description": "Phase 6c: doc-to-doc semantic link recomputation.",
@@ -6607,7 +8620,8 @@
                         "$ref": "#/components/schemas/MemoryCategory"
                     },
                     "object": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Navigable ref of the object entity, `entity:<type>/<name>`."
                     },
                     "source": {
                         "oneOf": [
@@ -6620,13 +8634,30 @@
                         ]
                     },
                     "subject": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Navigable ref of the subject entity, `entity:<type>/<name>` —\nresolvable via `GET /entities/{type}/{name}` or the `inspect` ref\ngrammar."
                     },
                     "validFrom": {
                         "type": ["string", "null"]
                     },
                     "validUntil": {
                         "type": ["string", "null"]
+                    }
+                }
+            },
+            "RelationListResponseJson": {
+                "type": "object",
+                "required": ["relations", "page"],
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    },
+                    "relations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RelationDetailJson"
+                        }
                     }
                 }
             },
@@ -6647,6 +8678,143 @@
                         "type": "string"
                     }
                 }
+            },
+            "ResourceRef": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "description": "A graph entity: resolve via `GET /entities/{type}/{name}`.",
+                        "required": ["entityType", "name", "kind"],
+                        "properties": {
+                            "entityType": {
+                                "type": "string"
+                            },
+                            "kind": {
+                                "type": "string",
+                                "enum": ["entity"]
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "description": "One attribute of an entity: resolve the chain via\n`GET /entities/{type}/{name}/history/{key}`.",
+                        "required": ["entityType", "name", "key", "kind"],
+                        "properties": {
+                            "entityType": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "type": "string"
+                            },
+                            "kind": {
+                                "type": "string",
+                                "enum": ["attribute"]
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "description": "A `relates_to` edge between two entities; either endpoint resolves via\n`GET /entities/{type}/{name}`.",
+                        "required": [
+                            "subjectType",
+                            "subjectName",
+                            "label",
+                            "objectType",
+                            "objectName",
+                            "kind"
+                        ],
+                        "properties": {
+                            "kind": {
+                                "type": "string",
+                                "enum": ["relation"]
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "objectName": {
+                                "type": "string"
+                            },
+                            "objectType": {
+                                "type": "string"
+                            },
+                            "subjectName": {
+                                "type": "string"
+                            },
+                            "subjectType": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "description": "A dated `action` row; the actor (and the object, when it resolved to a\ngraph entity) resolve via `GET /entities/{type}/{name}`.",
+                        "required": ["actorType", "actorName", "kind"],
+                        "properties": {
+                            "actorName": {
+                                "type": "string"
+                            },
+                            "actorType": {
+                                "type": "string"
+                            },
+                            "kind": {
+                                "type": "string",
+                                "enum": ["action"]
+                            },
+                            "objectName": {
+                                "type": ["string", "null"]
+                            },
+                            "objectType": {
+                                "type": ["string", "null"]
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "description": "A document passage (`chunk`, `knowledge_section`, or a multimodal\nchunk): `document_id` resolves via `GET /documents/{id}`; `position`\nis the row's ordering within the document.",
+                        "required": ["documentId", "kind"],
+                        "properties": {
+                            "documentId": {
+                                "type": "string"
+                            },
+                            "kind": {
+                                "type": "string",
+                                "enum": ["document"]
+                            },
+                            "position": {
+                                "type": ["integer", "null"],
+                                "format": "int64"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "description": "A conversational memory chunk: `session_id` resolves via\n`GET /sessions/{id}/turns`; `turn_id` / `position` locate the chunk\nwithin the session when the row carries the link.",
+                        "required": ["sessionId", "kind"],
+                        "properties": {
+                            "kind": {
+                                "type": "string",
+                                "enum": ["session"]
+                            },
+                            "position": {
+                                "type": ["integer", "null"],
+                                "format": "int64"
+                            },
+                            "sessionId": {
+                                "type": "string"
+                            },
+                            "turnId": {
+                                "type": ["string", "null"]
+                            }
+                        }
+                    }
+                ],
+                "description": "Typed pointer to the row behind a hit's [`ResultHit::id`], so a caller can\nresolve the underlying document, entity, or session without parsing raw\nrecord-id strings. The `kind` tag names the payload family; entity halves\ncarry the normalised name, which the entity read endpoints re-normalise,\nso every ref resolves via the corresponding read surface."
             },
             "ResponseTraceSummaryJson": {
                 "type": "object",
@@ -6694,7 +8862,15 @@
             "ResultKind": {
                 "type": "string",
                 "description": "Coarse-grained result type. Mirrors the row table the hit lives\nin.",
-                "enum": ["attribute", "entity", "chunk", "memory_chunk", "section"]
+                "enum": [
+                    "attribute",
+                    "entity",
+                    "action",
+                    "chunk",
+                    "memory_chunk",
+                    "turn",
+                    "section"
+                ]
             },
             "RetrievalStatsJson": {
                 "type": "object",
@@ -6838,6 +9014,23 @@
                     }
                 }
             },
+            "ScopeListResponseJson": {
+                "type": "object",
+                "description": "The `GET /{ctx}/scopes` response.\n\nAn envelope rather than a bare array: a top-level JSON array has nowhere to\ncarry the pagination block, and every list surface returns the same shape.",
+                "required": ["scopes", "page"],
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next.\n\n`scopes` may hold fewer than `limit` entries while `hasMore` is still\ntrue: the page is bounded in the database and then filtered for\nvisibility, so invisible nodes consume page budget without appearing.\nTerminate a walk on `hasMore`, never on a short page."
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ScopeNodeJson"
+                        }
+                    }
+                }
+            },
             "ScopeNodeJson": {
                 "type": "object",
                 "description": "One scope node in the `GET /{context}/scopes` response.",
@@ -6861,11 +9054,11 @@
             },
             "ScopePath": {
                 "type": "string",
-                "description": "A validated, canonical scope path in slash form, e.g. `org/apple/product/ipad/`. Root is `/`."
+                "description": "A validated, canonical scope path in slash form, e.g. `org/apple/product/ipad/`. Root is `/`. A leading and a trailing `/` are both optional on input (`/org/apple`, `org/apple/` and `org/apple` all denote the same node); the canonical form returned carries the trailing `/` and no leading one."
             },
             "ScopePattern": {
                 "type": "string",
-                "description": "A scope pattern: an exact node (`org/apple/product/ipad`) or a subtree (`org/apple/*` / `/*`)."
+                "description": "A scope pattern: an exact node (`org/apple/product/ipad`) or a subtree (`org/apple/*` / `/*`). A leading `/` is optional (`/org/apple` denotes the same node as `org/apple`); patterns are returned in the canonical form, without it."
             },
             "ScopeSets": {
                 "type": "array",
@@ -6946,7 +9139,14 @@
             },
             "StateResponseJson": {
                 "type": "object",
-                "required": ["identity", "knowledge", "context", "instructions", "unknowns"],
+                "required": [
+                    "identity",
+                    "knowledge",
+                    "context",
+                    "instructions",
+                    "unknowns",
+                    "truncated"
+                ],
                 "properties": {
                     "context": {
                         "$ref": "#/components/schemas/CategoryStateJson"
@@ -6963,11 +9163,47 @@
                     "knowledge": {
                         "$ref": "#/components/schemas/CategoryStateJson"
                     },
+                    "truncated": {
+                        "$ref": "#/components/schemas/StateTruncationJson",
+                        "description": "Per-table truncation. A `true` flag means that table has more rows\nthan this response carries, and the complete set must be walked\nthrough that table's own collection endpoint."
+                    },
                     "unknowns": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/UncertaintySummaryJson"
                         }
+                    }
+                }
+            },
+            "StateTruncationJson": {
+                "type": "object",
+                "description": "Which of the state read's underlying tables were bounded short.",
+                "required": [
+                    "entities",
+                    "attributes",
+                    "relations",
+                    "actions",
+                    "instructions",
+                    "unknowns"
+                ],
+                "properties": {
+                    "actions": {
+                        "type": "boolean"
+                    },
+                    "attributes": {
+                        "type": "boolean"
+                    },
+                    "entities": {
+                        "type": "boolean"
+                    },
+                    "instructions": {
+                        "type": "boolean"
+                    },
+                    "relations": {
+                        "type": "boolean"
+                    },
+                    "unknowns": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -6995,18 +9231,18 @@
             "Tier": {
                 "type": "string",
                 "description": "Which tier resolved the query. Exposed on the response for the\nCLI's `--tier` flag (Phase 8) and so callers can tell when their\nquery went all the way to tier 4.",
-                "enum": ["direct", "cache", "hybrid", "full_context"]
+                "enum": ["direct", "cache", "hybrid", "escalated"]
             },
             "TierCountsJson": {
                 "type": "object",
-                "required": ["direct", "hybrid", "fullContext"],
+                "required": ["direct", "hybrid", "escalated"],
                 "properties": {
                     "direct": {
                         "type": "integer",
                         "format": "int64",
                         "minimum": 0
                     },
-                    "fullContext": {
+                    "escalated": {
                         "type": "integer",
                         "format": "int64",
                         "minimum": 0
@@ -7025,8 +9261,12 @@
             },
             "TraceListResponseJson": {
                 "type": "object",
-                "required": ["traces"],
+                "required": ["traces", "page"],
                 "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    },
                     "traces": {
                         "type": "array",
                         "items": {
@@ -7218,8 +9458,12 @@
             },
             "TurnListResponseJson": {
                 "type": "object",
-                "required": ["turns"],
+                "required": ["turns", "page"],
                 "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/PageMeta",
+                        "description": "Where this page sits in the walk. Follow `nextCursor` for the next."
+                    },
                     "turns": {
                         "type": "array",
                         "items": {
@@ -7307,6 +9551,10 @@
                         "type": ["string", "null"],
                         "description": "Optional RFC3339 known/observed time for the content (backfill). Stamped as the\nknown-time of facts derived from this document, so `as_of` queries see them\ndated to when the content was observed. Omitted means facts date to ingest time."
                     },
+                    "observedAtHeader": {
+                        "type": ["string", "null"],
+                        "description": "Optional opt-in to detect the observed time from the document itself: the name\nof a field inside a leading `---`-fenced front-matter block whose value (RFC3339\nor `YYYY-MM-DD`) is read as `observedAt`. Ignored when `observedAt` is supplied\nexplicitly; a missing or unparseable field is non-fatal (facts date to ingest\ntime). The effective value is echoed in the upload response."
+                    },
                     "scopes": {
                         "$ref": "#/components/schemas/ScopeSets",
                         "description": "Optional DNF scope selector tagging the document, e.g.\n`[[\"org/apple/product/macbook\"]]` (or co-owned `[\"team/a\",\"team/b\"]`). Each\nclause's nodes must lie within the caller's `memory:write` region (a request\noutside it is a 403). Omitted ⇒ the document inherits the caller's whole\nwrite region (unchanged behaviour). Clients must send the `metadata` part\nbefore the `file` part for it to apply."
@@ -7331,6 +9579,11 @@
                     },
                     "id": {
                         "type": "string"
+                    },
+                    "observedAt": {
+                        "type": ["string", "null"],
+                        "format": "date-time",
+                        "description": "The known/observed time stamped onto the document: the request's explicit\n`observedAt` or the value detected via `observedAtHeader`. Absent when\nneither applied, so facts will date to ingest time. On a dedup hit this is\nthe matched document's known-time, which this upload fills only when that\nrow has none and its first ingest has not published."
                     },
                     "status": {
                         "$ref": "#/components/schemas/DocumentStatus"

--- a/packages/spectron/src/client.ts
+++ b/packages/spectron/src/client.ts
@@ -6,6 +6,7 @@ import { Principals } from "./components/principals.js";
 import { Scopes } from "./components/scopes.js";
 import { Sessions } from "./components/sessions.js";
 import { Traces } from "./components/traces.js";
+import { addPageParams, collectPages, type PageOptions } from "./pagination.js";
 import { getContextApiPrefix } from "./paths.js";
 import { normaliseScope, type Scope } from "./scope.js";
 import { type ChatChunk, parseChatStream } from "./streaming.js";
@@ -32,6 +33,7 @@ export type ElaborateResponseJson = components["schemas"]["ElaborateResponseJson
 export type FsckReportJson = components["schemas"]["FsckReportJson"];
 export type InspectResponseJson = components["schemas"]["InspectResponseJson"];
 export type AuditResponseJson = components["schemas"]["AuditResponseJson"];
+export type AuditRowJson = components["schemas"]["AuditRowJson"];
 export type StateResponseJson = components["schemas"]["StateResponseJson"];
 export type ProfileResponseJson = components["schemas"]["ProfileResponseJson"];
 
@@ -134,6 +136,20 @@ export interface ChatOptions {
     bypassCache?: boolean;
     /** Descriptive `key=value` labels for rows the chat persists. */
     labels?: string[];
+}
+
+/** Filters and pagination for {@link Spectron.audit}. */
+export interface AuditOptions extends PageOptions {
+    /** Only rows attributed to this principal. */
+    principal?: string;
+    /** Only rows attributed to this API key. */
+    key?: string;
+    /** Only rows of this trace kind. */
+    kind?: string;
+    /** Lower bound on `createdAt`, as an RFC 3339 timestamp. */
+    since?: string;
+    /** Upper bound on `createdAt`, as an RFC 3339 timestamp. */
+    until?: string;
 }
 
 function addDefined(target: Record<string, unknown>, key: string, value: unknown): void {
@@ -446,29 +462,36 @@ export class Spectron {
         return body as InspectResponseJson;
     }
 
-    /** Lists audit rows for write/recall activity (`GET /audit`). */
-    async audit(options?: {
-        principal?: string;
-        key?: string;
-        kind?: string;
-        since?: string;
-        until?: string;
-        limit?: number;
-    }): Promise<AuditResponseJson> {
+    /** Lists one page of audit rows for write/recall activity (`GET /audit`). */
+    async audit(options?: AuditOptions): Promise<AuditResponseJson> {
         const query: Record<string, unknown> = {};
         addDefined(query, "principal", options?.principal);
         addDefined(query, "key", options?.key);
         addDefined(query, "kind", options?.kind);
         addDefined(query, "since", options?.since);
         addDefined(query, "until", options?.until);
-        addDefined(query, "limit", options?.limit);
+        addPageParams(query, options);
         const body = await this.transport.requestJson("GET", `${this.base}/audit`, { query });
         return body as AuditResponseJson;
     }
 
-    /** Structured memory state snapshot (`GET /state`). */
-    async state(): Promise<StateResponseJson> {
-        const body = await this.transport.requestJson("GET", `${this.base}/state`);
+    /** Every matching audit row, following cursors to exhaustion. */
+    async auditAll(options?: Omit<AuditOptions, "cursor" | "count">): Promise<AuditRowJson[]> {
+        return collectPages((cursor) => this.audit({ ...options, cursor }), "rows");
+    }
+
+    /**
+     * Structured memory state snapshot (`GET /state`).
+     *
+     * A snapshot, not an export: this is a composite read over six tables, each
+     * bounded by `limit` (default 100, max 500), and `truncated` reports which
+     * of them had more rows. To enumerate a table completely, walk its own
+     * collection endpoint instead — {@link Spectron.entities} for entities.
+     */
+    async state(options?: { limit?: number }): Promise<StateResponseJson> {
+        const query: Record<string, unknown> = {};
+        addDefined(query, "limit", options?.limit);
+        const body = await this.transport.requestJson("GET", `${this.base}/state`, { query });
         return body as StateResponseJson;
     }
 

--- a/packages/spectron/src/client.ts
+++ b/packages/spectron/src/client.ts
@@ -6,7 +6,7 @@ import { Principals } from "./components/principals.js";
 import { Scopes } from "./components/scopes.js";
 import { Sessions } from "./components/sessions.js";
 import { Traces } from "./components/traces.js";
-import { addPageParams, collectPages, type PageOptions } from "./pagination.js";
+import { addPageParams, type CursorOptions, collectPages } from "./pagination.js";
 import { getContextApiPrefix } from "./paths.js";
 import { normaliseScope, type Scope } from "./scope.js";
 import { type ChatChunk, parseChatStream } from "./streaming.js";
@@ -138,8 +138,13 @@ export interface ChatOptions {
     labels?: string[];
 }
 
-/** Filters and pagination for {@link Spectron.audit}. */
-export interface AuditOptions extends PageOptions {
+/**
+ * Filters and pagination for {@link Spectron.audit}.
+ *
+ * Extends {@link CursorOptions} rather than {@link PageOptions}: `/audit` takes
+ * `limit` and `cursor` only, so there is no `count` to offer.
+ */
+export interface AuditOptions extends CursorOptions {
     /** Only rows attributed to this principal. */
     principal?: string;
     /** Only rows attributed to this API key. */
@@ -476,7 +481,7 @@ export class Spectron {
     }
 
     /** Every matching audit row, following cursors to exhaustion. */
-    async auditAll(options?: Omit<AuditOptions, "cursor" | "count">): Promise<AuditRowJson[]> {
+    async auditAll(options?: Omit<AuditOptions, "cursor">): Promise<AuditRowJson[]> {
         return collectPages((cursor) => this.audit({ ...options, cursor }), "rows");
     }
 
@@ -485,8 +490,13 @@ export class Spectron {
      *
      * A snapshot, not an export: this is a composite read over six tables, each
      * bounded by `limit` (default 100, max 500), and `truncated` reports which
-     * of them had more rows. To enumerate a table completely, walk its own
-     * collection endpoint instead — {@link Spectron.entities} for entities.
+     * of them had more rows.
+     *
+     * Four of those tables have their own collection endpoint to enumerate them
+     * completely — entities (see {@link Spectron.entities}), attributes,
+     * relations, and actions. The remaining two, `instructions` and `unknowns`,
+     * have no such route: when `truncated` flags either, the omitted rows cannot
+     * be recovered other than by raising `limit`.
      */
     async state(options?: { limit?: number }): Promise<StateResponseJson> {
         const query: Record<string, unknown> = {};

--- a/packages/spectron/src/components/documents.ts
+++ b/packages/spectron/src/components/documents.ts
@@ -1,4 +1,5 @@
 import { spectronFileInputToBlob } from "../file-body.js";
+import { addPageParams, collectPages, type PageOptions } from "../pagination.js";
 import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import { normaliseScope, type Scope } from "../scope.js";
 import type { Transport, UploadProgressListener } from "../transport.js";
@@ -7,7 +8,9 @@ import type { components } from "../types/generated.js";
 
 export type DocumentJson = components["schemas"]["DocumentJson"];
 export type DocumentPageJson = components["schemas"]["DocumentPageJson"];
+export type ChunkJson = components["schemas"]["ChunkJson"];
 export type ChunkPageJson = components["schemas"]["ChunkPageJson"];
+export type KeywordJson = components["schemas"]["KeywordJson"];
 export type UploadResponse = components["schemas"]["UploadResponse"];
 export type QueryRequestJson = components["schemas"]["QueryRequestJson"];
 export type QueryResponseJson = components["schemas"]["QueryResponseJson"];
@@ -19,6 +22,50 @@ export type DocumentKeywordsResponse = components["schemas"]["DocumentKeywordsRe
 export type DocumentKeywordJson = components["schemas"]["DocumentKeywordJson"];
 export type RecomputeLinksResponse = components["schemas"]["RecomputeLinksResponse"];
 
+/**
+ * The pre-cursor offset parameters `/documents`, `/documents/{id}/chunks`, and
+ * `/documents/keywords` still accept.
+ *
+ * Retained for callers with numbered page controls, which need a page index and
+ * a total that keyset pagination deliberately does not provide. They pay the
+ * scan cost the cursor path avoids, and cannot be combined with `cursor` — the
+ * server rejects that pairing with a 400.
+ *
+ * @deprecated Prefer `limit` + `cursor`.
+ */
+export interface OffsetPageOptions {
+    /** Zero-indexed page number. */
+    page?: number;
+    /** Rows per page. */
+    pageSize?: number;
+}
+
+/** The filters `/documents` accepts, beside its pagination parameters. */
+export interface DocumentFilters {
+    status?: string;
+    mimeType?: string;
+}
+
+export type DocumentListOptions = DocumentFilters & PageOptions & OffsetPageOptions;
+
+/** The filters `/documents/keywords` accepts, beside its pagination parameters. */
+export interface KeywordFilters {
+    q?: string;
+    minDocumentCount?: number;
+    sort?: string;
+}
+
+export type KeywordListOptions = KeywordFilters & PageOptions & OffsetPageOptions;
+
+/**
+ * Copies the deprecated offset parameters into a query object. Kept separate
+ * from {@link addPageParams} so the two never merge into one option bag: the
+ * server rejects `cursor` sent together with `page`.
+ */
+function addOffsetParams(query: Record<string, unknown>, options?: OffsetPageOptions): void {
+    if (options?.page !== undefined) query.page = options.page;
+    if (options?.pageSize !== undefined) query.pageSize = options.pageSize;
+}
 /** Options shared by document upload and reprocess. */
 export interface DocumentUploadOptions {
     /** Binary content. `File`, `Blob`, `Uint8Array`, `ArrayBuffer`, or `ReadableStream`. */
@@ -107,18 +154,23 @@ export class DocumentKeywords {
         return `${getContextApiPrefix(this.contextId)}/documents/keywords`;
     }
 
-    /** Lists keywords with optional filters and pagination. */
-    async list(options?: {
-        q?: string;
-        minDocumentCount?: number;
-        sort?: string;
-        page?: number;
-        pageSize?: number;
-    }): Promise<KeywordPageJson> {
-        const body = await this.transport.requestJson("GET", this.base, {
-            query: options as Record<string, unknown>,
-        });
+    /** Lists one page of keywords with optional filters. */
+    async list(options?: KeywordListOptions): Promise<KeywordPageJson> {
+        const query: Record<string, unknown> = {};
+        if (options?.q !== undefined) query.q = options.q;
+        if (options?.minDocumentCount !== undefined) {
+            query.minDocumentCount = options.minDocumentCount;
+        }
+        if (options?.sort !== undefined) query.sort = options.sort;
+        addPageParams(query, options);
+        addOffsetParams(query, options);
+        const body = await this.transport.requestJson("GET", this.base, { query });
         return body as KeywordPageJson;
+    }
+
+    /** Every matching keyword, following cursors to exhaustion. */
+    async listAll(options?: KeywordFilters & { limit?: number }): Promise<KeywordJson[]> {
+        return collectPages((cursor) => this.list({ ...options, cursor }), "keywords");
     }
 
     /** Vector search over keyword embeddings. */
@@ -217,36 +269,66 @@ export class Documents {
         );
     }
 
-    /** Paginated text chunks. */
+    /** Lists one page of a document's text chunks, in document order. */
     async chunks(
         documentId: string,
-        options?: { page?: number; pageSize?: number },
+        options?: PageOptions & OffsetPageOptions,
     ): Promise<ChunkPageJson> {
-        const q: Record<string, unknown> = {};
-        if (options?.page !== undefined) q.page = options.page;
-        if (options?.pageSize !== undefined) q.pageSize = options.pageSize;
+        const query: Record<string, unknown> = {};
+        addPageParams(query, options);
+        addOffsetParams(query, options);
         const body = await this.transport.requestJson(
             "GET",
             `${this.base}/${encodePathSegment(documentId)}/chunks`,
-            { query: q },
+            { query },
         );
         return body as ChunkPageJson;
     }
 
-    /** Lists documents with optional filters. */
-    async list(options?: {
-        status?: string;
-        mimeType?: string;
-        page?: number;
-        pageSize?: number;
-    }): Promise<DocumentPageJson> {
-        const q: Record<string, unknown> = {};
-        if (options?.status !== undefined) q.status = options.status;
-        if (options?.mimeType !== undefined) q.mimeType = options.mimeType;
-        if (options?.page !== undefined) q.page = options.page;
-        if (options?.pageSize !== undefined) q.pageSize = options.pageSize;
-        const body = await this.transport.requestJson("GET", this.base, { query: q });
+    /**
+     * Every chunk of a document, following cursors to exhaustion.
+     *
+     * Reconstructing a document's text needs all of it, and `limit` is clamped
+     * at 500 server-side, so a single wide page silently truncates anything
+     * longer. Pass `max` when only the first N chunks are ever rendered, so a
+     * very long document does not cost a page fetch per hundred chunks.
+     */
+    async allChunks(
+        documentId: string,
+        options?: { limit?: number; max?: number },
+    ): Promise<ChunkJson[]> {
+        return collectPages(
+            (cursor) => this.chunks(documentId, { limit: options?.limit, cursor }),
+            "chunks",
+            options?.max,
+        );
+    }
+
+    /** Lists one page of documents with optional filters. */
+    async list(options?: DocumentListOptions): Promise<DocumentPageJson> {
+        const query: Record<string, unknown> = {};
+        if (options?.status !== undefined) query.status = options.status;
+        if (options?.mimeType !== undefined) query.mimeType = options.mimeType;
+        addPageParams(query, options);
+        addOffsetParams(query, options);
+        const body = await this.transport.requestJson("GET", this.base, { query });
         return body as DocumentPageJson;
+    }
+
+    /** Every matching document, following cursors to exhaustion. */
+    async listAll(options?: DocumentFilters & { limit?: number }): Promise<DocumentJson[]> {
+        return collectPages((cursor) => this.list({ ...options, cursor }), "documents");
+    }
+
+    /**
+     * How many documents match, without fetching them.
+     *
+     * Asks for a single row with `count: true`, so the total is the only thing
+     * paid for beyond one page bound.
+     */
+    async count(options?: DocumentFilters): Promise<number> {
+        const page = await this.list({ ...options, limit: 1, count: true });
+        return page.page.totalSize ?? page.documents.length;
     }
 
     /** Deletes a document. */

--- a/packages/spectron/src/components/documents.ts
+++ b/packages/spectron/src/components/documents.ts
@@ -46,7 +46,19 @@ export interface DocumentFilters {
     mimeType?: string;
 }
 
-export type DocumentListOptions = DocumentFilters & PageOptions & OffsetPageOptions;
+/**
+ * Cursor pagination or the deprecated offset pagination, never both.
+ *
+ * The server rejects `cursor` sent together with `page` with a `400`, so the two
+ * modes are modelled as an exclusive union: the invalid pairing fails to
+ * type-check instead of surfacing as a runtime error. `limit` and `count` stay
+ * available in both arms — only the mode selector is exclusive.
+ */
+export type CursorOrOffsetOptions =
+    | (PageOptions & { page?: never; pageSize?: never })
+    | (OffsetPageOptions & Omit<PageOptions, "cursor"> & { cursor?: never });
+
+export type DocumentListOptions = DocumentFilters & CursorOrOffsetOptions;
 
 /** The filters `/documents/keywords` accepts, beside its pagination parameters. */
 export interface KeywordFilters {
@@ -55,7 +67,7 @@ export interface KeywordFilters {
     sort?: string;
 }
 
-export type KeywordListOptions = KeywordFilters & PageOptions & OffsetPageOptions;
+export type KeywordListOptions = KeywordFilters & CursorOrOffsetOptions;
 
 /**
  * Copies the deprecated offset parameters into a query object. Kept separate
@@ -270,10 +282,7 @@ export class Documents {
     }
 
     /** Lists one page of a document's text chunks, in document order. */
-    async chunks(
-        documentId: string,
-        options?: PageOptions & OffsetPageOptions,
-    ): Promise<ChunkPageJson> {
+    async chunks(documentId: string, options?: CursorOrOffsetOptions): Promise<ChunkPageJson> {
         const query: Record<string, unknown> = {};
         addPageParams(query, options);
         addOffsetParams(query, options);

--- a/packages/spectron/src/components/entities.ts
+++ b/packages/spectron/src/components/entities.ts
@@ -1,3 +1,4 @@
+import { addPageParams, collectPages, type PageOptions } from "../pagination.js";
 import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
@@ -23,12 +24,32 @@ export class Entities {
         return `${getContextApiPrefix(this.contextId)}/entities`;
     }
 
-    /** Lists entities, optionally filtered by type. */
-    async list(options?: { type?: string }): Promise<EntityDetailJson[]> {
-        const body = await this.transport.requestJson("GET", this.base, {
-            query: options?.type !== undefined ? { type: options.type } : undefined,
-        });
-        return (body as EntityListResponseJson).entities;
+    /** Lists one page of entities, optionally filtered by type. */
+    async list(options?: PageOptions & { type?: string }): Promise<EntityListResponseJson> {
+        const query: Record<string, unknown> = {};
+        if (options?.type !== undefined) query.type = options.type;
+        addPageParams(query, options);
+        const body = await this.transport.requestJson("GET", this.base, { query });
+        return body as EntityListResponseJson;
+    }
+
+    /** Every matching entity, following cursors to exhaustion. */
+    async listAll(options?: { type?: string; limit?: number }): Promise<EntityDetailJson[]> {
+        return collectPages(
+            (cursor) => this.list({ type: options?.type, limit: options?.limit, cursor }),
+            "entities",
+        );
+    }
+
+    /**
+     * How many entities match, without fetching them.
+     *
+     * Asks for a single row with `count: true`, so the total is the only thing
+     * paid for beyond one page bound.
+     */
+    async count(options?: { type?: string }): Promise<number> {
+        const page = await this.list({ type: options?.type, limit: 1, count: true });
+        return page.page.totalSize ?? page.entities.length;
     }
 
     /** Fetches a single entity by type and name, with its attributes and relations. */

--- a/packages/spectron/src/components/keys.ts
+++ b/packages/spectron/src/components/keys.ts
@@ -1,5 +1,9 @@
+import { addPageParams, collectPages, type PageOptions } from "../pagination.js";
 import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
+import type { components } from "../types/generated.js";
+
+export type KeyListResponseJson = components["schemas"]["KeyListResponseJson"];
 
 /**
  * A freshly minted (or rotated) self-service key. `key` is the full bearer
@@ -55,10 +59,25 @@ export class Keys {
         return body as MintedKeyJson;
     }
 
-    /** Lists key metadata for the context (secrets are never included). */
-    async list(): Promise<KeyDetailJson[]> {
-        const body = await this.transport.requestJson("GET", this.base);
-        return (body as KeyDetailJson[] | null) ?? [];
+    /**
+     * Lists one page of key metadata for the context (secrets are never
+     * included).
+     *
+     * `keys` can hold fewer than `limit` entries while `page.hasMore` is still
+     * true: a non-administrator sees only the key they authenticated with, so
+     * the page is bounded in the database and then filtered. Terminate a walk on
+     * `page.nextCursor`, never on a short page.
+     */
+    async list(options?: PageOptions): Promise<KeyListResponseJson> {
+        const query: Record<string, unknown> = {};
+        addPageParams(query, options);
+        const body = await this.transport.requestJson("GET", this.base, { query });
+        return body as KeyListResponseJson;
+    }
+
+    /** Every key the caller can see, following cursors to exhaustion. */
+    async listAll(options?: { limit?: number }): Promise<KeyDetailJson[]> {
+        return collectPages((cursor) => this.list({ limit: options?.limit, cursor }), "keys");
     }
 
     /** Revokes a key by name. */

--- a/packages/spectron/src/components/principals.ts
+++ b/packages/spectron/src/components/principals.ts
@@ -1,9 +1,11 @@
+import { addPageParams, collectPages, type PageOptions } from "../pagination.js";
 import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { Verb } from "../types/domain.js";
 import type { components } from "../types/generated.js";
 
 export type PrincipalJson = components["schemas"]["PrincipalJson"];
+export type PrincipalListResponseJson = components["schemas"]["PrincipalListResponseJson"];
 export type EffectiveGrantsJson = components["schemas"]["EffectiveGrantsJson"];
 
 /** Principals and their scope grants (requires the `manage` grant). */
@@ -21,10 +23,17 @@ export class Principals {
         return `${getContextApiPrefix(this.contextId)}/principals`;
     }
 
-    /** Lists all principals in the context. */
-    async list(): Promise<PrincipalJson[]> {
-        const body = await this.transport.requestJson("GET", this.base);
-        return body as PrincipalJson[];
+    /** Lists one page of the context's principals. */
+    async list(options?: PageOptions): Promise<PrincipalListResponseJson> {
+        const query: Record<string, unknown> = {};
+        addPageParams(query, options);
+        const body = await this.transport.requestJson("GET", this.base, { query });
+        return body as PrincipalListResponseJson;
+    }
+
+    /** Every principal in the context, following cursors to exhaustion. */
+    async listAll(options?: { limit?: number }): Promise<PrincipalJson[]> {
+        return collectPages((cursor) => this.list({ limit: options?.limit, cursor }), "principals");
     }
 
     /** Fetches a single principal and its declared grants. */

--- a/packages/spectron/src/components/scopes.ts
+++ b/packages/spectron/src/components/scopes.ts
@@ -1,4 +1,4 @@
-import { addPageParams, collectPages, type PageOptions } from "../pagination.js";
+import { addPageParams, type CursorOptions, collectPages } from "../pagination.js";
 import { getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
@@ -30,8 +30,12 @@ export class Scopes {
      * caller has no grant over, so invisible nodes consume page budget without
      * appearing. Terminate a walk on `page.nextCursor`, never on a short page —
      * or call {@link listAll}, which does it correctly.
+     *
+     * `page.totalSize` is always absent here: the endpoint takes no `count`, and
+     * a total counted before the visibility filter would not match what a walk
+     * returns anyway.
      */
-    async list(options?: PageOptions): Promise<ScopeListResponseJson> {
+    async list(options?: CursorOptions): Promise<ScopeListResponseJson> {
         const query: Record<string, unknown> = {};
         addPageParams(query, options);
         const body = await this.transport.requestJson("GET", this.base, { query });

--- a/packages/spectron/src/components/scopes.ts
+++ b/packages/spectron/src/components/scopes.ts
@@ -1,8 +1,10 @@
+import { addPageParams, collectPages, type PageOptions } from "../pagination.js";
 import { getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
 
 export type ScopeNodeJson = components["schemas"]["ScopeNodeJson"];
+export type ScopeListResponseJson = components["schemas"]["ScopeListResponseJson"];
 export type ForgetScopeResponseJson = components["schemas"]["ForgetScopeResponseJson"];
 
 /** The scope tree: register, list, delete, and forget scope subtrees. */
@@ -20,10 +22,31 @@ export class Scopes {
         return `${getContextApiPrefix(this.contextId)}/scopes`;
     }
 
-    /** Lists registered scope nodes. */
-    async list(): Promise<ScopeNodeJson[]> {
-        const body = await this.transport.requestJson("GET", this.base);
-        return body as ScopeNodeJson[];
+    /**
+     * Lists one page of registered scope nodes.
+     *
+     * `scopes` can hold fewer than `limit` entries while `page.hasMore` is still
+     * true: the server bounds the page in the database and then drops nodes the
+     * caller has no grant over, so invisible nodes consume page budget without
+     * appearing. Terminate a walk on `page.nextCursor`, never on a short page —
+     * or call {@link listAll}, which does it correctly.
+     */
+    async list(options?: PageOptions): Promise<ScopeListResponseJson> {
+        const query: Record<string, unknown> = {};
+        addPageParams(query, options);
+        const body = await this.transport.requestJson("GET", this.base, { query });
+        return body as ScopeListResponseJson;
+    }
+
+    /**
+     * Every registered scope node, following cursors to exhaustion.
+     *
+     * The scope tree is consumed whole — as a tree to render, or as the source
+     * for scope autocomplete and validation — so a single page of it is not
+     * useful.
+     */
+    async listAll(options?: { limit?: number }): Promise<ScopeNodeJson[]> {
+        return collectPages((cursor) => this.list({ limit: options?.limit, cursor }), "scopes");
     }
 
     /** Registers a scope path with optional display metadata. */

--- a/packages/spectron/src/components/sessions.ts
+++ b/packages/spectron/src/components/sessions.ts
@@ -1,3 +1,4 @@
+import { addPageParams, collectPages, type PageOptions } from "../pagination.js";
 import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import { normaliseScope, type Scope } from "../scope.js";
 import type { Transport } from "../transport.js";
@@ -40,10 +41,21 @@ export class Session {
         await this.transport.requestJson("DELETE", this.base);
     }
 
-    /** Lists turns recorded against this session. */
-    async turns(): Promise<TurnResponseJson[]> {
-        const body = await this.transport.requestJson("GET", `${this.base}/turns`);
-        return (body as TurnListResponseJson).turns;
+    /** Lists one page of turns recorded against this session, oldest first. */
+    async turns(options?: PageOptions): Promise<TurnListResponseJson> {
+        const query: Record<string, unknown> = {};
+        addPageParams(query, options);
+        const body = await this.transport.requestJson("GET", `${this.base}/turns`, { query });
+        return body as TurnListResponseJson;
+    }
+
+    /**
+     * Every turn in this session, following cursors to exhaustion.
+     *
+     * A transcript is read whole, so this is usually what a caller wants.
+     */
+    async allTurns(options?: { limit?: number }): Promise<TurnResponseJson[]> {
+        return collectPages((cursor) => this.turns({ limit: options?.limit, cursor }), "turns");
     }
 
     /** Retrieves session-scoped LLM context text for a query. */

--- a/packages/spectron/src/components/traces.ts
+++ b/packages/spectron/src/components/traces.ts
@@ -1,3 +1,4 @@
+import { addPageParams, collectPages, type PageOptions } from "../pagination.js";
 import { encodePathSegment, getContextApiPrefix } from "../paths.js";
 import type { Transport } from "../transport.js";
 import type { components } from "../types/generated.js";
@@ -21,12 +22,17 @@ export class Traces {
         return `${getContextApiPrefix(this.contextId)}/traces`;
     }
 
-    /** Lists recent trace records. */
-    async list(options?: { limit?: number }): Promise<TraceRecordJson[]> {
-        const body = await this.transport.requestJson("GET", this.base, {
-            query: options?.limit !== undefined ? { limit: options.limit } : undefined,
-        });
-        return (body as TraceListResponseJson).traces;
+    /** Lists one page of trace records, newest first. */
+    async list(options?: PageOptions): Promise<TraceListResponseJson> {
+        const query: Record<string, unknown> = {};
+        addPageParams(query, options);
+        const body = await this.transport.requestJson("GET", this.base, { query });
+        return body as TraceListResponseJson;
+    }
+
+    /** Every trace record, following cursors to exhaustion. */
+    async listAll(options?: { limit?: number }): Promise<TraceRecordJson[]> {
+        return collectPages((cursor) => this.list({ limit: options?.limit, cursor }), "traces");
     }
 
     /** Fetches one trace by id. */

--- a/packages/spectron/src/index.ts
+++ b/packages/spectron/src/index.ts
@@ -1,5 +1,7 @@
 export {
+    type AuditOptions,
     type AuditResponseJson,
+    type AuditRowJson,
     type BatchMessage,
     type ChatOptions,
     type ChatResponseJson,
@@ -26,18 +28,25 @@ export {
     type WhoamiResponseJson,
 } from "./client.js";
 export {
+    type ChunkJson,
     type ChunkPageJson,
+    type DocumentFilters,
     type DocumentJson,
     type DocumentKeywordJson,
     DocumentKeywords,
     type DocumentKeywordsResponse,
+    type DocumentListOptions,
     type DocumentPageJson,
     Documents,
     type DocumentUploadOptions,
     type KeywordDetailJson,
+    type KeywordFilters,
+    type KeywordJson,
+    type KeywordListOptions,
     type KeywordPageJson,
     type KeywordSearchRequestJson,
     type KeywordSearchResponseJson,
+    type OffsetPageOptions,
     type QueryRequestJson,
     type QueryResponseJson,
     type RecomputeLinksResponse,
@@ -51,14 +60,25 @@ export {
     type EntityListResponseJson,
     type EntityResponseJson,
 } from "./components/entities.js";
-export { type KeyDetailJson, Keys, type MintedKeyJson } from "./components/keys.js";
+export {
+    type KeyDetailJson,
+    type KeyListResponseJson,
+    Keys,
+    type MintedKeyJson,
+} from "./components/keys.js";
 export { Lifecycle, type LifecycleResponseJson } from "./components/lifecycle.js";
 export {
     type EffectiveGrantsJson,
     type PrincipalJson,
+    type PrincipalListResponseJson,
     Principals,
 } from "./components/principals.js";
-export { type ForgetScopeResponseJson, type ScopeNodeJson, Scopes } from "./components/scopes.js";
+export {
+    type ForgetScopeResponseJson,
+    type ScopeListResponseJson,
+    type ScopeNodeJson,
+    Scopes,
+} from "./components/scopes.js";
 export {
     Session,
     type SessionContextResponseJson,
@@ -87,6 +107,13 @@ export {
 } from "./errors.js";
 export { spectronFileInputToBlob } from "./file-body.js";
 export { idempotencyKey } from "./idempotency.js";
+export {
+    addPageParams,
+    collectPages,
+    type PageMeta,
+    type PageOptions,
+    walkPages,
+} from "./pagination.js";
 export { encodePathSegment, getContextApiPrefix } from "./paths.js";
 export { backoffSchedule, shouldRetry } from "./retry.js";
 export { normaliseScope, type Scope } from "./scope.js";

--- a/packages/spectron/src/index.ts
+++ b/packages/spectron/src/index.ts
@@ -30,6 +30,7 @@ export {
 export {
     type ChunkJson,
     type ChunkPageJson,
+    type CursorOrOffsetOptions,
     type DocumentFilters,
     type DocumentJson,
     type DocumentKeywordJson,
@@ -109,6 +110,7 @@ export { spectronFileInputToBlob } from "./file-body.js";
 export { idempotencyKey } from "./idempotency.js";
 export {
     addPageParams,
+    type CursorOptions,
     collectPages,
     type PageMeta,
     type PageOptions,

--- a/packages/spectron/src/pagination.ts
+++ b/packages/spectron/src/pagination.ts
@@ -1,0 +1,104 @@
+import type { components } from "./types/generated.js";
+
+/**
+ * The pagination block every Spectron list surface returns beside its rows.
+ *
+ * `nextCursor` is the only reliable end-of-walk signal: it is absent on the last
+ * page. `totalSize` is present only when the request asked for it with
+ * `count: true`, which costs a full count of the filtered set.
+ */
+export type PageMeta = components["schemas"]["PageMeta"];
+
+/** The three pagination parameters every list surface accepts. */
+export interface PageOptions {
+    /**
+     * Page size. Omitted means the server default (100); a value above the cap
+     * (500) is clamped rather than rejected, so a caller cannot widen a page by
+     * asking for more.
+     */
+    limit?: number;
+    /** Continuation token from the previous page's `page.nextCursor`. */
+    cursor?: string;
+    /**
+     * Also compute `page.totalSize`. Off by default because it scans the whole
+     * filtered set — the unbounded read pagination exists to remove.
+     */
+    count?: boolean;
+}
+
+/** A list response: the rows under their collection key, plus the page block. */
+type PagedResponse<K extends string, T> = { [P in K]: T[] } & { page: PageMeta };
+
+/**
+ * Copies the pagination parameters a caller supplied into a query object,
+ * leaving absent ones absent so the server applies its own defaults.
+ */
+export function addPageParams(query: Record<string, unknown>, options?: PageOptions): void {
+    if (options?.limit !== undefined) query.limit = options.limit;
+    if (options?.cursor !== undefined) query.cursor = options.cursor;
+    if (options?.count !== undefined) query.count = options.count;
+}
+
+/**
+ * Yields every page of a listing, following `page.nextCursor` to exhaustion.
+ *
+ * `fetchPage` receives the cursor to resume from — `undefined` on the first
+ * call — and must pass it through to the underlying request unchanged.
+ */
+export async function* walkPages<K extends string, T>(
+    fetchPage: (cursor: string | undefined) => Promise<PagedResponse<K, T>>,
+    collection: K,
+): AsyncGenerator<PagedResponse<K, T>, void, undefined> {
+    let cursor: string | undefined;
+    const seen = new Set<string>();
+
+    for (;;) {
+        const response = await fetchPage(cursor);
+        // An empty body (a `204`, or a proxy that drops one) carries no rows and
+        // no cursor, so it ends the walk rather than being yielded as a page.
+        if (response === null || response === undefined) return;
+        yield response;
+
+        // Terminate on the token, never on a short page: a page bounded in the
+        // database and then filtered for visibility (`/scopes`, `/keys`) can
+        // return fewer rows than `limit` while more pages remain.
+        const next = response.page?.nextCursor;
+        if (next === undefined || next === null || next === "") return;
+
+        // A cursor that repeats means the server is not advancing, and following
+        // it would spin forever. Fail loudly rather than hang or truncate.
+        if (seen.has(next)) {
+            throw new Error(
+                `Spectron returned a repeated pagination cursor while walking \`${collection}\`; the page walk cannot advance.`,
+            );
+        }
+        seen.add(next);
+        cursor = next;
+    }
+}
+
+/**
+ * Follows a listing's cursors to exhaustion and returns every row.
+ *
+ * This is what the `spectron` CLI does for verbs that print a whole set, and
+ * what a caller wants when the collection is a tree or a filter source rather
+ * than a screenful. Without `max` it is an unbounded read by construction:
+ * prefer the page-at-a-time `list` for anything user-facing and large.
+ *
+ * `max` stops the walk once that many rows are in hand, so a caller that only
+ * ever renders the first N does not pay for the pages beyond them. The result
+ * can still overshoot `max` by up to one page, because pages arrive whole.
+ */
+export async function collectPages<K extends string, T>(
+    fetchPage: (cursor: string | undefined) => Promise<PagedResponse<K, T>>,
+    collection: K,
+    max?: number,
+): Promise<T[]> {
+    const rows: T[] = [];
+    for await (const page of walkPages(fetchPage, collection)) {
+        const items = page[collection] as T[] | undefined;
+        if (items) rows.push(...items);
+        if (max !== undefined && rows.length >= max) break;
+    }
+    return rows;
+}

--- a/packages/spectron/src/pagination.ts
+++ b/packages/spectron/src/pagination.ts
@@ -9,7 +9,7 @@ import type { components } from "./types/generated.js";
  */
 export type PageMeta = components["schemas"]["PageMeta"];
 
-/** The three pagination parameters every list surface accepts. */
+/** The three pagination parameters a countable list surface accepts. */
 export interface PageOptions {
     /**
      * Page size. Omitted means the server default (100); a value above the cap
@@ -25,6 +25,15 @@ export interface PageOptions {
      */
     count?: boolean;
 }
+
+/**
+ * Pagination for a listing that offers no total.
+ *
+ * `/audit` and `/scopes` take `limit` and `cursor` only. Neither accepts
+ * `count`, so their `page.totalSize` is always absent and offering the option
+ * would only send a parameter the endpoint does not take.
+ */
+export type CursorOptions = Omit<PageOptions, "count">;
 
 /** A list response: the rows under their collection key, plus the page block. */
 type PagedResponse<K extends string, T> = { [P in K]: T[] } & { page: PageMeta };

--- a/packages/spectron/src/types/generated.ts
+++ b/packages/spectron/src/types/generated.ts
@@ -20,6 +20,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/{context_id}/actions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List live actions (dated events), newest first by write time. `since`/`until` bound the event time. Paginated: follow `page.nextCursor`. Ordered on write time rather than event time because event time is revisable, and a revision under an event-time ordering would move a row across page boundaries mid-walk. */
+        get: operations["list_actions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/{context_id}/attributes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List live attributes, newest first. Live means not superseded and inside its validity window; superseded values are reachable through the entity history endpoint. Paginated: follow `page.nextCursor`. */
+        get: operations["list_attributes"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/{context_id}/audit": {
         parameters: {
             query?: never;
@@ -46,7 +80,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Phase 7.5 — Spectron-as-agent chat endpoint. Stores the user message via /facts, retrieves context via the unified /query router, calls the configured LLM provider, stores the assistant response via /facts, and emits a response_trace. Set `stream=true` for SSE. */
+        /** @description Phase 7.5 — Spectron-as-agent chat endpoint. Resolves the session, retrieves context via the unified /query router, and calls the configured LLM provider; then, only after a successful synthesis (or a tier-2 cache hit), stores the user message and the assistant response via /facts and emits a response_trace. A failed synthesis writes no turn, fact, or response_trace (a retrieval_trace recording the query may still be written). Set `stream=true` for SSE. */
         post: operations["chat"];
         delete?: never;
         options?: never;
@@ -63,7 +97,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Phase 11b: pool recent facts and consolidate into observations */
+        /** @description Phase 11b: pool recent facts and consolidate into observations. Scope-gated: only facts in the caller's `memory:read` region are pooled, and only groups in the caller's `memory:write` region are persisted (others are returned as dry-run previews). */
         post: operations["consolidate"];
         delete?: never;
         options?: never;
@@ -285,7 +319,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description List entities (optionally filtered by type), ordered by type then name. Unpaginated by default; pass `limit` (capped at 500) and `offset` to page. */
+        /** @description List entities (optionally filtered by type), ordered by type then name. Paginated: `limit` defaults to 100 and is capped at 500; follow `page.nextCursor` to walk the Context. */
         get: operations["list_entities"];
         put?: never;
         post?: never;
@@ -422,7 +456,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description List the caller's own data-plane keys (id, name, timestamps, attenuating grants). Never returns the secret. Gated by the Context's `allow_self_service_keys` flag. */
+        /** @description List the key the caller authenticated with (id, name, timestamps, attenuating grants); a context administrator (`grant:manage` over `/`) lists every key in the Context. Never returns the secret. Gated by the Context's `allow_self_service_keys` flag. Paginated: follow `page.nextCursor`. */
         get: operations["list_self_keys"];
         put?: never;
         /** @description Mint a new data-plane API key bound to the caller's own principal. The optional `grants` body only attenuates (never widens) the caller's effective grants. Gated by the Context's `allow_self_service_keys` flag; rejects legacy / delegated callers. */
@@ -443,7 +477,7 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** @description Delete one of the caller's own keys by name. A name that does not belong to the caller surfaces as 404 (no cross-principal leakage). Gated by `allow_self_service_keys`; rejects legacy / delegated callers. */
+        /** @description Delete the caller's own key by name (or, for a context administrator holding `grant:manage` over `/`, any key). A key that is not the caller's own and that it may not manage surfaces as 404 (no cross-key leakage). Gated by `allow_self_service_keys`; rejects legacy / delegated callers. */
         delete: operations["delete_self_key"];
         options?: never;
         head?: never;
@@ -459,7 +493,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Rotate the secret on one of the caller's own keys. The id stays stable (preserving the principal binding and attenuating grants); the previous secret stops validating immediately. `ttlSeconds` is reset-or-inherit, matching the management rotate path. */
+        /** @description Rotate the secret on the caller's own key (or, for a context administrator holding `grant:manage` over `/`, any key). The id stays stable (preserving the principal binding and attenuating grants); the previous secret stops validating immediately. A key the caller may not manage surfaces as 404. `ttlSeconds` is reset-or-inherit, matching the management rotate path. */
         post: operations["rotate_self_key"];
         delete?: never;
         options?: never;
@@ -525,7 +559,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description List the Context's principals (requires the `grant:manage` grant) */
+        /** @description List the Context's principals (requires the `grant:manage` grant). Paginated: follow `page.nextCursor`. */
         get: operations["list_principals"];
         put?: never;
         post?: never;
@@ -638,6 +672,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/{context_id}/relations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List live relation edges, newest first. Paginated: follow `page.nextCursor`. */
+        get: operations["list_relations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/{context_id}/scope-grants": {
         parameters: {
             query?: never;
@@ -662,12 +713,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description List the Context's registered scope nodes (live and tombstoned). Only nodes the caller has a grant over are returned (`scope:read`, or any other verb in the region); a `grant:manage` holder over `/` sees the whole tree. */
+        /** @description List the Context's registered scope nodes (live and tombstoned). Only nodes the caller has a grant over are returned (`scope:read`, or any other verb in the region); a `grant:manage` holder over `/` sees the whole tree. Paginated: follow `page.nextCursor`. Visibility filtering happens after the page bound, so a page can be short while `page.hasMore` is still true. */
         get: operations["list_scopes"];
         put?: never;
         /** @description Register a scope node (auto-vivifies missing ancestors; enforces scope:create, depth, node-budget, and per-node policy). */
         post: operations["register_scope"];
-        /** @description Tombstone a scope node (soft-delete: sets tombstoned_at = time::now()) */
+        /** @description Tombstone a scope node (soft-delete: sets tombstoned_at = time::now()). The root scope `/` is reserved and cannot be tombstoned. */
         delete: operations["delete_scope"];
         options?: never;
         head?: never;
@@ -749,7 +800,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description List turns in a session, oldest first. Paginated: `limit` defaults to 100 and is capped at 500; use `offset` to page. */
+        /** @description List turns in a session, oldest first. Paginated: `limit` defaults to 100 and is capped at 500; follow `page.nextCursor` to walk the session. */
         get: operations["list_turns"];
         put?: never;
         post?: never;
@@ -766,7 +817,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Get the full structured memory state grouped by category */
+        /** @description Get the structured memory state grouped by category. This is a composite read over six tables, each bounded by `limit` (default 100, max 500); `truncated` reports which tables had more rows. It is a snapshot, not an export: to enumerate a table completely, walk `/entities`, `/attributes`, `/relations`, or `/actions` instead. */
         get: operations["get_state"];
         put?: never;
         post?: never;
@@ -831,12 +882,62 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        ActionDetailJson: {
+            /** @description Navigable ref of the acting entity, `entity:<type>/<name>`. */
+            actor: string;
+            /** Format: double */
+            confidence: number;
+            createdAt: string;
+            id: string;
+            memoryCategory: components["schemas"]["MemoryCategory"];
+            /**
+             * @description Navigable ref (`entity:<type>/<name>`) of the acted-on entity, when
+             *     the object resolved to a graph entity.
+             */
+            object?: string | null;
+            /**
+             * @description The acted-on thing's verbatim name, when it did not resolve to an
+             *     entity. At most one of `object` / `objectText` is set.
+             */
+            objectText?: string | null;
+            /**
+             * @description Event time, distinct from assertion validity and learn time. Absent
+             *     when the source stated no resolvable time.
+             */
+            occurredAt?: string | null;
+            source?: null | components["schemas"]["SourceRefJson"];
+            summary: string;
+            validFrom?: string | null;
+            validUntil?: string | null;
+            verb: string;
+        };
+        ActionListResponseJson: {
+            actions: components["schemas"]["ActionDetailJson"][];
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
+        };
+        ActionSummaryJson: {
+            actor: string;
+            memoryCategory: components["schemas"]["MemoryCategory"];
+            /**
+             * @description The acted-on thing as the extraction named it, whether or not it
+             *     resolved to a graph entity.
+             */
+            object?: string | null;
+            occurredAt?: string | null;
+            summary: string;
+            verb: string;
+        };
         /** @description Unified error response type for all REST endpoints. */
         ApiErrorResponse: {
             message: string;
         };
         AttributeDetailJson: {
             createdAt: string;
+            /**
+             * @description Navigable ref of the owning entity, `entity:<type>/<name>` — resolvable
+             *     via `GET /entities/{type}/{name}` or the `inspect` ref grammar.
+             */
             entity: string;
             id: string;
             /** Format: double */
@@ -850,6 +951,11 @@ export interface components {
             validUntil?: string | null;
             value: string;
         };
+        AttributeListResponseJson: {
+            attributes: components["schemas"]["AttributeDetailJson"][];
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
+        };
         AttributeSummaryJson: {
             entityId: string;
             id: string;
@@ -858,6 +964,8 @@ export interface components {
             value: string;
         };
         AuditResponseJson: {
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
             rows: components["schemas"]["AuditRowJson"][];
         };
         AuditRowJson: {
@@ -880,12 +988,31 @@ export interface components {
         BatchExtractionMode: "per_message" | "whole_conversation";
         /** @description One message in a `/facts/batch` payload. */
         BatchMessage: {
+            /**
+             * @description Who this message is addressed to, as entity-surface names, when the
+             *     caller knows. Grounds the second person at extraction: one addressee
+             *     resolves "you"/"your" (and the ownership of reacted-to events), several
+             *     ground only "we"/"us". Empty keeps extraction byte-identical to the
+             *     addressee-less form. Declared by the caller, never inferred. Only the
+             *     `per_message` extraction mode reads this; `whole_conversation` runs one
+             *     extraction over the transcript, where per-message addressees vary line
+             *     by line, so it ignores the field. Names are Unicode-normalized (NFC)
+             *     on receipt. When consumed, each name must be name-like: at most 8
+             *     names of at most 128 characters and 8 words each, letters/digits in
+             *     any script (with the combining marks scripts build names from) plus
+             *     spaces and ' - . _, at least one alphanumeric
+             *     character, and never the reserved alias `self`; requests outside
+             *     these rules are rejected. Modes that ignore the field do not check
+             *     it.
+             */
+            addressees?: string[];
             content: string;
             role: components["schemas"]["TurnRole"];
             /** Format: date-time */
             ts?: string | null;
         };
         CategoryStateJson: {
+            actions: components["schemas"]["ActionDetailJson"][];
             attributes: components["schemas"]["AttributeDetailJson"][];
             entities: components["schemas"]["EntityDetailJson"][];
             relations: components["schemas"]["RelationDetailJson"][];
@@ -907,8 +1034,17 @@ export interface components {
             scopes?: components["schemas"]["ScopeSets"];
             sessionId?: string | null;
             stream?: boolean;
+            /**
+             * @description When `true`, the reply text carries no inline citation marker in
+             *     either form (`[S1]` or bare `S1`); `citations` still names every
+             *     source the reply cited before the markers were removed. Defaults to
+             *     `false`.
+             */
+            suppressMarkers?: boolean;
         };
         ChatResponseJson: {
+            /** @description Sources the reply cited, one per `[S1]`-style marker. */
+            citations: components["schemas"]["CitationJson"][];
             memoryUpdates: components["schemas"]["ExtractionResultJson"];
             reply: string;
             sessionId: string;
@@ -930,18 +1066,45 @@ export interface components {
         };
         ChunkPageJson: {
             chunks: components["schemas"]["ChunkJson"][];
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
+        };
+        /**
+         * @description A source the reply cited, resolving an inline `[S1]` marker to the
+         *     underlying row plus a human-friendly locator (document title + approximate
+         *     percentage through the document, when it's a document passage).
+         */
+        CitationJson: {
+            documentTitle?: string | null;
+            id: string;
+            kind: string;
+            marker: string;
+            occurredAt?: string | null;
             /** Format: int32 */
-            page: number;
-            /** Format: int32 */
-            pageSize: number;
-            /** Format: int64 */
-            total: number;
+            positionPercent?: number | null;
+            /**
+             * @description Conversational role of a cited conversational row (`user` / `assistant` /
+             *     `system` / `tool`), so callers can tell a cited assistant reply (derived
+             *     text) from a user-asserted turn. Carried by `memory_chunk` and `turn`
+             *     citations; absent for non-conversational rows and legacy rows with no
+             *     recorded role.
+             */
+            role?: string | null;
+            /** Format: float */
+            score: number;
+            snippet: string;
         };
         ConsolidateOutcomeJson: {
             entityName: string;
             key: string;
             kind: components["schemas"]["DecisionKind"];
             observationId?: string | null;
+            /**
+             * @description `false` marks a preview that was not committed: a dry-run request, or a
+             *     scope group the caller can read but not write. Committed observations are
+             *     `true`.
+             */
+            persisted: boolean;
             /** Format: int32 */
             proofCount: number;
             rationale?: string | null;
@@ -1051,6 +1214,12 @@ export interface components {
             error?: string | null;
             id: string;
             mimeType: string;
+            /**
+             * Format: date-time
+             * @description Known/observed time of the content (explicit or front-matter-detected at
+             *     upload); facts extracted from the document carry it as their known-time.
+             */
+            observedAt?: string | null;
             /** Format: date-time */
             processingCompletedAt?: string | null;
             /** Format: date-time */
@@ -1077,12 +1246,12 @@ export interface components {
         };
         DocumentPageJson: {
             documents: components["schemas"]["DocumentJson"][];
-            /** Format: int32 */
-            page: number;
-            /** Format: int32 */
-            pageSize: number;
-            /** Format: int64 */
-            total: number;
+            /**
+             * @description Where this page sits in the walk. Follow `nextCursor` for the next.
+             *     `totalSize` is present only when the request passed `count=true`, which
+             *     scans the whole filtered set.
+             */
+            page: components["schemas"]["PageMeta"];
         };
         /**
          * @description Lifecycle state of a [`Document`] in the ingestion pipeline.
@@ -1168,6 +1337,8 @@ export interface components {
         };
         EntityListResponseJson: {
             entities: components["schemas"]["EntityDetailJson"][];
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
         };
         EntityResponseJson: {
             attributes: components["schemas"]["AttributeDetailJson"][];
@@ -1182,6 +1353,7 @@ export interface components {
             name: string;
         };
         ExtractionResultJson: {
+            actions: components["schemas"]["ActionSummaryJson"][];
             attributes: components["schemas"]["AttributeSummaryJson"][];
             corrections: components["schemas"]["CorrectionSummaryJson"][];
             entities: components["schemas"]["EntitySummaryJson"][];
@@ -1192,6 +1364,15 @@ export interface components {
         };
         /** @description Request body for `POST /api/v1/{ctx}/facts/batch`. */
         FactsBatchRequest: {
+            /**
+             * @description Bulk extraction strategy. `per_message` runs one extraction per
+             *     message, role-gating the caller's first person and reading each
+             *     message's `addressees`. `whole_conversation` (default) runs one
+             *     extraction over the full transcript, ignores per-message addressees,
+             *     and binds the caller's first person only when every message is
+             *     user-role - a single grounding line cannot be true for a transcript
+             *     with lines the caller did not speak.
+             */
             extract?: components["schemas"]["BatchExtractionMode"];
             infer?: components["schemas"]["InferMode"];
             /**
@@ -1211,6 +1392,21 @@ export interface components {
         };
         /** @description Request body for `POST /api/v1/{ctx}/facts`. */
         FactsRequest: {
+            /**
+             * @description Who the turn is addressed to, as entity-surface names, when the
+             *     caller knows. Grounds the second person at extraction: one addressee
+             *     resolves "you"/"your" (and the ownership of reacted-to events), several
+             *     ground only "we"/"us". Empty keeps extraction byte-identical to the
+             *     addressee-less form. Declared by the caller, never inferred. Names are
+             *     Unicode-normalized (NFC) on receipt. When consumed (the `full` and
+             *     `preview` infer modes; `none` and `triples` ignore the field), each
+             *     name must be name-like: at most 8 names of at most 128 characters and
+             *     8 words each, letters/digits in any script (with the combining marks
+             *     scripts build names from) plus spaces and ' - . _, at least one
+             *     alphanumeric character, and never the reserved alias
+             *     `self`; requests outside these rules are rejected.
+             */
+            addressees?: string[];
             /** @description Inference mode (`full` is the default). */
             infer?: components["schemas"]["InferMode"];
             /**
@@ -1427,6 +1623,17 @@ export interface components {
              */
             validUntil?: string | null;
         };
+        /**
+         * @description The `GET /{ctx}/keys` response.
+         *
+         *     An envelope rather than a bare array: a top-level JSON array has nowhere to
+         *     carry the pagination block, and every list surface returns the same shape.
+         */
+        KeyListResponseJson: {
+            keys: components["schemas"]["KeyDetailJson"][];
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
+        };
         KeywordDetailJson: {
             /** Format: int64 */
             documentCount: number;
@@ -1450,12 +1657,8 @@ export interface components {
         };
         KeywordPageJson: {
             keywords: components["schemas"]["KeywordJson"][];
-            /** Format: int32 */
-            page: number;
-            /** Format: int32 */
-            pageSize: number;
-            /** Format: int64 */
-            total: number;
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
         };
         KeywordSearchHitJson: {
             /** Format: int64 */
@@ -1493,7 +1696,21 @@ export interface components {
          */
         MemoryCategory: "identity" | "knowledge" | "context";
         MemoryHitJson: {
+            /**
+             * @description Day-precise relative-date notes stored beside a memory chunk at write
+             *     time ("last friday = Friday 2023-05-19"): deterministic resolutions of
+             *     the chunk text's own relative expressions against its source timestamp.
+             *     Absent for non-chunk rows and text with no day-precise mentions.
+             */
+            dateNotes?: string | null;
             id: string;
+            /**
+             * @description Known-time the hit's fact/turn carries (ISO string), so a caller can date
+             *     the evidence and resolve relative time in the source text. Absent when the
+             *     row carries no resolvable date.
+             */
+            occurredAt?: string | null;
+            resource?: null | components["schemas"]["ResourceRef"];
             /** Format: float */
             score: number;
             source: components["schemas"]["ResultKind"];
@@ -1544,6 +1761,19 @@ export interface components {
              */
             validUntil?: string | null;
         };
+        /** @description The pagination block returned beside a page's rows. */
+        PageMeta: {
+            /** @description Whether a further page exists. */
+            hasMore: boolean;
+            /** @description Token for the next page; absent on the last page. */
+            nextCursor?: string | null;
+            /**
+             * Format: int64
+             * @description Total rows matching the filters, present only when the request asked for
+             *     it with `count=true`.
+             */
+            totalSize?: number | null;
+        };
         /** @description A principal in the `GET /{ctx}/principals` / `…/{id}` responses. */
         PrincipalJson: {
             /** @description Human-readable display name. */
@@ -1555,7 +1785,20 @@ export interface components {
             /** @description Identity kind: `human` / `agent` / `service` / `unknown`. */
             kind: string;
         };
+        /**
+         * @description The `GET /{ctx}/principals` response.
+         *
+         *     An envelope rather than a bare array: a top-level JSON array has nowhere to
+         *     carry the pagination block, and every list surface returns the same shape.
+         */
+        PrincipalListResponseJson: {
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
+            principals: components["schemas"]["PrincipalJson"][];
+        };
         ProfileEntryJson: {
+            entity?: string | null;
+            entityType?: string | null;
             key: string;
             value: string;
         };
@@ -1563,6 +1806,7 @@ export interface components {
             dynamic: components["schemas"]["ProfileEntryJson"][];
             instructions: components["schemas"]["InstructionSummaryJson"][];
             preferences: components["schemas"]["ProfileEntryJson"][];
+            selfFacts: components["schemas"]["ProfileEntryJson"][];
             static: components["schemas"]["ProfileEntryJson"][];
         };
         QueryFilter: {
@@ -1619,10 +1863,10 @@ export interface components {
              */
             include?: string[] | null;
             /**
-             * @description When `false` (the default), chunks flagged as near-duplicates of an older
-             *     chunk are excluded from the fused ranker's chunk recall so the same text
-             *     does not occupy several ranks. Set `true` to include them (parity with the
-             *     documents `/query` opt-in).
+             * @description When `false` (the default), document chunks and memory turns flagged as
+             *     near-duplicates of an older row are excluded from the fused ranker's
+             *     recall so the same text does not occupy several ranks. Set `true` to
+             *     include them (parity with the documents `/query` opt-in).
              */
             includeDuplicates?: boolean | null;
             /**
@@ -1680,9 +1924,25 @@ export interface components {
              *     from the query.
              */
             classificationKind: components["schemas"]["QueryKind"];
+            /**
+             * @description Synthesis-context rows, **separate from `hits`** and **not** counted
+             *     against `k`: `hits` is the ranked answer set, these are the extra rows
+             *     the synthesis layer reads alongside it. Sources: same-section sibling
+             *     chunks from section expansion, the neighbouring conversation chunks of
+             *     ranked memory hits from turn expansion, structured attribute/relation
+             *     rows gathered by the tier-1 seed reads for direct-lookup queries, and
+             *     (opt-in) entity fact cards summarising a ranked entity's attributes and
+             *     relationships, and - when the ranked-overflow depth is configured - the
+             *     fused candidates at ranks `k+1..k+N` that the answer truncation would
+             *     otherwise discard. Each row's `source` names its family. Empty when no
+             *     expansion contributed. A UI can render them as an "expanded context"
+             *     group distinct from the ranked hits.
+             */
+            contextHits?: components["schemas"]["MemoryHitJson"][];
             hits: components["schemas"]["MemoryHitJson"][];
             /** Format: int64 */
             queryMs: number;
+            queryWindow?: null | components["schemas"]["QueryWindowJson"];
             seedEntities: string[];
             tier: components["schemas"]["Tier"];
             /** @description Phase 7 — short trace summary returned inline. */
@@ -1751,6 +2011,17 @@ export interface components {
             topScores: number[];
             traceId: string;
         };
+        /**
+         * @description Wire echo of the derived query window: RFC3339 bounds, the resolver's
+         *     precision label (`day`/`week`/`month`/`season`/`year`), and the phrase it
+         *     matched.
+         */
+        QueryWindowJson: {
+            end: string;
+            phrase: string;
+            precision: string;
+            start: string;
+        };
         /** @description Phase 6c: doc-to-doc semantic link recomputation. */
         RecomputeLinksResponse: {
             /** Format: int64 */
@@ -1791,17 +2062,75 @@ export interface components {
             id: string;
             label: string;
             memoryCategory: components["schemas"]["MemoryCategory"];
+            /** @description Navigable ref of the object entity, `entity:<type>/<name>`. */
             object: string;
             source?: null | components["schemas"]["SourceRefJson"];
+            /**
+             * @description Navigable ref of the subject entity, `entity:<type>/<name>` —
+             *     resolvable via `GET /entities/{type}/{name}` or the `inspect` ref
+             *     grammar.
+             */
             subject: string;
             validFrom?: string | null;
             validUntil?: string | null;
+        };
+        RelationListResponseJson: {
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
+            relations: components["schemas"]["RelationDetailJson"][];
         };
         RelationSummaryJson: {
             label: string;
             memoryCategory: components["schemas"]["MemoryCategory"];
             object: string;
             subject: string;
+        };
+        /**
+         * @description Typed pointer to the row behind a hit's [`ResultHit::id`], so a caller can
+         *     resolve the underlying document, entity, or session without parsing raw
+         *     record-id strings. The `kind` tag names the payload family; entity halves
+         *     carry the normalised name, which the entity read endpoints re-normalise,
+         *     so every ref resolves via the corresponding read surface.
+         */
+        ResourceRef: {
+            entityType: string;
+            /** @enum {string} */
+            kind: "entity";
+            name: string;
+        } | {
+            entityType: string;
+            key: string;
+            /** @enum {string} */
+            kind: "attribute";
+            name: string;
+        } | {
+            /** @enum {string} */
+            kind: "relation";
+            label: string;
+            objectName: string;
+            objectType: string;
+            subjectName: string;
+            subjectType: string;
+        } | {
+            actorName: string;
+            actorType: string;
+            /** @enum {string} */
+            kind: "action";
+            objectName?: string | null;
+            objectType?: string | null;
+        } | {
+            documentId: string;
+            /** @enum {string} */
+            kind: "document";
+            /** Format: int64 */
+            position?: number | null;
+        } | {
+            /** @enum {string} */
+            kind: "session";
+            /** Format: int64 */
+            position?: number | null;
+            sessionId: string;
+            turnId?: string | null;
         };
         /** @description Summary of the response trace that owns a decision trace. */
         ResponseTraceSummaryJson: {
@@ -1821,7 +2150,7 @@ export interface components {
          *     in.
          * @enum {string}
          */
-        ResultKind: "attribute" | "entity" | "chunk" | "memory_chunk" | "section";
+        ResultKind: "attribute" | "entity" | "action" | "chunk" | "memory_chunk" | "turn" | "section";
         /** @description §15 operational signal (#174): retrieval candidate-set breadth. */
         RetrievalStatsJson: {
             /** Format: double */
@@ -1886,6 +2215,24 @@ export interface components {
             /** @description Principal the grant applies to. */
             subject?: string | null;
         };
+        /**
+         * @description The `GET /{ctx}/scopes` response.
+         *
+         *     An envelope rather than a bare array: a top-level JSON array has nowhere to
+         *     carry the pagination block, and every list surface returns the same shape.
+         */
+        ScopeListResponseJson: {
+            /**
+             * @description Where this page sits in the walk. Follow `nextCursor` for the next.
+             *
+             *     `scopes` may hold fewer than `limit` entries while `hasMore` is still
+             *     true: the page is bounded in the database and then filtered for
+             *     visibility, so invisible nodes consume page budget without appearing.
+             *     Terminate a walk on `hasMore`, never on a short page.
+             */
+            page: components["schemas"]["PageMeta"];
+            scopes: components["schemas"]["ScopeNodeJson"][];
+        };
         /** @description One scope node in the `GET /{context}/scopes` response. */
         ScopeNodeJson: {
             /**
@@ -1901,9 +2248,9 @@ export interface components {
              */
             tombstonedAt?: string | null;
         };
-        /** @description A validated, canonical scope path in slash form, e.g. `org/apple/product/ipad/`. Root is `/`. */
+        /** @description A validated, canonical scope path in slash form, e.g. `org/apple/product/ipad/`. Root is `/`. A leading and a trailing `/` are both optional on input (`/org/apple`, `org/apple/` and `org/apple` all denote the same node); the canonical form returned carries the trailing `/` and no leading one. */
         ScopePath: string;
-        /** @description A scope pattern: an exact node (`org/apple/product/ipad`) or a subtree (`org/apple/*` / `/*`). */
+        /** @description A scope pattern: an exact node (`org/apple/product/ipad`) or a subtree (`org/apple/*` / `/*`). A leading `/` is optional (`/org/apple` denotes the same node as `org/apple`); patterns are returned in the canonical form, without it. */
         ScopePattern: string;
         /** @description A DNF scope selector: an OR of conjunctive clauses. Each clause is an array of scope paths, ALL of which a reader must cover (AND); the outer array is the OR. E.g. [["team/a"],["team/b","clearance/secret"]] means team/a OR (team/b AND clearance/secret). Empty means unscoped (the caller's default region). A bare string is also accepted as a singleton clause. */
         ScopeSets: string[][];
@@ -1945,7 +2292,22 @@ export interface components {
             identity: components["schemas"]["CategoryStateJson"];
             instructions: components["schemas"]["InstructionSummaryJson"][];
             knowledge: components["schemas"]["CategoryStateJson"];
+            /**
+             * @description Per-table truncation. A `true` flag means that table has more rows
+             *     than this response carries, and the complete set must be walked
+             *     through that table's own collection endpoint.
+             */
+            truncated: components["schemas"]["StateTruncationJson"];
             unknowns: components["schemas"]["UncertaintySummaryJson"][];
+        };
+        /** @description Which of the state read's underlying tables were bounded short. */
+        StateTruncationJson: {
+            actions: boolean;
+            attributes: boolean;
+            entities: boolean;
+            instructions: boolean;
+            relations: boolean;
+            unknowns: boolean;
         };
         /** @description §15 operational signal (#174): supersession churn. */
         SupersessionStatsJson: {
@@ -1962,12 +2324,12 @@ export interface components {
          *     query went all the way to tier 4.
          * @enum {string}
          */
-        Tier: "direct" | "cache" | "hybrid" | "full_context";
+        Tier: "direct" | "cache" | "hybrid" | "escalated";
         TierCountsJson: {
             /** Format: int64 */
             direct: number;
             /** Format: int64 */
-            fullContext: number;
+            escalated: number;
             /** Format: int64 */
             hybrid: number;
         };
@@ -1981,6 +2343,8 @@ export interface components {
          */
         TraceKind: "decision" | "retrieval" | "response";
         TraceListResponseJson: {
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
             traces: components["schemas"]["TraceRecordJson"][];
         };
         TraceRecordJson: {
@@ -2062,6 +2426,8 @@ export interface components {
             type: string;
         };
         TurnListResponseJson: {
+            /** @description Where this page sits in the walk. Follow `nextCursor` for the next. */
+            page: components["schemas"]["PageMeta"];
             turns: components["schemas"]["TurnResponseJson"][];
         };
         TurnResponseJson: {
@@ -2103,6 +2469,14 @@ export interface components {
              */
             observedAt?: string | null;
             /**
+             * @description Optional opt-in to detect the observed time from the document itself: the name
+             *     of a field inside a leading `---`-fenced front-matter block whose value (RFC3339
+             *     or `YYYY-MM-DD`) is read as `observedAt`. Ignored when `observedAt` is supplied
+             *     explicitly; a missing or unparseable field is non-fatal (facts date to ingest
+             *     time). The effective value is echoed in the upload response.
+             */
+            observedAtHeader?: string | null;
+            /**
              * @description Optional DNF scope selector tagging the document, e.g.
              *     `[["org/apple/product/macbook"]]` (or co-owned `["team/a","team/b"]`). Each
              *     clause's nodes must lie within the caller's `memory:write` region (a request
@@ -2118,6 +2492,15 @@ export interface components {
             contentHash: string;
             deduplicated: boolean;
             id: string;
+            /**
+             * Format: date-time
+             * @description The known/observed time stamped onto the document: the request's explicit
+             *     `observedAt` or the value detected via `observedAtHeader`. Absent when
+             *     neither applied, so facts will date to ingest time. On a dedup hit this is
+             *     the matched document's known-time, which this upload fills only when that
+             *     row has none and its first ingest has not published.
+             */
+            observedAt?: string | null;
             status: components["schemas"]["DocumentStatus"];
         };
         /** @description A grant verb in `<noun>:<verb>` form: one of `memory:read`, `memory:write`, `memory:forget`, `scope:read`, `scope:create`, `scope:delete`, `grant:manage`. */
@@ -2182,6 +2565,152 @@ export interface operations {
             };
         };
     };
+    list_actions: {
+        parameters: {
+            query?: {
+                /** @description Filter by acting entity, as `<type>/<name>` (e.g. `person/alice`) */
+                actor?: string;
+                /** @description Filter by action verb */
+                verb?: string;
+                /** @description Inclusive lower bound on occurred_at (RFC 3339) */
+                since?: string;
+                /** @description Inclusive upper bound on occurred_at (RFC 3339) */
+                until?: string;
+                /** @description Max rows to return (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the filtered set) */
+                count?: boolean;
+            };
+            header?: never;
+            path: {
+                /** @description Spectron context id */
+                context_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActionListResponseJson"];
+                };
+            };
+            /** @description Invalid pagination parameter, entity ref, or time bound */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Invalid context id */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    list_attributes: {
+        parameters: {
+            query?: {
+                /** @description Filter to one entity's attributes, as `<type>/<name>` (e.g. `person/alice`) */
+                entity?: string;
+                /** @description Filter by attribute key */
+                key?: string;
+                /** @description Max rows to return (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the filtered set) */
+                count?: boolean;
+            };
+            header?: never;
+            path: {
+                /** @description Spectron context id */
+                context_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttributeListResponseJson"];
+                };
+            };
+            /** @description Invalid pagination parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Invalid context id */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
     list_audit: {
         parameters: {
             query?: {
@@ -2195,8 +2724,10 @@ export interface operations {
                 since?: string;
                 /** @description Inclusive upper bound on created_at (RFC 3339) */
                 until?: string;
-                /** @description Max rows to return (default 50, max 500) */
+                /** @description Max rows to return (default 100, max 500) */
                 limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
             };
             header?: never;
             path: {
@@ -2236,6 +2767,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2295,6 +2837,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     consolidate: {
@@ -2333,6 +2886,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2392,6 +2956,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_documents: {
@@ -2401,9 +2976,15 @@ export interface operations {
                 status?: string;
                 /** @description Filter by mime type */
                 mimeType?: string;
-                /** @description Page number (0-indexed) */
+                /** @description Max documents to return (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the filtered set) */
+                count?: boolean;
+                /** @description Deprecated: zero-based page index. Use `cursor`. */
                 page?: number;
-                /** @description Page size, max 100 */
+                /** @description Deprecated: page size. Use `limit`. */
                 pageSize?: number;
             };
             header?: never;
@@ -2445,6 +3026,17 @@ export interface operations {
             /** @description Unexpected error */
             500: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2541,6 +3133,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_keywords: {
@@ -2552,9 +3155,15 @@ export interface operations {
                 minDocumentCount?: number;
                 /** @description Sort key */
                 sort?: string;
-                /** @description Page number (0-indexed) */
+                /** @description Max keywords to return (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor`. Only valid for the `sort` it was minted under. */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the filtered set) */
+                count?: boolean;
+                /** @description Deprecated: zero-based page index. Use `cursor`. */
                 page?: number;
-                /** @description Page size, max 100 */
+                /** @description Deprecated: page size. Use `limit`. */
                 pageSize?: number;
             };
             header?: never;
@@ -2586,6 +3195,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2645,6 +3265,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     get_keyword: {
@@ -2690,6 +3321,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2758,6 +3400,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     recompute_document_links: {
@@ -2801,6 +3454,17 @@ export interface operations {
             /** @description Unexpected error */
             500: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2862,6 +3526,17 @@ export interface operations {
             /** @description Unexpected error */
             500: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2951,6 +3626,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     delete_document: {
@@ -3010,14 +3696,31 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_chunks: {
         parameters: {
             query?: {
-                /** @description Page number (0-indexed) */
+                /** @description Max chunks to return (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the document's chunks) */
+                count?: boolean;
+                /** @description Deprecated: zero-based page index. Use `cursor`. */
                 page?: number;
-                /** @description Page size, max 100 */
+                /** @description Deprecated: page size. Use `limit`. */
                 pageSize?: number;
             };
             header?: never;
@@ -3075,6 +3778,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_document_keywords: {
@@ -3120,6 +3834,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -3185,6 +3910,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     elaborate: {
@@ -3238,6 +3974,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_entities: {
@@ -3245,9 +3992,13 @@ export interface operations {
             query?: {
                 /** @description Filter by entity type */
                 type?: string;
-                /** @description Max entities to return (default: all, capped at 500) */
+                /** @description Max entities to return (default 100, max 500) */
                 limit?: number;
-                /** @description Number of entities to skip (default 0) */
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the filtered set) */
+                count?: boolean;
+                /** @description Deprecated: rows to skip. Use `cursor`. */
                 offset?: number;
             };
             header?: never;
@@ -3267,6 +4018,15 @@ export interface operations {
                     "application/json": components["schemas"]["EntityListResponseJson"];
                 };
             };
+            /** @description Invalid pagination parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
             /** @description Unauthorized */
             401: {
                 headers: {
@@ -3279,6 +4039,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -3338,6 +4109,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     delete_entity: {
@@ -3381,6 +4163,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     get_entity_history: {
@@ -3418,9 +4211,29 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Entity not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -3489,6 +4302,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     create_facts_batch: {
@@ -3551,6 +4375,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     forget: {
@@ -3604,6 +4439,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     fsck: {
@@ -3651,6 +4497,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -3735,11 +4592,29 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_self_keys: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Max keys to return (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` */
+                count?: boolean;
+            };
             header?: never;
             path: {
                 /** @description Spectron context id */
@@ -3754,7 +4629,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KeyDetailJson"][];
+                    "application/json": components["schemas"]["KeyListResponseJson"];
+                };
+            };
+            /** @description Invalid pagination parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
             /** @description Unauthorized */
@@ -3778,6 +4662,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -3863,6 +4758,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     delete_self_key: {
@@ -3916,6 +4822,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -3990,6 +4907,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     decay_importance: {
@@ -4024,6 +4952,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4070,6 +5009,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     whoami: {
@@ -4110,11 +5060,29 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_principals: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Max principals to return (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` */
+                count?: boolean;
+            };
             header?: never;
             path: {
                 /** @description Spectron context id */
@@ -4129,7 +5097,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PrincipalJson"][];
+                    "application/json": components["schemas"]["PrincipalListResponseJson"];
+                };
+            };
+            /** @description Invalid pagination parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
             /** @description Unauthorized */
@@ -4153,6 +5130,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4213,6 +5201,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4293,6 +5292,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     grant_principal: {
@@ -4361,6 +5371,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4441,6 +5462,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     get_profile: {
@@ -4475,6 +5507,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4534,6 +5577,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     reflect: {
@@ -4587,6 +5641,90 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    list_relations: {
+        parameters: {
+            query?: {
+                /** @description Filter by subject entity, as `<type>/<name>` (e.g. `person/alice`) */
+                src?: string;
+                /** @description Filter by object entity, as `<type>/<name>` (e.g. `company/techco`) */
+                dst?: string;
+                /** @description Filter by relation label */
+                label?: string;
+                /** @description Max rows to return (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the filtered set) */
+                count?: boolean;
+            };
+            header?: never;
+            path: {
+                /** @description Spectron context id */
+                context_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RelationListResponseJson"];
+                };
+            };
+            /** @description Invalid pagination parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Invalid context id */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     scope_grants_stub: {
@@ -4632,11 +5770,27 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_scopes: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Max nodes to scan per page (default 100, max 500) */
+                limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+            };
             header?: never;
             path: {
                 /** @description Spectron context id */
@@ -4651,7 +5805,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ScopeNodeJson"][];
+                    "application/json": components["schemas"]["ScopeListResponseJson"];
+                };
+            };
+            /** @description Invalid pagination parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
             /** @description Unauthorized */
@@ -4666,6 +5829,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4725,6 +5899,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     delete_scope: {
@@ -4767,9 +5952,29 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Caller lacks the `scope:delete` grant over the region, or the target is the reserved root scope `/` */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4838,6 +6043,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     create_session: {
@@ -4876,6 +6092,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4926,6 +6153,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -4987,6 +6225,17 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_turns: {
@@ -4994,7 +6243,11 @@ export interface operations {
             query?: {
                 /** @description Max turns to return (default 100, max 500) */
                 limit?: number;
-                /** @description Number of turns to skip (default 0) */
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the session's turns) */
+                count?: boolean;
+                /** @description Deprecated: rows to skip. Use `cursor`. */
                 offset?: number;
             };
             header?: never;
@@ -5014,6 +6267,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TurnListResponseJson"];
+                };
+            };
+            /** @description Invalid pagination parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
             /** @description Unauthorized */
@@ -5043,11 +6305,25 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     get_state: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Max rows per table (default 100, max 500) */
+                limit?: number;
+            };
             header?: never;
             path: {
                 /** @description Spectron context id */
@@ -5083,13 +6359,28 @@ export interface operations {
                     "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_traces: {
         parameters: {
             query?: {
-                /** @description Max traces to return (default 50, max 500) */
+                /** @description Max traces to return (default 100, max 500) */
                 limit?: number;
+                /** @description Continuation token from the previous page's `page.nextCursor` */
+                cursor?: string;
+                /** @description Also return `page.totalSize` (costs a full count of the visible traces) */
+                count?: boolean;
             };
             header?: never;
             path: {
@@ -5120,6 +6411,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -5160,6 +6462,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -5211,6 +6524,17 @@ export interface operations {
             /** @description Invalid context id */
             422: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server too busy: the per-pod in-flight request cap was exceeded. Retry per the `Retry-After` header. */
+            503: {
+                headers: {
+                    /** @description Seconds to wait before retrying. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {

--- a/packages/tests/spectron/unit/keys.test.ts
+++ b/packages/tests/spectron/unit/keys.test.ts
@@ -54,16 +54,56 @@ describe("client.keys", () => {
         expect(init?.body).toBeUndefined();
     });
 
-    test("list GETs /keys and defaults to an empty array", async () => {
+    test("list GETs /keys and forwards the pagination parameters", async () => {
         let url = "";
         const fetchImpl = mock((u: string | URL) => {
             url = String(u);
-            return Promise.resolve(new Response("", { status: 204 }));
+            return Promise.resolve(
+                new Response(JSON.stringify({ keys: [], page: { hasMore: false } }), {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                }),
+            );
         });
         const s = client(fetchImpl);
-        const keys = await s.keys.list();
-        expect(keys).toEqual([]);
-        expect(url.endsWith("/api/v1/ctx-1/keys")).toBe(true);
+        const page = await s.keys.list({ limit: 25, count: true });
+        expect(page.keys).toEqual([]);
+        expect(page.page.hasMore).toBe(false);
+        expect(url).toContain("/api/v1/ctx-1/keys");
+        expect(url).toContain("limit=25");
+        expect(url).toContain("count=true");
+    });
+
+    test("listAll follows nextCursor to exhaustion", async () => {
+        const urls: string[] = [];
+        const pages = [
+            {
+                keys: [{ id: "a", name: "a", createdAt: "t" }],
+                page: { hasMore: true, nextCursor: "c1" },
+            },
+            { keys: [{ id: "b", name: "b", createdAt: "t" }], page: { hasMore: false } },
+        ];
+        const fetchImpl = mock((u: string | URL) => {
+            urls.push(String(u));
+            return Promise.resolve(
+                new Response(JSON.stringify(pages[urls.length - 1]), {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                }),
+            );
+        });
+        const s = client(fetchImpl);
+        const keys = await s.keys.listAll();
+        expect(keys.map((k) => k.id)).toEqual(["a", "b"]);
+        expect(urls).toHaveLength(2);
+        expect(urls[0]).not.toContain("cursor=");
+        expect(urls[1]).toContain("cursor=c1");
+    });
+
+    test("listAll degrades to an empty array on an empty body", async () => {
+        const fetchImpl = mock(() => Promise.resolve(new Response("", { status: 204 })));
+        const s = client(fetchImpl);
+        expect(await s.keys.listAll()).toEqual([]);
     });
 
     test("delete DELETEs /keys/{name} (path-encoded)", async () => {


### PR DESCRIPTION
## What is the motivation?

Spectron [paginated every list surface with keyset cursors](https://github.com/surrealdb/spectron/pull/938). This package's vendored OpenAPI copy (`packages/spectron/spec/openapi.json`) is a hand-maintained snapshot of `spectron/doc/spec/enduser.swagger.json` with nothing automating the copy, and it was **two commits behind** — so the generated types kept compiling happily against a contract the server had already moved off.

That drift is the dangerous part: the change is additive on the request side (no parameters were removed), so nothing errors when you send an old-style request. The breaks are all in the **response** shapes, which means silent truncation and `undefined` reads rather than failures.

Syncing the spec surfaces three of them:

| Spec change | What it broke here |
| --- | --- |
| `/keys`, `/principals`, `/scopes` went from a bare JSON array to an envelope — a top-level array has nowhere to carry a pagination block | `keys.list()`, `principals.list()` and `scopes.list()` cast the body straight to an array. Callers got an object typed as an array, and `.map()` threw |
| `DocumentPageJson` / `ChunkPageJson` / `KeywordPageJson` repurposed `page` from an offset index to a metadata block, dropping `total` and `pageSize` | `page` silently changed type from `number` to an object; anything computing a page count from `total` read `undefined` |
| Every listing is now bounded (100 default, 500 max), and `/state` became a bounded composite read reporting per-table truncation | Lists silently stop at 100 rows. `/state` is no longer an export |

It also picks up the rename of `tierCounts.fullContext` to `escalated`, which landed in spectron before the pagination work — studio has been carrying a dual-spelling workaround for exactly that drift.

## What does this change do?

**A shared pagination surface** in the new `src/pagination.ts`: `PageMeta`, `PageOptions`, `walkPages`, `collectPages`, `addPageParams`, all exported for wrapping other paginated surfaces.

**Each `list` returns the wire envelope** rather than unwrapping it, so a caller can see where it is in the walk. Each gains a `listAll` that follows cursors to exhaustion — `Session.turns` pairs with `allTurns`, `client.audit` with `auditAll`. `documents.count()` and `entities.count()` read `page.totalSize` from a single one-row `count: true` request, for callers that only ever wanted the figure.

Two correctness details worth reviewer attention:

- **The walk terminates on `nextCursor`, never on a short page.** `/scopes` and `/keys` bound the page in the database and *then* filter for visibility, so a short page mid-walk is normal and stopping there silently truncates. This is the easiest thing to get wrong about this contract.
- **A repeated cursor throws** rather than spinning forever, and an empty body (a `204`, or a proxy that drops one) ends the walk rather than being yielded as a page — preserving the `?? []` robustness the old `keys.list()` had.

**`documents.allChunks` takes a `max`**, so a caller rendering a fixed prefix doesn't pay a page fetch per hundred rows beyond it.

**The deprecated offset parameters stay available** on the three endpoints that still accept them (`/documents`, `/documents/{id}/chunks`, `/documents/keywords`), for callers with numbered page controls that need a page index and a total keyset cursors deliberately don't provide. They live in a separate `OffsetPageOptions` type from `cursor`, kept apart deliberately: the server rejects the two sent together with a `400`.

Version bumped to `1.0.0-alpha.8`. The README gains a Pagination section documenting the contract and the walk.

## What is your testing strategy?

`bun run qts` is at the baseline 16 errors (all pre-existing: unbuilt `wasm`/`node` native packages, plus 3 older type errors in `wasm`/`sqon`), with **zero** in `spectron`. `bun test unit` in `packages/tests/spectron` is 46 pass / 0 fail. `bun run build:spectron` succeeds. Biome clean.

`packages/tests/spectron/unit/keys.test.ts` is updated for the new contract — the old test asserted `keys.list()` returned `[]`, which no longer describes the API. It now covers three things: that `list` forwards `limit`/`count`, that `listAll` follows `nextCursor` across pages and sends no cursor on the first request, and that an empty body degrades to `[]`.

The primitives were also exercised against a stub server that reproduces the awkward parts of the real contract:

| Scenario | Result |
| --- | --- |
| 250 rows, 100/page, **every page deliberately 3 rows short** | 241 rows, all ids distinct, 3 requests. A stop-on-short-page walk returns 97 |
| `count()` over 4312 rows | `4312` in exactly 1 request |
| Server returns the same cursor forever | Throws, does not hang |
| Empty `204` body | `[]` |
| `max: 2000` over 10k rows at 500/page | 2000 rows in 4 requests, not 20 |

To reproduce the spec sync: copy `spectron/doc/spec/enduser.swagger.json` over `packages/spectron/spec/openapi.json`, reformat with the **repo-pinned** biome (`./node_modules/.bin/biome format --write` — `bunx biome` silently no-ops on this file, which is why the committed copy is 4-space biome-formatted), then `bun run generate && bun run build` in `packages/spectron`.

## Is this related to any issues?

Downstream of spectron#938. **surrealdb/studio#211 is blocked on this** — it consumes `listAll`, `count`, `allChunks` and `state({ limit })`, so its `bun install` fails until `1.0.0-alpha.8` is on npm. Merge order: this PR → publish `1.0.0-alpha.8` → `bun install` in studio → commit that lockfile → studio#211 goes green.

Two things deliberately **out of scope**:

- The same spectron commit added `/actions`, `/attributes` and `/relations` — the documented way to enumerate what `/state` now truncates. Their types come in with the regeneration and are reachable via `components[...]`, but no component wrappers were added: that's new surface rather than something pagination broke.
- The management spec (`spectron/doc/spec/management.swagger.json`) isn't vendored here and took the same envelope change. Consumers reach it through the Fabric proxy, so that needs a Fabric-side change.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
