### PR TITLE
Release Agent Memory 1.0.0 alpha 9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/memory": {
       "name": "@surrealdb/memory",
-      "version": "1.0.0-alpha.8",
+      "version": "1.0.0-alpha.9",
       "devDependencies": {
         "@types/bun": "^1.2.21",
         "openapi-typescript": "^7.10.0",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@surrealdb/memory",
-    "version": "1.0.0-alpha.8",
+    "version": "1.0.0-alpha.9",
     "type": "module",
     "license": "Apache-2.0",
     "description": "The official Agent Memory client for JavaScript.",


### PR DESCRIPTION
Bumps `@surrealdb/memory` from `1.0.0-alpha.8` to `1.0.0-alpha.9`.

This is the first release under the `@surrealdb/memory` name, following the rename from `@surrealdb/spectron` in #666. Version `1.0.0-alpha.8` was published under the old package name, so `@surrealdb/memory` starts at `alpha.9` to keep the version line continuous.

Ships the following unreleased changes:

- The `@surrealdb/spectron` → `@surrealdb/memory` rename, including the renamed `dist/memory.*` entrypoints and updated exports map (#666)