### PR TITLE
Read the chat stream's own frames

### DIFF
--- a/packages/memory/src/client.ts
+++ b/packages/memory/src/client.ts
@@ -55,6 +55,14 @@ export interface AgentMemoryOptions {
     /** API endpoint origin without trailing slash. */
     endpoint: string;
     /** Request timeout in milliseconds. Defaults to `30_000`. */
+    timeoutMs?: number;
+    /**
+     * Request timeout in milliseconds.
+     *
+     * @deprecated Use `timeoutMs`, which is what {@link Transport} has always
+     * called it. Kept so existing callers keep working; ignored when both are
+     * given.
+     */
     timeout?: number;
     /** Maximum retry attempts for idempotent requests. Defaults to `3`. */
     maxRetries?: number;
@@ -136,6 +144,15 @@ export interface ChatOptions {
     bypassCache?: boolean;
     /** Descriptive `key=value` labels for rows the chat persists. */
     labels?: string[];
+    /**
+     * Strip inline citation markers from the reply text.
+     *
+     * With markers left in, the reply carries `[S1]`-style labels that resolve
+     * against `citations`; a caller that does not render them shows them as
+     * prose. Suppressing them leaves `citations` intact, so the sources are
+     * still available to a caller that wants to list rather than inline them.
+     */
+    suppressMarkers?: boolean;
 }
 
 /**
@@ -206,7 +223,7 @@ export class AgentMemory {
         this.transport = new Transport({
             apiKey: options.apiKey,
             endpoint: options.endpoint,
-            timeoutMs: options.timeout,
+            timeoutMs: options.timeoutMs ?? options.timeout,
             maxRetries: options.maxRetries,
             fetchImpl: options.fetchImpl,
         });
@@ -324,6 +341,9 @@ export class AgentMemory {
         addDefined(payload, "location", options?.location);
         const body = await this.transport.requestJson("POST", `${this.base}/query`, {
             body: payload,
+            // A read behind a POST, because the query travels in the body. Safe
+            // to replay, so it takes the retry budget every other read gets.
+            idempotent: true,
         });
         return body as QueryMemoryResponseJson;
     }
@@ -360,6 +380,7 @@ export class AgentMemory {
         addDefined(payload, "model", options?.model);
         if (options?.bypassCache) payload.bypassCache = true;
         addDefined(payload, "labels", options?.labels);
+        if (options?.suppressMarkers) payload.suppressMarkers = true;
 
         if (options?.stream) {
             payload.stream = true;
@@ -391,6 +412,7 @@ export class AgentMemory {
         addDefined(payload, "scopeView", options?.scopeView);
         const body = await this.transport.requestJson("POST", `${this.base}/context`, {
             body: payload,
+            idempotent: true,
         });
         return body as ContextQueryResponseJson;
     }

--- a/packages/memory/src/components/documents.ts
+++ b/packages/memory/src/components/documents.ts
@@ -222,6 +222,9 @@ export class DocumentKeywords {
         if (lens) payload.lens = lens;
         const body = await this.transport.requestJson("POST", `${this.base}/search`, {
             body: payload,
+            // A read behind a POST, because the query travels in the body. Safe
+            // to replay, so it takes the retry budget every other read gets.
+            idempotent: true,
         });
         return body as KeywordSearchResponseJson;
     }
@@ -385,6 +388,8 @@ export class Documents {
         if (scopeSets) payload.lens = scopeSets;
         const body = await this.transport.requestJson("POST", `${this.base}/query`, {
             body: payload,
+            // A read behind a POST; safe to replay.
+            idempotent: true,
         });
         return body as QueryResponseJson;
     }

--- a/packages/memory/src/components/sessions.ts
+++ b/packages/memory/src/components/sessions.ts
@@ -62,6 +62,8 @@ export class Session {
     async context(options: { query: string }): Promise<SessionContextResponseJson> {
         const body = await this.transport.requestJson("POST", `${this.base}/context`, {
             body: { query: options.query },
+            // A read behind a POST; safe to replay.
+            idempotent: true,
         });
         return body as SessionContextResponseJson;
     }

--- a/packages/memory/src/errors.ts
+++ b/packages/memory/src/errors.ts
@@ -88,6 +88,18 @@ export class ConnectionError extends AgentMemoryError {
 }
 
 /**
+ * The server reported a failure part-way through a stream (status 0).
+ *
+ * A streaming `chat` opens with `200`, so a failure after the headers arrives as
+ * an `error` frame on the stream itself rather than as an HTTP status. Raised by
+ * the stream parser so a mid-flight failure is caught where a request failure
+ * would be, instead of ending the stream as though the reply were complete.
+ */
+export class StreamError extends AgentMemoryError {
+    override readonly name: string = "StreamError";
+}
+
+/**
  * The caller aborted the request through the `signal` they supplied (status 0).
  *
  * Distinct from {@link ConnectionError} so a deliberate cancellation can be told

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -106,6 +106,7 @@ export {
     RateLimitError,
     ScopeError,
     ServerError,
+    StreamError,
     ValidationError,
 } from "./errors.js";
 export { agentMemoryFileInputToBlob } from "./file-body.js";

--- a/packages/memory/src/streaming.ts
+++ b/packages/memory/src/streaming.ts
@@ -2,47 +2,94 @@
  * Server-sent-event parsing for the streaming chat endpoint.
  */
 
+import { StreamError } from "./errors.js";
+import type { components } from "./types/generated.js";
+
+type CitationJson = components["schemas"]["CitationJson"];
+type ExtractionResultJson = components["schemas"]["ExtractionResultJson"];
+
 /** One incremental frame from a streaming `chat` call. */
 export interface ChatChunk {
-    /** Token delta for this frame (may be empty on metadata-only frames). */
+    /**
+     * The SSE event name, when the server labels the frame.
+     *
+     * The chat stream labels every frame (`meta`, `chunk`, `done`), so this is
+     * how a metadata frame is told from a token frame without inspecting the
+     * payload.
+     */
+    event: string | undefined;
+    /** Token delta for this frame (empty on metadata and terminal frames). */
     delta: string;
     /** Trace id, present once the server has assigned one. */
     traceId?: string;
     /** Session id the conversation is attached to. */
     sessionId?: string;
+    /**
+     * The complete reply, on the terminal frame.
+     *
+     * Already sanitised by the server, and identical to the concatenated
+     * deltas. Prefer it over an accumulator when only the final text matters.
+     */
+    reply?: string;
+    /**
+     * What the turn wrote to memory, on the terminal frame.
+     *
+     * The same payload the non-streaming response carries, so a caller has no
+     * reason to reconstruct it by diffing state snapshots.
+     */
+    memoryUpdates?: ExtractionResultJson;
+    /** Sources the reply cited, on the terminal frame, one per marker. */
+    citations?: CitationJson[];
     /** `true` on the terminal frame. */
     done: boolean;
     /** The raw decoded frame payload. */
     raw: Record<string, unknown>;
 }
 
-function frameToChunk(payload: Record<string, unknown>, done: boolean): ChatChunk {
-    const delta =
-        typeof payload.delta === "string"
-            ? payload.delta
-            : typeof payload.token === "string"
-              ? payload.token
-              : "";
-    const traceId =
-        typeof payload.traceId === "string"
-            ? payload.traceId
-            : typeof payload.trace_id === "string"
-              ? payload.trace_id
-              : undefined;
-    const sessionId =
-        typeof payload.sessionId === "string"
-            ? payload.sessionId
-            : typeof payload.session_id === "string"
-              ? payload.session_id
-              : undefined;
-    return { delta, traceId, sessionId, done, raw: payload };
+function str(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function frameToChunk(
+    payload: Record<string, unknown>,
+    event: string | undefined,
+    done: boolean,
+): ChatChunk {
+    // `text` is what the chat stream labels its token frames with; `delta` and
+    // `token` are the shapes other streaming endpoints use. All three are read
+    // so one parser serves every stream the API exposes.
+    const delta = str(payload.delta) ?? str(payload.token) ?? str(payload.text) ?? "";
+    const chunk: ChatChunk = {
+        event,
+        delta,
+        traceId: str(payload.traceId) ?? str(payload.trace_id),
+        sessionId: str(payload.sessionId) ?? str(payload.session_id),
+        done,
+        raw: payload,
+    };
+
+    // Terminal-frame extras. Read by shape rather than gated on the event name,
+    // so a server that ends the stream with `done: true` and no label still
+    // hands the caller its reply.
+    const reply = str(payload.reply);
+    if (reply !== undefined) chunk.reply = reply;
+    if (payload.memoryUpdates !== undefined && payload.memoryUpdates !== null) {
+        chunk.memoryUpdates = payload.memoryUpdates as ExtractionResultJson;
+    }
+    if (Array.isArray(payload.citations)) {
+        chunk.citations = payload.citations as CitationJson[];
+    }
+
+    return chunk;
 }
 
 /**
  * Parses an SSE response body into {@link ChatChunk}s.
  *
- * Handles multi-line `data:` payloads, comment lines, and the terminal
- * `[DONE]` sentinel.
+ * Handles multi-line `data:` payloads, comment lines, event labels, and the
+ * terminal `[DONE]` sentinel. A frame the server labels `error` is raised as a
+ * {@link StreamError} rather than yielded, so a failure part-way through a
+ * stream surfaces where a request failure would.
  *
  * @param response A streaming `fetch` response with a readable body.
  */
@@ -66,14 +113,19 @@ export async function* parseChatStream(response: Response): AsyncGenerator<ChatC
                 const rawFrame = buffer.slice(0, sep);
                 buffer = buffer.slice(sep + (buffer[sep] === "\r" ? 4 : 2));
                 const dataLines: string[] = [];
+                let event: string | undefined;
                 for (const line of rawFrame.split(/\r?\n/)) {
                     if (line.startsWith(":")) continue; // comment / keep-alive
+                    if (line.startsWith("event:")) {
+                        event = line.slice(6).trim();
+                        continue;
+                    }
                     if (line.startsWith("data:")) dataLines.push(line.slice(5).trimStart());
                 }
                 if (dataLines.length === 0) continue;
                 const data = dataLines.join("\n");
                 if (data === "[DONE]") {
-                    yield { delta: "", done: true, raw: {} };
+                    yield { event, delta: "", done: true, raw: {} };
                     return;
                 }
                 let payload: Record<string, unknown>;
@@ -82,8 +134,20 @@ export async function* parseChatStream(response: Response): AsyncGenerator<ChatC
                 } catch {
                     payload = { delta: data };
                 }
-                const isDone = payload.done === true;
-                yield frameToChunk(payload, isDone);
+
+                // The stream opened `200`, so a failure after the headers can
+                // only arrive as a frame. Throwing keeps it from reading as a
+                // stream that simply ended.
+                if (event === "error" || typeof payload.error === "string") {
+                    throw new StreamError({
+                        status: 0,
+                        title: "Chat stream failed",
+                        detail: str(payload.error) ?? "The server ended the stream with an error.",
+                    });
+                }
+
+                const isDone = event === "done" || payload.done === true;
+                yield frameToChunk(payload, event, isDone);
                 if (isDone) return;
             }
 


### PR DESCRIPTION
## Summary

The streaming `chat` parser ignored the fields the API actually sends, so a caller could not reach anything the stream reports about a turn. Found while auditing how SurrealDB Studio's context Workbench talks to Agent Memory: it was rebuilding, with up to 45 extra requests per turn, three things the terminal frame already carries.

### Stream parsing

- **Parse the SSE `event:` label.** Every chat frame is named (`meta`, `chunk`, `done`), which is how a metadata frame is told from a token frame without guessing at the payload. `ChatChunk` now carries `event`.
- **Read `text` as a token source** alongside `delta` and `token`. `text` is what the chat stream labels its token frames with, so `ChatChunk.delta` was *always* empty against this server and every caller had to reach into `raw`.
- **Surface the terminal frame's `reply`, `memoryUpdates` and `citations`** as typed fields. This is the same payload the non-streaming response carries, so a streaming caller no longer has to reconstruct what a turn wrote by diffing `state()` snapshots either side of it.
- **Treat a frame named `done` as terminal.** The done frame carries no `done` field, so `ChatChunk.done` never fired and callers had to break on the presence of a reply instead.
- **Raise a frame named `error` as a `StreamError`** rather than yielding it. A streaming chat opens `200`, so a failure after the headers arrived as an ordinary empty chunk and read as a stream that simply ended.

### Requests

- **`ChatOptions.suppressMarkers`**, which the API has always accepted and documents. Without it a caller that does not render citations shows the reply's `[S1]` labels as prose.
- **Mark the read-shaped POSTs idempotent**: `recall`, `context`, a session's `context`, document `query`, and keyword `search`. Each is a read whose query travels in the body, so they now take the same retry budget as any other read instead of failing on a single transient `5xx`.
- **`AgentMemoryOptions.timeoutMs`**, matching what `TransportOptions` has always called it. `timeout` stays as a deprecated alias and is ignored when both are given.

## Compatibility

Additive. `ChatChunk` gains fields and `event`; `delta` keeps its meaning and now actually populates against the chat stream. The one behaviour change is that an `error` frame throws instead of yielding an empty chunk, which is the point of it.

## Verification

`bun run build` and `tsc --noEmit` are clean. Driven end to end against SurrealDB Studio's Workbench with a mock that mirrors the server's frames exactly — named events, `text` token frames, and a terminal `done` frame with `citations` and `memoryUpdates` and no `done` field. A settled turn there now costs one request instead of six to forty-six, and the evidence panel shows what the reply actually cited rather than a parallel recall's guess at it.
