### PR TITLE
Settle the work in flight when a connection closes

### DIFF
--- a/packages/sdk/src/engine/websocket.ts
+++ b/packages/sdk/src/engine/websocket.ts
@@ -150,24 +150,11 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
                         this.#publisher.publish("error", new ReconnectExhaustionError());
                     }
 
-                    // Optionally terminate pending calls
-                    if (!this.#terminated) {
-                        for (const { reject } of this.#calls.values()) {
-                            reject(new CallTerminatedError());
-                        }
-                    }
-
-                    // No socket is coming, so the streams held for a re-send are given up on
-                    // too - failed or dropped to match the calls above.
-                    if (this.#terminated) {
-                        this.#streams.clear();
-                    } else {
-                        this.failStreams(new CallTerminatedError());
-                    }
+                    // No socket is coming back, so nothing in flight can be answered.
+                    this.terminatePending(new CallTerminatedError());
 
                     this._state = undefined;
                     this.#active = false;
-                    this.#calls.clear();
                     this.#publisher.publish("disconnected");
 
                     break;
@@ -193,13 +180,14 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
 
         this._state = undefined;
         this.#terminated = true;
+        this.#active = false;
         this.#socket?.close();
 
-        // Dropped rather than failed, which is what closing does to the calls in flight: the
-        // caller has abandoned its pending work. A streamed query must not answer a `close`
-        // differently from a buffered one, and failing them here would turn a query nobody is
-        // holding into an unhandled rejection.
-        this.#streams.clear();
+        // Settled here rather than when the loop above next wakes, which a reconnect cooldown
+        // can hold off for as long as its backoff: a caller awaiting a query when the connection
+        // is closed under it learns that it died, instead of waiting on it for the life of the
+        // process.
+        this.terminatePending(new CallTerminatedError());
 
         if (socketState === WebSocketImpl.OPEN || socketState === WebSocketImpl.CLOSING) {
             await this.#publisher.subscribeFirst("disconnected");
@@ -474,6 +462,23 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
     }
 
     /**
+     * Fails everything in flight, for a connection which is not coming back.
+     *
+     * The calls and the streams are settled together: a query which reported a
+     * closed connection differently for having been streamed would make the
+     * two transports observably different, and one which reported nothing at
+     * all would leave its caller waiting on it for the life of the process.
+     */
+    private terminatePending(error: Error): void {
+        for (const { reject } of this.#calls.values()) {
+            reject(error);
+        }
+
+        this.#calls.clear();
+        this.failStreams(error);
+    }
+
+    /**
      * Fails the streaming queries in flight, as a stream cannot outlive its socket.
      *
      * With `framedOnly`, only those which have delivered a frame: they cannot be
@@ -557,7 +562,9 @@ export class WebSocketEngine extends RpcEngine implements SurrealEngine {
 
                     this.#pinger = setInterval(() => {
                         try {
-                            this.send({ method: "ping" });
+                            // A ping in flight is terminated with every other call when the
+                            // connection goes, and its rejection belongs to nobody.
+                            this.send({ method: "ping" }).catch(() => {});
                         } catch {
                             // we are not interested in the result
                         }

--- a/packages/sdk/src/utils/live.ts
+++ b/packages/sdk/src/utils/live.ts
@@ -107,6 +107,11 @@ export class ManagedLiveSubscription extends LiveSubscription {
 
         if (this.#controller.status === "connected") {
             this.#ready = this.#listen();
+
+            // Awaiting `ready()` is optional, and the registration fails with the connection it
+            // was made on - which `#listen` has already reported on the error channel - so the
+            // promise is kept from going unhandled. Callers who do await it still see it fail.
+            this.#ready.catch(() => {});
         }
     }
 

--- a/packages/tests/surrealdb/integration/query/live.test.ts
+++ b/packages/tests/surrealdb/integration/query/live.test.ts
@@ -306,7 +306,10 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
 
                 expect(subscription.isAlive).toBeTrue();
 
-                (async () => {
+                // Kept so it can be awaited below: the KILLED notification ends the iteration
+                // before this has finished, and a query still in flight when the test returns
+                // is failed with the connection the harness then closes.
+                const removal = (async () => {
                     await Bun.sleep(100);
                     // Removing the subscribed table terminates the live query
                     // server-side, which emits a KILLED notification.
@@ -316,6 +319,8 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
                 for await (const message of subscription) {
                     messages.push(message);
                 }
+
+                await removal;
 
                 // The final message is the server-side KILLED (which carries no
                 // record), and the subscription is no longer alive afterwards.
@@ -337,7 +342,9 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
 
             let latestId: Uuid = initialId;
 
-            (async () => {
+            // Kept so it can be awaited below, like the tests above: work still in flight when
+            // the test returns is failed with the connection the harness closes.
+            const restart = (async () => {
                 await Bun.sleep(100);
 
                 // Restart server and wait for reconnection
@@ -365,6 +372,8 @@ describe.if(SURREAL_PROTOCOL === "ws" || SURREAL_PROTOCOL === "mem")(
             for await (const message of subscription) {
                 messages.push(message);
             }
+
+            await restart;
 
             expect(latestId).not.toEqual(initialId);
 

--- a/packages/tests/surrealdb/unit/streaming/engine.test.ts
+++ b/packages/tests/surrealdb/unit/streaming/engine.test.ts
@@ -554,32 +554,52 @@ describe("websocket query streaming", () => {
         expect(new Set(ids).size).toBe(1);
     });
 
-    test("closing answers a stream the way it answers a buffered call", async () => {
-        // Closing abandons the work in flight rather than failing it, for both kinds of query.
-        // A streamed query which answered a `close` differently - by rejecting - would turn a
-        // query nobody is holding into an unhandled rejection, which a buffered one never does.
+    test("closing fails a query in flight, streamed or buffered alike", async () => {
         for (const streaming of [true, false]) {
             MockSocket.reset();
 
             const started = await openEngine({ streaming });
 
             MockSocket.handler = () => {
-                // Answer nothing: the query is still in flight when the engine is closed.
+                // Answer nothing: the query is in flight when the connection is closed.
             };
 
-            const outcomes: string[] = [];
-            const attempt = collect(started.query(new BoundQuery("SLEEP 5s"), undefined))
-                .then(() => outcomes.push("resolved"))
-                .catch((error: Error) => outcomes.push(`rejected: ${error.constructor.name}`));
+            const attempt = collect(started.query(new BoundQuery("SLEEP 5s"), undefined));
+            const outcome = attempt.then(
+                () => "resolved",
+                (error: Error) => error.constructor.name,
+            );
 
             await Bun.sleep(10);
             await started.close();
-            await Promise.race([attempt, Bun.sleep(500)]);
 
-            expect(outcomes).toBeEmpty();
+            // Raced, so a promise which never settles fails this rather than hanging the run.
+            expect(
+                await Promise.race([outcome, Bun.sleep(1_000).then(() => "still waiting")]),
+            ).toBe("CallTerminatedError");
 
             engine = undefined;
         }
+    });
+
+    test("a query issued after closing is refused rather than queued", async () => {
+        const started = await openEngine();
+
+        MockSocket.handler = () => {};
+
+        await started.close();
+
+        const attempt = collect(started.query(new BoundQuery("RETURN 1"), undefined));
+        const outcome = attempt.then(
+            () => "resolved",
+            (error: Error) => error.constructor.name,
+        );
+
+        expect(await Promise.race([outcome, Bun.sleep(1_000).then(() => "still waiting")])).toBe(
+            "ConnectionUnavailableError",
+        );
+
+        engine = undefined;
     });
 
     test("a query which lost its socket part way through is failed, never replayed", async () => {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

> **Stacked on #664.** The base is `tobiemh/surrealdb-pr-812-support-88fc90`, not `main`, because the stream registry this settles only exists there. On `main` the engine has `#calls` and nothing else, so "settle both kinds of pending work together" is not expressible yet — and settling only one of them is what made #664 diverge in the first place (b12642b).

## What is the motivation?

A query still running when `close()` is called is neither resolved nor rejected. Its caller waits on that promise for the life of the process, with no error to debug:

```ts
const db = await createSurreal();
let settled = "pending";
const q = db.query("SLEEP 2s").collect();
q.then(() => { settled = "resolved"; }, () => { settled = "rejected"; });

await Bun.sleep(100);
await db.close();
await Bun.sleep(400);

console.log(settled);   // "pending" - and stays that way
```

The branch in `open()` which gives up rejects the calls in flight only `if (!this.#terminated)`, then clears the map, so an explicit `close()` drops them unsettled. Closing during a reconnect cooldown does not even reach that branch: the loop leaves by its own `while` condition.

#664 hit this from the other side. Settling streams on close while calls were still dropped made the same query reject when streamed and stay pending when buffered, so that change went back to dropping in order to keep the two transports indistinguishable. This settles both, which is the end state that satisfies both constraints.

## What does this change do?

One `terminatePending` rejects the calls and fails the streams together, called wherever no socket is coming back, which also removes the `!this.#terminated` asymmetry that caused the hang. `close()` calls it directly rather than leaving it to the loop, so a close during a cooldown settles at once instead of waiting out a backoff the defaults can stretch to a minute. A query issued after closing is refused rather than queued onto a connection that will never carry it.

| | in flight at `close()` | issued after `close()` |
|---|---|---|
| before | never settles | never settles |
| after (streamed) | `CallTerminatedError` | `ConnectionUnavailableError` |
| after (buffered) | `CallTerminatedError` | `ConnectionUnavailableError` |

### Failing what used to be dropped needs the fire-and-forget paths handled

A rejection nobody is holding is an unhandled rejection, and Node treats those as fatal by default. So the paths which fire a query without keeping its promise are fixed in the same change:

- The **pinger** wrapped `this.send({ method: "ping" })` in a synchronous `try`, which cannot catch a rejected promise. A ping in flight at close would have taken the process down.
- **`ManagedLiveSubscription`** stores `#listen()` in `#ready` with no handler, so a registration in flight at close was unhandled for any caller who never awaits `ready()`. It is kept from going unhandled; callers who do await it still see the failure.
- Three background tasks in the live tests (`iterable`, the 3.x `KILLED` test, and the `iterable survives reconnect` todo) launched work in an un-awaited IIFE. They now hold and await it, which is also what stops them racing the teardown.

## What is your testing strategy?

| Gate | Result |
|---|---|
| `bun test` (WebSocket, nightly 3.4.0 — real streaming) | 622 pass, 0 fail |
| `bun test` (WebSocket, 3.2.3 — buffered) | 622 pass, 0 fail |
| `bun run qc`, `bun run qts`, `bun run build:sdk` | clean |
| `tsc --project packages/tests/surrealdb/typecheck` | clean |

Verified against a real nightly server rather than only in the harness, for both transports and in both directions:

```
streaming true  | in flight at close: rejected: CallTerminatedError | issued after close: ConnectionUnavailableError | unhandled: none
streaming false | in flight at close: rejected: CallTerminatedError | issued after close: ConnectionUnavailableError | unhandled: none
```

New tests, in `packages/tests/surrealdb/unit/streaming/engine.test.ts`:

- A query in flight when the connection closes rejects with `CallTerminatedError`, run over both the streamed and the buffered path so the two cannot drift apart again. The assertion races the promise against a timer, so a promise which never settles fails the test instead of hanging the run — which is how the original defect would have read.
- A query issued after closing is refused with `ConnectionUnavailableError`.

## Is this related to any issues?

Follows #664, which is its base. The behaviour it changes is older than #664 and applies to buffered queries too, which is why it is not folded into that PR.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
