### PR TITLE
Release Agent Memory 1.0.0 alpha 10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "packages/memory": {
       "name": "@surrealdb/memory",
-      "version": "1.0.0-alpha.9",
+      "version": "1.0.0-alpha.10",
       "devDependencies": {
         "@types/bun": "^1.2.21",
         "openapi-typescript": "^7.10.0",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@surrealdb/memory",
-    "version": "1.0.0-alpha.9",
+    "version": "1.0.0-alpha.10",
     "type": "module",
     "license": "Apache-2.0",
     "description": "The official Agent Memory client for JavaScript.",


### PR DESCRIPTION
Bumps `@surrealdb/memory` from `1.0.0-alpha.9` to `1.0.0-alpha.10`.

Ships the following unreleased change:

- Read the chat stream's own frames (#669)